### PR TITLE
add forks api

### DIFF
--- a/examples/list_forks.rs
+++ b/examples/list_forks.rs
@@ -1,0 +1,21 @@
+use octocrab::{repos::forks::ForkSort, Octocrab};
+
+#[tokio::main]
+async fn main() -> octocrab::Result<()> {
+    let token = std::env::var("GITHUB_TOKEN")
+        .expect("GITHUB_TOKEN env variable is required");
+
+    let octocrab = Octocrab::builder().personal_token(token).build()?;
+
+    let forks = octocrab
+        .repos("rust-lang", "rust")
+        .list_forks()
+        .sort(ForkSort::Oldest)
+        .send()
+        .await?;
+
+    for f in forks {
+        println!("fork: {}", f.owner.login);
+    }
+    Ok(())
+}

--- a/examples/list_forks.rs
+++ b/examples/list_forks.rs
@@ -1,21 +1,23 @@
-use octocrab::{repos::forks::ForkSort, Octocrab};
+use octocrab::{params::repos::forks::Sort, Octocrab};
 
 #[tokio::main]
 async fn main() -> octocrab::Result<()> {
-    let token = std::env::var("GITHUB_TOKEN")
-        .expect("GITHUB_TOKEN env variable is required");
+    let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env variable is required");
 
     let octocrab = Octocrab::builder().personal_token(token).build()?;
 
     let forks = octocrab
         .repos("rust-lang", "rust")
         .list_forks()
-        .sort(ForkSort::Oldest)
+        .sort(Sort::Oldest)
+        .page(2u32)
+        .per_page(35)
         .send()
         .await?;
 
     for f in forks {
         println!("fork: {}", f.owner.login);
     }
+
     Ok(())
 }

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -1,12 +1,13 @@
 //! The repositories API.
 
 mod file;
+pub mod forks;
 pub mod releases;
 mod tags;
 
 pub use file::UpdateFileBuilder;
+pub use releases::ReleasesHandler;
 pub use tags::ListTagsBuilder;
-pub use releases::{ReleasesHandler};
 
 use crate::{models, params, Octocrab, Result};
 

