### PR TITLE
Add endpoint for code search

### DIFF
--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -16,7 +16,7 @@ impl<'octo> SearchHandler<'octo> {
         Self { crab }
     }
 
-    /// Searchs for all the repositories matching the search query.
+    /// Searches for all the repositories matching the search query.
     /// ```no_run
     ///# async fn run() -> octocrab::Result<()> {
     /// let page = octocrab::instance()
@@ -36,7 +36,7 @@ impl<'octo> SearchHandler<'octo> {
         QueryHandler::new(self.crab, "repositories", query.as_ref())
     }
 
-    /// Searchs for all the commits matching the search query.
+    /// Searches for all the commits matching the search query.
     /// ```no_run
     ///# async fn run() -> octocrab::Result<()> {
     /// let page = octocrab::instance()
@@ -56,7 +56,7 @@ impl<'octo> SearchHandler<'octo> {
         QueryHandler::new(self.crab, "commits", query.as_ref())
     }
 
-    /// Searchs for all users matching the search query.
+    /// Searches for all users matching the search query.
     /// ```no_run
     ///# async fn run() -> octocrab::Result<()> {
     /// let page = octocrab::instance()
@@ -76,7 +76,7 @@ impl<'octo> SearchHandler<'octo> {
         QueryHandler::new(self.crab, "users", query.as_ref())
     }
 
-    /// Searchs for all the issues matching the search query.
+    /// Searches for all the issues matching the search query.
     /// ```no_run
     ///# async fn run() -> octocrab::Result<()> {
     /// let page = octocrab::instance()
@@ -94,6 +94,26 @@ impl<'octo> SearchHandler<'octo> {
         query: &'query (impl AsRef<str> + ?Sized),
     ) -> QueryHandler<'octo, 'query, models::Issue> {
         QueryHandler::new(self.crab, "issues", query.as_ref())
+    }
+
+    /// Searches for all code matching the search query.
+    /// ```no_run
+    ///# async fn run() -> octocrab::Result<()> {
+    /// let page = octocrab::instance()
+    ///     .search()
+    ///     .code("println! language:rust repo:rust-lang/rust")
+    ///     .sort("indexed")
+    ///     .order("asc")
+    ///     .send()
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn code<'query>(
+        self,
+        query: &'query (impl AsRef<str> + ?Sized),
+    ) -> QueryHandler<'octo, 'query, models::Code> {
+        QueryHandler::new(self.crab, "code", query.as_ref())
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -694,6 +694,17 @@ pub struct Commit {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Code {
+    pub name: String,
+    pub path: String,
+    pub sha: String,
+    pub url: Url,
+    pub git_url: Url,
+    pub html_url: Url,
+    pub repository: Repository,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct Permissions {
     admin: bool,

--- a/src/models.rs
+++ b/src/models.rs
@@ -586,7 +586,8 @@ pub struct Repository {
     pub git_commits_url: Url,
     pub git_refs_url: Url,
     pub git_tags_url: Url,
-    pub git_url: Url,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_url: Option<Url>,
     pub issue_comment_url: Url,
     pub issue_events_url: Url,
     pub issues_url: Url,
@@ -598,7 +599,8 @@ pub struct Repository {
     pub notifications_url: Url,
     pub pulls_url: Url,
     pub releases_url: Url,
-    pub ssh_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ssh_url: Option<String>,
     pub stargazers_url: Url,
     pub statuses_url: Url,
     pub subscribers_url: Url,
@@ -606,37 +608,53 @@ pub struct Repository {
     pub tags_url: Url,
     pub teams_url: Url,
     pub trees_url: Url,
-    pub clone_url: Url,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clone_url: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mirror_url: Option<Url>,
     pub hooks_url: Url,
-    pub svn_url: Url,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub svn_url: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub homepage: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<::serde_json::Value>,
-    pub forks_count: u32,
-    pub stargazers_count: u32,
-    pub watchers_count: u32,
-    pub size: u32,
-    pub default_branch: String,
-    pub open_issues_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forks_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stargazers_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub watchers_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub open_issues_count: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_template: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topics: Option<Vec<String>>,
-    pub has_issues: bool,
-    pub has_projects: bool,
-    pub has_wiki: bool,
-    pub has_pages: bool,
-    pub has_downloads: bool,
-    pub archived: bool,
-    pub disabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_issues: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_projects: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_wiki: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_pages: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_downloads: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archived: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub visibility: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pushed_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/models.rs
+++ b/src/models.rs
@@ -712,6 +712,7 @@ pub struct Commit {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Code {
     pub name: String,
     pub path: String,


### PR DESCRIPTION
Adds an endpoint for code search, as described [here](https://docs.github.com/en/rest/reference/search#search-code).