### PR TITLE
Make several Team fields optional

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -375,12 +375,16 @@ pub struct Team {
     pub permission: String,
     pub members_url: Url,
     pub repositories_url: Url,
-    pub members_count: i64,
-    pub repos_count: i64,
-    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub members_count: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repos_count: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub organization: Organization,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub organization: Option<Organization>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Each of these fields was missing for me causing serde to panic
when listing pull requests on a specific private repo.
It appears that requested reviewers for a PR included a team that had a
parent team that did not have these fields in the API response.

Fwiw, I made no attempt to refer to Github API documentation,
  I merely ran a short snippet, saw serde panic on a serializing a missing
  field, made it optional, and repeated until my tool ran to completion.

And fwiw, there was nothing fancy about by code snippet:

```
   let gh = OctocrabBuilder::new()
        .personal_token(token)
        .build()?;
    let page = gh.pulls("MYORG", "MYREPO")
        .list()
        .base("develop")
        .state(State::Closed)
        .per_page(100)
        .send()
        .await?;
```