--- a/src/api/repos/forks.rs
+++ b/src/api/repos/forks.rs
@@ -112,7 +112,13 @@ impl<'octo> RepoHandler<'octo> {
     /// create the fork in.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
-    /// let new_fork = octocrab::instance().repos("owner", "repo").create_fork().organization("weyland-yutani").send().await?;
+    /// let new_fork = octocrab::instance()
+    ///     .repos("owner", "repo")
+    ///     .create_fork()
+    ///     // Optional Parameters
+    ///     .organization("weyland-yutani")
+    ///     .send()
+    ///     .await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/api/repos/forks.rs
+++ b/src/api/repos/forks.rs
@@ -69,7 +69,7 @@ pub struct CreateForkBuilder<'octo, 'r> {
     organization: Option<String>,
 }
 impl<'octo, 'r> CreateForkBuilder<'octo, 'r> {
-    pub fn new(handler: &'r RepoHandler<'octo>) -> Self {
+    pub(crate) fn new(handler: &'r RepoHandler<'octo>) -> Self {
         Self {
             handler,
             organization: None,

--- a/src/api/repos/forks.rs
+++ b/src/api/repos/forks.rs
@@ -1,0 +1,126 @@
+use super::*;
+
+/// The available methods to sort repository forks by.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ForkSort {
+    Newest,
+    Oldest,
+    Stargazers,
+}
+
+#[derive(serde::Serialize)]
+pub struct ListForksBuilder<'octo, 'r> {
+    #[serde(skip)]
+    handler: &'r RepoHandler<'octo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sort: Option<ForkSort>,
+}
+
+impl<'octo, 'r> ListForksBuilder<'octo, 'r> {
+    pub fn new(handler: &'r RepoHandler<'octo>) -> Self {
+        Self {
+            handler,
+            per_page: None,
+            page: None,
+            sort: None,
+        }
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.page = Some(page.into());
+        self
+    }
+
+    /// Sort order of the results.
+    pub fn sort(mut self, sort: ForkSort) -> Self {
+        self.sort = Some(sort);
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(
+        self,
+    ) -> crate::Result<crate::Page<crate::models::Repository>> {
+        let url = format!(
+            "/repos/{owner}/{repo}/forks",
+            owner = self.handler.owner,
+            repo = self.handler.repo
+        );
+        self.handler.crab.get(url, Some(&self)).await
+    }
+}
+#[derive(serde::Serialize)]
+pub struct CreateForkBuilder<'octo, 'r> {
+    #[serde(skip)]
+    handler: &'r RepoHandler<'octo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    organization: Option<String>,
+}
+impl<'octo, 'r> CreateForkBuilder<'octo, 'r> {
+    pub fn new(handler: &'r RepoHandler<'octo>) -> Self {
+        Self {
+            handler,
+            organization: None,
+        }
+    }
+
+    /// The organization name, if forking into an organization.
+    pub fn organization(mut self, organization: impl Into<String>) -> Self {
+        self.organization = Some(organization.into());
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(self) -> crate::Result<crate::models::Repository> {
+        let url = format!(
+            "/repos/{owner}/{repo}/forks",
+            owner = self.handler.owner,
+            repo = self.handler.repo
+        );
+        self.handler.crab.post(url, Some(&self)).await
+    }
+}
+
+impl<'octo> RepoHandler<'octo> {
+    /// List forks of a repository.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let forks = octocrab::instance().repos("owner", "repo").list_forks().send().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// Optionally, specify a sort order with [`ForkSort`].
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// use octocrab::repos::forks::ForkSort;
+    /// let forks = octocrab::instance().repos("owner", "repo").list_forks().sort(ForkSort::Oldest).send().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list_forks(&self) -> ListForksBuilder<'_, '_> {
+        ListForksBuilder::new(self)
+    }
+
+    /// Creates a fork of a repository.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let new_fork = octocrab::instance().repos("owner", "repo").create_fork().send().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create_fork(&self) -> CreateForkBuilder<'_, '_> {
+        CreateForkBuilder::new(self)
+    }
+}

--- a/src/api/repos/forks.rs
+++ b/src/api/repos/forks.rs
@@ -85,9 +85,9 @@ impl<'octo, 'r> CreateForkBuilder<'octo, 'r> {
 
 impl<'octo> RepoHandler<'octo> {
     /// List forks of a repository. Optionally, specify the
-    /// [sort](./forks/struct.ListForksBuilder.html#method.sort) order,
-    /// [page](./forks/struct.ListForksBuilder.html#method.page),
-    /// and items [per_page](./forks/struct.ListForksBuilder.html#method.per_page)
+    /// [sort](ListForksBuilder::sort()) order,
+    /// [page](ListForksBuilder::page()),
+    /// and items [per_page](ListForksBuilder::per_page())
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
     /// use octocrab::params::repos::forks::Sort;
@@ -108,7 +108,7 @@ impl<'octo> RepoHandler<'octo> {
     }
 
     /// Creates a fork of a repository. Optionally, specify the target
-    /// [organization](./forks/struct.CreateForkBuilder.html#method.organization) to
+    /// [organization](CreateForkBuilder::organization()) to
     /// create the fork in.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {

--- a/src/api/repos/forks.rs
+++ b/src/api/repos/forks.rs
@@ -91,7 +91,15 @@ impl<'octo> RepoHandler<'octo> {
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
     /// use octocrab::params::repos::forks::Sort;
-    /// let forks = octocrab::instance().repos("owner", "repo").list_forks().sort(Sort::Oldest).page(2u32).per_page(30).send().await?;
+    /// let forks = octocrab::instance()
+    ///     .repos("owner", "repo")
+    ///     .list_forks()
+    ///     // Optional Parameters
+    ///     .sort(Sort::Oldest)
+    ///     .page(2u32)
+    ///     .per_page(30)
+    ///     .send()
+    ///     .await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/api/repos/forks.rs
+++ b/src/api/repos/forks.rs
@@ -22,7 +22,7 @@ pub struct ListForksBuilder<'octo, 'r> {
 }
 
 impl<'octo, 'r> ListForksBuilder<'octo, 'r> {
-    pub fn new(handler: &'r RepoHandler<'octo>) -> Self {
+    pub(crate) fn new(handler: &'r RepoHandler<'octo>) -> Self {
         Self {
             handler,
             per_page: None,

--- a/src/api/repos/forks.rs
+++ b/src/api/repos/forks.rs
@@ -1,13 +1,5 @@
+use super::params::repos::forks::Sort;
 use super::*;
-
-/// The available methods to sort repository forks by.
-#[derive(serde::Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ForkSort {
-    Newest,
-    Oldest,
-    Stargazers,
-}
 
 #[derive(serde::Serialize)]
 pub struct ListForksBuilder<'octo, 'r> {
@@ -18,7 +10,7 @@ pub struct ListForksBuilder<'octo, 'r> {
     #[serde(skip_serializing_if = "Option::is_none")]
     page: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    sort: Option<ForkSort>,
+    sort: Option<Sort>,
 }
 
 impl<'octo, 'r> ListForksBuilder<'octo, 'r> {
@@ -44,15 +36,13 @@ impl<'octo, 'r> ListForksBuilder<'octo, 'r> {
     }
 
     /// Sort order of the results.
-    pub fn sort(mut self, sort: ForkSort) -> Self {
+    pub fn sort(mut self, sort: Sort) -> Self {
         self.sort = Some(sort);
         self
     }
 
     /// Sends the actual request.
-    pub async fn send(
-        self,
-    ) -> crate::Result<crate::Page<crate::models::Repository>> {
+    pub async fn send(self) -> crate::Result<crate::Page<crate::models::Repository>> {
         let url = format!(
             "/repos/{owner}/{repo}/forks",
             owner = self.handler.owner,
@@ -94,18 +84,14 @@ impl<'octo, 'r> CreateForkBuilder<'octo, 'r> {
 }
 
 impl<'octo> RepoHandler<'octo> {
-    /// List forks of a repository.
+    /// List forks of a repository. Optionally, specify the
+    /// [sort](./forks/struct.ListForksBuilder.html#method.sort) order,
+    /// [page](./forks/struct.ListForksBuilder.html#method.page),
+    /// and items [per_page](./forks/struct.ListForksBuilder.html#method.per_page)
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
-    /// let forks = octocrab::instance().repos("owner", "repo").list_forks().send().await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    /// Optionally, specify a sort order with [`ForkSort`].
-    /// ```no_run
-    /// # async fn run() -> octocrab::Result<()> {
-    /// use octocrab::repos::forks::ForkSort;
-    /// let forks = octocrab::instance().repos("owner", "repo").list_forks().sort(ForkSort::Oldest).send().await?;
+    /// use octocrab::params::repos::forks::Sort;
+    /// let forks = octocrab::instance().repos("owner", "repo").list_forks().sort(Sort::Oldest).page(2u32).per_page(30).send().await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -113,10 +99,12 @@ impl<'octo> RepoHandler<'octo> {
         ListForksBuilder::new(self)
     }
 
-    /// Creates a fork of a repository.
+    /// Creates a fork of a repository. Optionally, specify the target
+    /// [organization](./forks/struct.CreateForkBuilder.html#method.organization) to
+    /// create the fork in.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
-    /// let new_fork = octocrab::instance().repos("owner", "repo").create_fork().send().await?;
+    /// let new_fork = octocrab::instance().repos("owner", "repo").create_fork().organization("weyland-yutani").send().await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 //! - [`orgs`] GitHub Organisations
 //! - [`pulls`] Pull Requests
 //! - [`repos`] Repositories
+//! - [`repos::forks`] Repositories
 //! - [`repos::releases`] Repositories
 //! - [`search`] Using GitHub's search.
 //! - [`teams`] Teams
@@ -413,11 +414,7 @@ impl Octocrab {
 
     /// Creates a [`repos::RepoHandler`] for the repo specified at `owner/repo`,
     /// that allows you to access GitHub's repository API.
-    pub fn repos(
-        &self,
-        owner: impl Into<String>,
-        repo: impl Into<String>,
-    ) -> repos::RepoHandler {
+    pub fn repos(&self, owner: impl Into<String>, repo: impl Into<String>) -> repos::RepoHandler {
         repos::RepoHandler::new(self, owner.into(), repo.into())
     }
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -272,6 +272,18 @@ pub mod repos {
             f.write_str(&self.full_ref_url())
         }
     }
+    pub mod forks {
+        /// The available methods to sort repository forks by.
+        #[derive(Debug, Clone, Copy, serde::Serialize)]
+        #[serde(rename_all = "snake_case")]
+        #[non_exhaustive]
+
+        pub enum Sort {
+            Newest,
+            Oldest,
+            Stargazers,
+        }
+    }
 }
 
 pub mod teams {

--- a/src/params.rs
+++ b/src/params.rs
@@ -277,7 +277,6 @@ pub mod repos {
         #[derive(Debug, Clone, Copy, serde::Serialize)]
         #[serde(rename_all = "snake_case")]
         #[non_exhaustive]
-
         pub enum Sort {
             Newest,
             Oldest,


### PR DESCRIPTION
Thanks for this library! I'd like to use it for a project I have in mind that involves using the [`forks`](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#forks) API and thought I'd try adding it to octocrab.

I'm relatively new to Rust so if I've done something silly please don't hesitate to call it out, and if this is an unwelcome addition that's ok too.

On a side note, it appears dependabot updated tokio to 1.0, but reqwest is currently on 0.2. Unless you manually set it back, it results in a panic similar to [this](https://github.com/tokio-rs/tokio/issues/1837) when you run any example or use it in your own project and specify tokio 1.0 :frowning_face: 