### PR TITLE
Add `IssueHandler::replace_labels`

### DIFF
--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -341,6 +341,29 @@ impl<'octo> IssueHandler<'octo> {
             .await
     }
 
+    /// Replaces all labels for an issue.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let labels = octocrab::instance()
+    ///     .issues("owner", "repo")
+    ///     .replace_labels(101, &[String::from("help wanted")])
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn replace_labels(&self, number: u64, labels: &[String]) -> Result<Vec<models::Label>> {
+        let route = format!(
+            "/repos/{owner}/{repo}/issues/{issue}/labels",
+            owner = self.owner,
+            repo = self.repo,
+            issue = number
+        );
+
+        self.crab
+            .put(route, Some(&serde_json::json!({ "labels": labels })))
+            .await
+    }
+
     /// Creates a label in the repository.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {

--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -346,7 +346,7 @@ impl<'octo> IssueHandler<'octo> {
     /// # async fn run() -> octocrab::Result<()> {
     /// let labels = octocrab::instance()
     ///     .issues("owner", "repo")
-    ///     .replace_labels(101, &[String::from("help wanted")])
+    ///     .replace_all_labels(101, &[String::from("help wanted")])
     ///     .await?;
     /// # Ok(())
     /// # }

--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -351,7 +351,7 @@ impl<'octo> IssueHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn replace_labels(&self, number: u64, labels: &[String]) -> Result<Vec<models::Label>> {
+    pub async fn replace_all_labels(&self, number: u64, labels: &[String]) -> Result<Vec<models::Label>> {
         let route = format!(
             "/repos/{owner}/{repo}/issues/{issue}/labels",
             owner = self.owner,


### PR DESCRIPTION
Implements the *[Replace all labels for an issue](https://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue)* endpoint.
I'd need this for rust-lang/triagebot#477.