### PR TITLE
Parse the boolean values on Pullrequests to default false.

### DIFF
--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -17,7 +17,9 @@ pub struct PullRequest {
     pub statuses_url: Url,
     pub number: u64,
     pub state: IssueState,
+    #[serde(default)]
     pub locked: bool,
+    #[serde(default)]
     pub maintainer_can_modify: bool,
     pub title: String,
     pub user: User,


### PR DESCRIPTION
I added this small change, as the GH API seems to omit false values. After this change the PR::list() method works again :)