### PR TITLE
Add the `Octocrab::current_user` method

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -3,3 +3,4 @@ pub mod markdown;
 pub mod gitignore;
 pub mod orgs;
 pub mod pulls;
+pub mod current;

--- a/src/api/current.rs
+++ b/src/api/current.rs
@@ -1,0 +1,16 @@
+use crate::{models, Octocrab, Result};
+
+pub struct CurrentAuthHandler<'octo> {
+    crab: &'octo Octocrab,
+}
+
+impl<'octo> CurrentAuthHandler<'octo> {
+    pub(crate) fn new(crab: &'octo Octocrab) -> Self {
+        Self { crab }
+    }
+
+    /// Fetches information about the current user.
+    pub async fn user(&self) -> Result<models::User> {
+        self.crab.get("/user", None::<&()>).await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ use snafu::*;
 use auth::Auth;
 
 pub use self::{
-    api::{issues, gitignore, markdown, orgs, pulls},
+    api::{issues, gitignore, markdown, orgs, pulls, current},
     error::{Error, GitHubError},
     from_response::FromResponse,
     page::Page,
@@ -364,6 +364,12 @@ impl Octocrab {
         repo: impl Into<String>,
     ) -> api::pulls::PullRequestHandler {
         api::pulls::PullRequestHandler::new(self, owner.into(), repo.into())
+    }
+
+    /// Creates a `CurrentAuthHandler` that allows you to access
+    /// information about the current authenticated user.
+    pub fn current(&self) -> api::current::CurrentAuthHandler {
+        api::current::CurrentAuthHandler::new(self)
     }
 }
 


### PR DESCRIPTION
I think this will be quite useful, from what I'd need to do in [rust-lang/triagebot](https://github.com/rust-lang/triagebot).
@XAMPPRocky please comment on the design, I'm not completely sure about how to handle unauthenticated users. Maybe I can avoid doing a request if the auth token is not set?