### PR TITLE
Add initial support for event handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ doc-cfg = "0.1.0"
 
 [dev-dependencies]
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+wiremock = "0.4.0"
 
 [features]
 default = ["reqwest/native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ futures-util = { version = "0.3.6", optional = true }
 doc-cfg = "0.1.0"
 
 [dev-dependencies]
-tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread"] }
-wiremock = "0.4.0"
+tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
+wiremock = "0.4.3"
 
 [features]
 default = ["reqwest/native-tls"]

--- a/examples/poll_repo_events.rs
+++ b/examples/poll_repo_events.rs
@@ -36,6 +36,6 @@ async fn main() -> octocrab::Result<()> {
             }
         }
         etag = response.etag;
-        tokio::time::delay_for(tokio::time::Duration::from_millis(DELAY_MS)).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(DELAY_MS)).await;
     }
 }

--- a/examples/poll_repo_events.rs
+++ b/examples/poll_repo_events.rs
@@ -1,0 +1,41 @@
+use octocrab::{etag::Etagged, models::events::Event, Page};
+use std::collections::VecDeque;
+
+const DELAY_MS: u64 = 500;
+const TRACKING_CAPACITY: usize = 20;
+
+#[tokio::main]
+async fn main() -> octocrab::Result<()> {
+    let mut etag = None;
+    let mut seen = VecDeque::with_capacity(TRACKING_CAPACITY);
+    let octo = octocrab::instance();
+    loop {
+        let response: Etagged<Page<Event>> = octo
+            .repos("nixos", "nixpkgs")
+            .events()
+            .etag(etag)
+            .per_page(10)
+            .send()
+            .await?;
+        if let Some(page) = response.value {
+            for event in page {
+                // If an etag changes and we get a new page, this page may contain events we have
+                // already seen along with new events. So, keep track of the ones we have seen for
+                // each page, this will be at most 20 events - the current page of 10 events and
+                // the last page.
+                if !seen.contains(&event.id) {
+                    println!(
+                        "New event : id = {:?}, type = {:?}, time = {:?}",
+                        event.id, event.typ, event.created_at
+                    );
+                    if seen.len() == TRACKING_CAPACITY {
+                        seen.pop_back();
+                    }
+                    seen.push_front(event.id);
+                }
+            }
+        }
+        etag = response.etag;
+        tokio::time::delay_for(tokio::time::Duration::from_millis(DELAY_MS)).await;
+    }
+}

--- a/examples/poll_repo_events.rs
+++ b/examples/poll_repo_events.rs
@@ -26,7 +26,7 @@ async fn main() -> octocrab::Result<()> {
                 if !seen.contains(&event.id) {
                     println!(
                         "New event : id = {:?}, type = {:?}, time = {:?}",
-                        event.id, event.typ, event.created_at
+                        event.id, event.r#type, event.created_at
                     );
                     if seen.len() == TRACKING_CAPACITY {
                         seen.pop_back();

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -7,11 +7,11 @@ pub mod releases;
 mod status;
 mod tags;
 
+use crate::{models, params, Octocrab, Result};
 pub use file::UpdateFileBuilder;
 pub use releases::ReleasesHandler;
 pub use status::CreateStatusBuilder;
 pub use tags::ListTagsBuilder;
-use crate::{models, params, Octocrab, Result};
 
 /// Handler for GitHub's repository API.
 ///
@@ -217,7 +217,7 @@ impl<'octo> RepoHandler<'octo> {
     /// repositories events.
     /// ```no_run
     /// # use std::convert::TryFrom;
-    /// # use octocrab::{models::events::Event, etag::{Etagged,Etag}, Page};
+    /// # use octocrab::{models::events::Event, etag::{Etagged,EntityTag}, Page};
     /// # async fn run() -> octocrab::Result<()> {
     /// let mut etag = None;
     /// loop {

--- a/src/api/repos/events.rs
+++ b/src/api/repos/events.rs
@@ -1,0 +1,97 @@
+//! GitHub Repository Events
+use crate::{
+    etag::{Etag, Etagged},
+    models::events,
+    repos::RepoHandler,
+    FromResponse, Page,
+};
+use reqwest::{
+    header::{self, HeaderMap},
+    Method, StatusCode,
+};
+use std::convert::TryFrom;
+
+pub struct ListRepoEventsBuilder<'octo, 'handler> {
+    handler: &'handler RepoHandler<'octo>,
+    headers: Headers,
+    params: Params,
+}
+
+struct Headers {
+    etag: Option<Etag>,
+}
+
+#[derive(serde::Serialize)]
+struct Params {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+}
+
+impl<'octo, 'handler> ListRepoEventsBuilder<'octo, 'handler> {
+    pub(crate) fn new(handler: &'handler RepoHandler<'octo>) -> Self {
+        Self {
+            handler,
+            headers: Headers { etag: None },
+            params: Params {
+                per_page: None,
+                page: None,
+            },
+        }
+    }
+
+    /// Etag for this request.
+    pub fn etag(mut self, etag: Option<Etag>) -> Self {
+        self.headers.etag = etag;
+        self
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.params.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.params.page = Some(page.into());
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(self) -> crate::Result<Etagged<Page<events::Event>>> {
+        let url = format!(
+            "{base_url}repos/{owner}/{repo}/events",
+            base_url = self.handler.crab.base_url,
+            owner = self.handler.owner,
+            repo = self.handler.repo
+        );
+        let mut headers = HeaderMap::new();
+        if let Some(etag) = self.headers.etag {
+            headers.append(header::IF_NONE_MATCH, etag.into());
+        }
+        let builder = self
+            .handler
+            .crab
+            .client
+            .request(Method::GET, &url)
+            .headers(headers)
+            .query(&self.params);
+        let response = self.handler.crab.execute(builder).await?;
+        let etag = response
+            .headers()
+            .get(header::ETAG)
+            .and_then(|val| Etag::try_from(val).ok());
+        if response.status() == StatusCode::NOT_MODIFIED {
+            Ok(Etagged { etag, value: None })
+        } else {
+            <Page<events::Event>>::from_response(crate::map_github_error(response).await?)
+                .await
+                .map(|page| Etagged {
+                    etag,
+                    value: Some(page),
+                })
+        }
+    }
+}

--- a/src/api/repos/events.rs
+++ b/src/api/repos/events.rs
@@ -80,7 +80,7 @@ impl<'octo, 'handler> ListRepoEventsBuilder<'octo, 'handler> {
             .headers()
             .decode::<ETag>()
             .ok()
-            .map(|etag| (*etag).clone());
+            .map(|ETag(tag)| tag);
         if response.status() == StatusCode::NOT_MODIFIED {
             Ok(Etagged { etag, value: None })
         } else {

--- a/src/etag.rs
+++ b/src/etag.rs
@@ -1,7 +1,5 @@
 //! Types for handling etags.
-use reqwest::header::HeaderValue;
-use snafu::ResultExt;
-use std::convert::TryFrom;
+pub use hyperx::header::EntityTag;
 
 /// Represents resources identified by etags.
 #[derive(Debug, PartialEq)]
@@ -10,134 +8,9 @@ pub struct Etagged<T> {
     ///
     /// It is possible, although unlikely, that a response which should contain an etag header does
     /// not, or that etag header is invalid. In such cases this field will be `None`.
-    pub etag: Option<Etag>,
+    pub etag: Option<EntityTag>,
     /// The value identified by this etag.
     ///
     /// This can be `None` if we have already received the data which this etag identifies.
     pub value: Option<T>,
-}
-
-/// An etag.
-#[derive(Debug, PartialEq)]
-pub struct Etag(String);
-
-impl Etag {
-    pub fn as_str(&self) -> &str {
-        self.0.as_ref()
-    }
-}
-
-impl TryFrom<&str> for Etag {
-    type Error = crate::Error;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        if value.is_ascii() {
-            Ok(Etag(value.to_owned()))
-        } else {
-            Err("An Etag can only contain ASCII characters".into()).context(crate::error::Other)
-        }
-    }
-}
-
-impl TryFrom<HeaderValue> for Etag {
-    type Error = crate::Error;
-
-    fn try_from(value: HeaderValue) -> Result<Self, Self::Error> {
-        convert_header_value(&value)
-    }
-}
-
-impl TryFrom<&HeaderValue> for Etag {
-    type Error = crate::Error;
-
-    fn try_from(value: &HeaderValue) -> Result<Self, Self::Error> {
-        convert_header_value(value)
-    }
-}
-
-fn convert_header_value(value: &HeaderValue) -> crate::Result<Etag> {
-    value
-        .to_str()
-        .map(|val| Etag(val.to_owned()))
-        .map_err(|_| "Received etag header containing non-ASCII characters".into())
-        .context(crate::error::Other)
-}
-
-impl From<Etag> for HeaderValue {
-    fn from(etag: Etag) -> Self {
-        // By construction, the Etag is guaranteed to have only ASCII (non-extended) characters, so
-        // unwrapping here is ok.
-        HeaderValue::from_str(etag.as_str()).unwrap()
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::Etag;
-    use reqwest::header::HeaderValue;
-    use std::convert::TryFrom;
-
-    #[test]
-    fn str_slice_to_etag_conversion_should_succeed_if_ascii() {
-        let etag_str = "1234";
-        let result = Etag::try_from(etag_str);
-        assert!(result.is_ok(), "unexpected error: {:#?}", result);
-        assert_eq!(result.ok().unwrap().as_str(), etag_str);
-    }
-
-    #[test]
-    fn str_slice_to_etag_conversion_should_fail_if_non_ascii() {
-        let etag_str = "123µ";
-        let result = Etag::try_from(etag_str);
-        assert!(
-            result.is_err(),
-            "expected an error, instead it returned: {:#?}",
-            result
-        );
-        let expected_msg = "An Etag can only contain ASCII characters";
-        let error = result.err().unwrap().to_string();
-        assert!(
-            error.contains(expected_msg),
-            "error '{}' did not contain expected message",
-            error
-        );
-    }
-
-    #[test]
-    fn header_value_ref_to_etag_should_fail_with_non_ascii() {
-        let value = HeaderValue::from_bytes(b"123\xb5").unwrap();
-        let result = Etag::try_from(&value);
-        assert!(
-            result.is_err(),
-            "expected unsuccessful conversion, got etag {:?}",
-            result
-        );
-        let error = result.err().unwrap();
-        assert!(
-            error
-                .to_string()
-                .contains("Received etag header containing non-ASCII characters"),
-            "expected error to contain specific string, got: {:?}",
-            error
-        );
-    }
-
-    #[test]
-    fn header_value_to_etag_should_fail_with_non_ascii() {
-        let value = HeaderValue::from_bytes(b"123\xb5").unwrap();
-        let result = Etag::try_from(value);
-        assert!(
-            result.is_err(),
-            "expected unsuccessful conversion, got etag {:?}",
-            result
-        );
-        let error = result.err().unwrap();
-        assert!(
-            error
-                .to_string()
-                .contains("Received etag header containing non-ASCII characters"),
-            "expected error to contain specific string, got: {:?}",
-            error
-        );
-    }
 }

--- a/src/etag.rs
+++ b/src/etag.rs
@@ -1,0 +1,143 @@
+//! Types for handling etags.
+use reqwest::header::HeaderValue;
+use snafu::ResultExt;
+use std::convert::TryFrom;
+
+/// Represents resources identified by etags.
+#[derive(Debug, PartialEq)]
+pub struct Etagged<T> {
+    /// A possible etag.
+    ///
+    /// It is possible, although unlikely, that a response which should contain an etag header does
+    /// not, or that etag header is invalid. In such cases this field will be `None`.
+    pub etag: Option<Etag>,
+    /// The value identified by this etag.
+    ///
+    /// This can be `None` if we have already received the data which this etag identifies.
+    pub value: Option<T>,
+}
+
+/// An etag.
+#[derive(Debug, PartialEq)]
+pub struct Etag(String);
+
+impl Etag {
+    pub fn as_str(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl TryFrom<&str> for Etag {
+    type Error = crate::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        if value.is_ascii() {
+            Ok(Etag(value.to_owned()))
+        } else {
+            Err("An Etag can only contain ASCII characters".into()).context(crate::error::Other)
+        }
+    }
+}
+
+impl TryFrom<HeaderValue> for Etag {
+    type Error = crate::Error;
+
+    fn try_from(value: HeaderValue) -> Result<Self, Self::Error> {
+        convert_header_value(&value)
+    }
+}
+
+impl TryFrom<&HeaderValue> for Etag {
+    type Error = crate::Error;
+
+    fn try_from(value: &HeaderValue) -> Result<Self, Self::Error> {
+        convert_header_value(value)
+    }
+}
+
+fn convert_header_value(value: &HeaderValue) -> crate::Result<Etag> {
+    value
+        .to_str()
+        .map(|val| Etag(val.to_owned()))
+        .map_err(|_| "Received etag header containing non-ASCII characters".into())
+        .context(crate::error::Other)
+}
+
+impl From<Etag> for HeaderValue {
+    fn from(etag: Etag) -> Self {
+        // By construction, the Etag is guaranteed to have only ASCII (non-extended) characters, so
+        // unwrapping here is ok.
+        HeaderValue::from_str(etag.as_str()).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Etag;
+    use reqwest::header::HeaderValue;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn str_slice_to_etag_conversion_should_succeed_if_ascii() {
+        let etag_str = "1234";
+        let result = Etag::try_from(etag_str);
+        assert!(result.is_ok(), "unexpected error: {:#?}", result);
+        assert_eq!(result.ok().unwrap().as_str(), etag_str);
+    }
+
+    #[test]
+    fn str_slice_to_etag_conversion_should_fail_if_non_ascii() {
+        let etag_str = "123µ";
+        let result = Etag::try_from(etag_str);
+        assert!(
+            result.is_err(),
+            "expected an error, instead it returned: {:#?}",
+            result
+        );
+        let expected_msg = "An Etag can only contain ASCII characters";
+        let error = result.err().unwrap().to_string();
+        assert!(
+            error.contains(expected_msg),
+            "error '{}' did not contain expected message",
+            error
+        );
+    }
+
+    #[test]
+    fn header_value_ref_to_etag_should_fail_with_non_ascii() {
+        let value = HeaderValue::from_bytes(b"123\xb5").unwrap();
+        let result = Etag::try_from(&value);
+        assert!(
+            result.is_err(),
+            "expected unsuccessful conversion, got etag {:?}",
+            result
+        );
+        let error = result.err().unwrap();
+        assert!(
+            error
+                .to_string()
+                .contains("Received etag header containing non-ASCII characters"),
+            "expected error to contain specific string, got: {:?}",
+            error
+        );
+    }
+
+    #[test]
+    fn header_value_to_etag_should_fail_with_non_ascii() {
+        let value = HeaderValue::from_bytes(b"123\xb5").unwrap();
+        let result = Etag::try_from(value);
+        assert!(
+            result.is_err(),
+            "expected unsuccessful conversion, got etag {:?}",
+            result
+        );
+        let error = result.err().unwrap();
+        assert!(
+            error
+                .to_string()
+                .contains("Received etag header containing non-ASCII characters"),
+            "expected error to contain specific string, got: {:?}",
+            error
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,7 @@ mod error;
 mod from_response;
 mod page;
 
+pub mod etag;
 pub mod models;
 pub mod params;
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -4,6 +4,7 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 
 pub mod activity;
+pub mod events;
 pub mod issues;
 pub mod orgs;
 pub mod pulls;

--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -21,6 +21,7 @@ pub struct Event {
 
 /// The type of an event.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
 #[non_exhaustive]
 pub enum EventType {
     PushEvent,

--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -110,14 +110,15 @@ fn deserialize_payload(
     data: serde_json::Value,
 ) -> Result<Option<EventPayload>, serde_json::Error> {
     let maybe_payload = match event_type {
-        EventType::PushEvent => serde_json::from_value::<PushEventPayload>(data)
-            .map(|payload| Some(EventPayload::PushEvent(payload)))?,
-        EventType::CreateEvent => serde_json::from_value::<CreateEventPayload>(data)
-            .map(|payload| Some(EventPayload::CreateEvent(payload)))?,
-        _ => serde_json::from_value::<serde_json::Value>(data)
-            .map(|payload| Some(EventPayload::UnknownEvent(payload)))?,
+        EventType::PushEvent => {
+            serde_json::from_value::<PushEventPayload>(data).map(EventPayload::PushEvent)?
+        }
+        EventType::CreateEvent => {
+            serde_json::from_value::<CreateEventPayload>(data).map(EventPayload::CreateEvent)?
+        }
+        _ => EventPayload::UnknownEvent(data),
     };
-    Ok(maybe_payload)
+    Ok(Some(maybe_payload))
 }
 
 #[cfg(test)]

--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -10,8 +10,7 @@ use serde::{de::Error, Deserialize, Serialize};
 #[non_exhaustive]
 pub struct Event {
     pub id: String,
-    #[serde(rename = "type")]
-    pub typ: EventType,
+    pub r#type: EventType,
     pub actor: Actor,
     pub repo: Repository,
     pub public: bool,
@@ -85,7 +84,7 @@ impl<'de> Deserialize<'de> for Event {
         })?;
         let event = Event {
             id: intermediate.id,
-            typ: event_type,
+            r#type: event_type,
             actor: intermediate.actor,
             repo: intermediate.repo,
             public: intermediate.public,
@@ -132,7 +131,7 @@ mod test {
         let json = include_str!("../../tests/resources/push_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
         assert_eq!(event.id, "14289834535".to_owned());
-        assert_eq!(event.typ, EventType::PushEvent);
+        assert_eq!(event.r#type, EventType::PushEvent);
         assert_eq!(
             event.actor,
             Actor {
@@ -171,7 +170,7 @@ mod test {
                 assert_eq!(payload.push_id, 6080608029);
                 assert_eq!(payload.size, 1);
                 assert_eq!(payload.distinct_size, 1);
-                assert_eq!(payload.ref_field, "refs/heads/master");
+                assert_eq!(payload.r#ref, "refs/heads/master");
                 assert_eq!(payload.head, "eb1a60c03544dcea290f2d57bb66ae188ce25778");
                 assert_eq!(payload.before, "9b2afb3a8e03fb30cc09e5efb64823bde802cf59");
                 assert_eq!(payload.commits.len(), 1);
@@ -203,7 +202,7 @@ mod test {
         let payload = event.payload.unwrap();
         match payload {
             EventPayload::CreateEvent(payload) => {
-                assert_eq!(payload.ref_field, Some("url-normalisation".to_string()));
+                assert_eq!(payload.r#ref, Some("url-normalisation".to_string()));
                 assert_eq!(payload.ref_type, "branch");
                 assert_eq!(payload.master_branch, "main");
                 assert_eq!(
@@ -269,7 +268,7 @@ mod test {
     fn should_capture_event_name_if_we_dont_currently_handle_this_event() {
         let json = include_str!("../../tests/resources/unknown_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        match event.typ {
+        match event.r#type {
             EventType::UnknownEvent(typ) => assert_eq!(typ, "AmazingEvent"),
             _ => panic!("unexpected event deserialized"),
         }

--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -1,0 +1,294 @@
+pub mod payload;
+
+use self::payload::{CreateEventPayload, EventPayload, PushEventPayload};
+use chrono::{DateTime, Utc};
+use reqwest::Url;
+use serde::{de::Error, Deserialize, Serialize};
+
+/// A GitHub event.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct Event {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub typ: EventType,
+    pub actor: Actor,
+    pub repo: Repository,
+    pub public: bool,
+    pub created_at: DateTime<Utc>,
+    pub payload: Option<EventPayload>,
+    pub org: Option<Org>,
+}
+
+/// The type of an event.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum EventType {
+    PushEvent,
+    CreateEvent,
+    UnknownEvent(String),
+}
+
+/// The repository an [`Event`] belongs to.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Repository {
+    pub id: u64,
+    pub name: String,
+    pub url: Url,
+}
+
+/// The organization an [`Event`] belongs to.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Org {
+    pub id: u64,
+    pub login: String,
+    pub gravatar_id: String,
+    pub url: Url,
+    pub avatar_url: Url,
+}
+
+/// The actor that created this [`Event`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Actor {
+    pub id: u64,
+    pub login: String,
+    pub display_login: String,
+    pub gravatar_id: String,
+    pub url: Url,
+    pub avatar_url: Url,
+}
+
+impl<'de> Deserialize<'de> for Event {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Intermediate {
+            id: String,
+            #[serde(rename = "type")]
+            typ: String,
+            actor: Actor,
+            repo: Repository,
+            public: bool,
+            created_at: DateTime<Utc>,
+            org: Option<Org>,
+            payload: Option<serde_json::Value>,
+        }
+        let intermediate = Intermediate::deserialize(deserializer)?;
+        let event_type = deserialize_event_type(intermediate.typ.as_ref());
+        let payload = intermediate.payload.map_or(Ok(None), |data| {
+            deserialize_payload(&event_type, data).map_err(|e| Error::custom(e.to_string()))
+        })?;
+        let event = Event {
+            id: intermediate.id,
+            typ: event_type,
+            actor: intermediate.actor,
+            repo: intermediate.repo,
+            public: intermediate.public,
+            created_at: intermediate.created_at,
+            org: intermediate.org,
+            payload,
+        };
+        Ok(event)
+    }
+}
+
+fn deserialize_event_type(event_type: &str) -> EventType {
+    match event_type {
+        "CreateEvent" => EventType::CreateEvent,
+        "PushEvent" => EventType::PushEvent,
+        unknown => EventType::UnknownEvent(unknown.to_owned()),
+    }
+}
+
+fn deserialize_payload(
+    event_type: &EventType,
+    data: serde_json::Value,
+) -> Result<Option<EventPayload>, serde_json::Error> {
+    let maybe_payload = match event_type {
+        EventType::PushEvent => serde_json::from_value::<PushEventPayload>(data)
+            .map(|payload| Some(EventPayload::PushEvent(payload)))?,
+        EventType::CreateEvent => serde_json::from_value::<CreateEventPayload>(data)
+            .map(|payload| Some(EventPayload::CreateEvent(payload)))?,
+        _ => serde_json::from_value::<serde_json::Value>(data)
+            .map(|payload| Some(EventPayload::UnknownEvent(payload)))?,
+    };
+    Ok(maybe_payload)
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Actor, Event, EventPayload, EventType, Repository};
+    use crate::models::repos::GitUser;
+    use chrono::DateTime;
+    use reqwest::Url;
+
+    #[test]
+    fn should_deserialize_push_event() {
+        let json = include_str!("../../tests/resources/push_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        assert_eq!(event.id, "14289834535".to_owned());
+        assert_eq!(event.typ, EventType::PushEvent);
+        assert_eq!(
+            event.actor,
+            Actor {
+                id: 8739360,
+                login: "orhanarifoglu".to_string(),
+                display_login: "orhanarifoglu".to_string(),
+                gravatar_id: "".to_string(),
+                url: Url::parse("https://api.github.com/users/orhanarifoglu").unwrap(),
+                avatar_url: Url::parse("https://avatars.githubusercontent.com/u/8739360?").unwrap(),
+            }
+        );
+        assert_eq!(
+            event.repo,
+            Repository {
+                id: 291596188,
+                name: "orhanarifoglu/orhanarifoglu".to_string(),
+                url: Url::parse("https://api.github.com/repos/orhanarifoglu/orhanarifoglu")
+                    .unwrap()
+            }
+        );
+        assert!(event.public);
+        assert_eq!(
+            event.created_at,
+            DateTime::parse_from_rfc3339("2020-11-23T19:54:09Z").unwrap()
+        );
+    }
+
+    #[test]
+    fn should_deserialize_push_event_with_correct_payload() {
+        let json = include_str!("../../tests/resources/push_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        assert!(event.payload.is_some());
+        let payload = event.payload.unwrap();
+        match payload {
+            EventPayload::PushEvent(payload) => {
+                assert_eq!(payload.push_id, 6080608029);
+                assert_eq!(payload.size, 1);
+                assert_eq!(payload.distinct_size, 1);
+                assert_eq!(payload.ref_field, "refs/heads/master");
+                assert_eq!(payload.head, "eb1a60c03544dcea290f2d57bb66ae188ce25778");
+                assert_eq!(payload.before, "9b2afb3a8e03fb30cc09e5efb64823bde802cf59");
+                assert_eq!(payload.commits.len(), 1);
+                let commit = payload.commits.get(0).unwrap();
+                assert_eq!(commit.sha, "eb1a60c03544dcea290f2d57bb66ae188ce25778");
+                assert_eq!(
+                    commit.author,
+                    GitUser {
+                        name: "readme-bot".to_string(),
+                        email: "readme-bot@example.com".to_string()
+                    }
+                );
+                assert_eq!(commit.message, "Charts Updated");
+                assert_eq!(commit.distinct, true);
+                assert_eq!(
+                    commit.url,
+                    Url::parse("https://api.github.com/repos/user/user/commits/12345").unwrap()
+                );
+            }
+            _ => panic!("unexpected event deserialized"),
+        }
+    }
+
+    #[test]
+    fn should_deserialize_create_event_with_correct_payload() {
+        let json = include_str!("../../tests/resources/create_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        assert!(event.payload.is_some());
+        let payload = event.payload.unwrap();
+        match payload {
+            EventPayload::CreateEvent(payload) => {
+                assert_eq!(payload.ref_field, Some("url-normalisation".to_string()));
+                assert_eq!(payload.ref_type, "branch");
+                assert_eq!(payload.master_branch, "main");
+                assert_eq!(
+                    payload.description,
+                    Some("Your friendly URL vetting service".to_string())
+                );
+                assert_eq!(payload.pusher_type, "user");
+            }
+            _ => panic!("unexpected event deserialized"),
+        }
+    }
+
+    #[test]
+    fn should_deserialize_with_org_when_present() {
+        let json = include_str!("../../tests/resources/create_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        assert!(event.org.is_some());
+        let org = event.org.unwrap();
+        assert_eq!(org.id, 1243215);
+        assert_eq!(org.login, "hypothesis");
+        assert_eq!(org.gravatar_id, "");
+        assert_eq!(
+            org.url,
+            Url::parse("https://api.github.com/orgs/hypothesis").unwrap()
+        );
+        assert_eq!(
+            org.avatar_url,
+            Url::parse("https://avatars.githubusercontent.com/u/1243215?").unwrap()
+        );
+    }
+
+    #[test]
+    fn should_deserialize_unknown_event_payload() {
+        let json = include_str!("../../tests/resources/delete_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        assert!(event.payload.is_some());
+        let payload = event.payload.unwrap();
+        match payload {
+            EventPayload::UnknownEvent(json) => {
+                assert!(json.is_object());
+                let map = json.as_object().unwrap();
+                assert_eq!(map.get("ref").unwrap(), "Core.GetText");
+                assert_eq!(map.get("ref_type").unwrap(), "branch");
+                assert_eq!(map.get("pusher_type").unwrap(), "user");
+            }
+            _ => panic!("unexpected event deserialized"),
+        }
+    }
+
+    #[test]
+    fn should_deserialize_null_description_as_none() {
+        let json = include_str!("../../tests/resources/create_event_with_null_description.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        assert!(event.payload.is_some());
+        let payload = event.payload.unwrap();
+        match payload {
+            EventPayload::CreateEvent(payload) => assert_eq!(payload.description, None),
+            _ => panic!("unexpected event deserialized"),
+        }
+    }
+
+    #[test]
+    fn should_capture_event_name_if_we_dont_currently_handle_this_event() {
+        let json = include_str!("../../tests/resources/unknown_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        match event.typ {
+            EventType::UnknownEvent(typ) => assert_eq!(typ, "AmazingEvent"),
+            _ => panic!("unexpected event deserialized"),
+        }
+    }
+
+    #[test]
+    fn event_deserialize_and_serialize_should_be_isomorphic() {
+        let json = include_str!("../../tests/resources/create_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        let serialized = serde_json::to_string(&event).unwrap();
+        // do it again so we can compare Events, otherwise we are comparing strings which may have
+        // different whitespace characteristics.
+        let deserialized = serde_json::from_str::<Event>(&serialized);
+        assert!(
+            deserialized.is_ok(),
+            "expected deserialized result to be ok, got error instead {:?}",
+            deserialized
+        );
+        let deserialized = deserialized.unwrap();
+        assert_eq!(deserialized, event);
+    }
+}

--- a/src/models/events/payload.rs
+++ b/src/models/events/payload.rs
@@ -1,0 +1,55 @@
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use crate::models::repos::GitUser;
+
+/// The payload in an event type.
+///
+/// Different event types have different payloads. Any event type not specifically part
+/// of this enum will be captured in the variant `UnknownEvent` with a value of
+/// [`serde_json::Value`](serde_json::Value).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(untagged)]
+pub enum EventPayload {
+    PushEvent(PushEventPayload),
+    CreateEvent(CreateEventPayload),
+    UnknownEvent(serde_json::Value),
+}
+
+/// The payload in a [`EventPayload::PushEvent`] type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PushEventPayload {
+    pub push_id: u64,
+    pub size: u64,
+    pub distinct_size: u64,
+    #[serde(rename = "ref")]
+    pub ref_field: String,
+    pub head: String,
+    pub before: String,
+    pub commits: Vec<Commit>,
+}
+
+/// The payload in a [`EventPayload::CreateEvent`] type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CreateEventPayload {
+    // a null ref will occur on the initial create event
+    #[serde(rename = "ref")]
+    pub ref_field: Option<String>,
+    pub ref_type: String,
+    pub master_branch: String,
+    pub description: Option<String>,
+    pub pusher_type: String,
+}
+
+/// A git commit in specific payload types.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Commit {
+    pub sha: String,
+    pub author: GitUser,
+    pub message: String,
+    pub distinct: bool,
+    pub url: Url,
+}

--- a/src/models/events/payload.rs
+++ b/src/models/events/payload.rs
@@ -1,6 +1,6 @@
+use crate::models::repos::GitUser;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
-use crate::models::repos::GitUser;
 
 /// The payload in an event type.
 ///
@@ -23,8 +23,7 @@ pub struct PushEventPayload {
     pub push_id: u64,
     pub size: u64,
     pub distinct_size: u64,
-    #[serde(rename = "ref")]
-    pub ref_field: String,
+    pub r#ref: String,
     pub head: String,
     pub before: String,
     pub commits: Vec<Commit>,
@@ -35,8 +34,7 @@ pub struct PushEventPayload {
 #[non_exhaustive]
 pub struct CreateEventPayload {
     // a null ref will occur on the initial create event
-    #[serde(rename = "ref")]
-    pub ref_field: Option<String>,
+    pub r#ref: Option<String>,
     pub ref_type: String,
     pub master_branch: String,
     pub description: Option<String>,

--- a/tests/repos_events_test.rs
+++ b/tests/repos_events_test.rs
@@ -1,0 +1,143 @@
+// Tests for calls to the /repos/{owner}/{repo}/events API.
+use octocrab::{
+    etag::{Etag, Etagged},
+    models::events,
+    Octocrab, OctocrabBuilder,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::convert::TryFrom;
+use wiremock::{
+    matchers::{method, path, path_regex},
+    Mock, MockServer, ResponseTemplate,
+};
+
+#[derive(Serialize, Deserialize)]
+struct FakePage<T> {
+    items: Vec<T>,
+}
+
+async fn setup_api(template: ResponseTemplate) -> MockServer {
+    let owner = "owner";
+    let repo = "repo";
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{}/{}/events", owner, repo)))
+        .respond_with(template)
+        .mount(&mock_server)
+        .await;
+    setup_error_handler(
+        &mock_server,
+        &format!("GET on /repo/{}/{}/events was not received", owner, repo),
+    )
+    .await;
+    mock_server
+}
+
+// Sets up a handler on the mock server which will return a 500 with the given message. This
+// will be mapped internally into a GitHub json error, making it much easier to identify the cause
+// of these test failures.
+//
+// This handler should always come after your real expectations as it will match any GET request.
+async fn setup_error_handler(mock_server: &MockServer, message: &str) {
+    Mock::given(method("GET"))
+        .and(path_regex(".*"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!( {
+            "documentation_url": "",
+            "errors": None::<Vec<serde_json::Value>>,
+            "message": message,
+        })))
+        .mount(&mock_server)
+        .await;
+}
+
+fn setup_octocrab(uri: &str) -> Octocrab {
+    OctocrabBuilder::new()
+        .base_url(uri)
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+const OWNER: &str = "owner";
+const REPO: &str = "repo";
+
+#[tokio::test]
+async fn should_return_page_with_events_and_etag() {
+    let event: events::Event =
+        serde_json::from_str(include_str!("resources/create_event.json")).unwrap();
+    let page_response = FakePage { items: vec![event] };
+    let expected_etag = "12345";
+    let template = ResponseTemplate::new(200)
+        .set_body_json(&page_response)
+        .insert_header("etag", expected_etag);
+    let mock_server = setup_api(template).await;
+    let octo = setup_octocrab(&mock_server.uri());
+    let repos = octo.repos(OWNER.to_owned(), REPO.to_owned());
+    let result = repos.events().send().await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    match result.unwrap() {
+        Etagged {
+            etag: Some(etag),
+            value: Some(mut page),
+        } => {
+            assert_eq!(page.take_items(), page_response.items);
+            assert_eq!(etag, Etag::try_from(expected_etag).unwrap());
+        }
+        unexpected => panic!("expected a page and an etag, got {:#?}", unexpected),
+    }
+}
+
+#[tokio::test]
+async fn should_return_no_page_with_events_and_etag_when_response_is_304() {
+    let expected_etag = "12345";
+    let template = ResponseTemplate::new(304).append_header("etag", expected_etag);
+    let mock_server = setup_api(template).await;
+    let octo = setup_octocrab(&mock_server.uri());
+    let repos = octo.repos(OWNER.to_owned(), REPO.to_owned());
+    let result = repos.events().send().await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    match result.unwrap() {
+        Etagged {
+            etag: Some(etag),
+            value: None,
+        } => {
+            assert_eq!(etag, Etag::try_from(expected_etag).unwrap());
+        }
+        unexpected => panic!("expected no page and an etag, got {:#?}", unexpected),
+    }
+}
+
+#[tokio::test]
+async fn should_return_no_etag_if_response_contains_none() {
+    let event: events::Event =
+        serde_json::from_str(include_str!("resources/create_event.json")).unwrap();
+    let page_response = FakePage { items: vec![event] };
+    let template = ResponseTemplate::new(200).set_body_json(&page_response);
+    let mock_server = setup_api(template).await;
+    let octo = setup_octocrab(&mock_server.uri());
+    let repos = octo.repos(OWNER.to_owned(), REPO.to_owned());
+    let result = repos.events().send().await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    match result.unwrap() {
+        Etagged {
+            etag: None,
+            value: Some(mut page),
+        } => {
+            assert_eq!(page.take_items(), page_response.items);
+        }
+        unexpected => panic!("expected a page with no etag, got {:#?}", unexpected),
+    }
+}

--- a/tests/resources/create_event.json
+++ b/tests/resources/create_event.json
@@ -1,0 +1,33 @@
+{
+  "id": "14304136554",
+  "type": "CreateEvent",
+  "actor": {
+    "id": 7131143,
+    "login": "jon-betts",
+    "display_login": "jon-betts",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/jon-betts",
+    "avatar_url": "https://avatars.githubusercontent.com/u/7131143?"
+  },
+  "repo": {
+    "id": 311739396,
+    "name": "hypothesis/checkmate",
+    "url": "https://api.github.com/repos/hypothesis/checkmate"
+  },
+  "payload": {
+    "ref": "url-normalisation",
+    "ref_type": "branch",
+    "master_branch": "main",
+    "description": "Your friendly URL vetting service",
+    "pusher_type": "user"
+  },
+  "public": true,
+  "created_at": "2020-11-24T20:04:43Z",
+  "org": {
+    "id": 1243215,
+    "login": "hypothesis",
+    "gravatar_id": "",
+    "url": "https://api.github.com/orgs/hypothesis",
+    "avatar_url": "https://avatars.githubusercontent.com/u/1243215?"
+  }
+}

--- a/tests/resources/create_event_with_null_description.json
+++ b/tests/resources/create_event_with_null_description.json
@@ -1,0 +1,33 @@
+{
+  "id": "14304136554",
+  "type": "CreateEvent",
+  "actor": {
+    "id": 7131143,
+    "login": "jon-betts",
+    "display_login": "jon-betts",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/jon-betts",
+    "avatar_url": "https://avatars.githubusercontent.com/u/7131143?"
+  },
+  "repo": {
+    "id": 311739396,
+    "name": "hypothesis/checkmate",
+    "url": "https://api.github.com/repos/hypothesis/checkmate"
+  },
+  "payload": {
+    "ref": "url-normalisation",
+    "ref_type": "branch",
+    "master_branch": "main",
+    "description": null,
+    "pusher_type": "user"
+  },
+  "public": true,
+  "created_at": "2020-11-24T20:04:43Z",
+  "org": {
+    "id": 1243215,
+    "login": "hypothesis",
+    "gravatar_id": "",
+    "url": "https://api.github.com/orgs/hypothesis",
+    "avatar_url": "https://avatars.githubusercontent.com/u/1243215?"
+  }
+}

--- a/tests/resources/delete_event.json
+++ b/tests/resources/delete_event.json
@@ -1,0 +1,24 @@
+{
+  "id": "14316142282",
+  "type": "DeleteEvent",
+  "actor": {
+    "id": 7158903,
+    "login": "perpetualKid",
+    "display_login": "perpetualKid",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/perpetualKid",
+    "avatar_url": "https://avatars.githubusercontent.com/u/7158903?"
+  },
+  "repo": {
+    "id": 137481275,
+    "name": "perpetualKid/ORTS-MG",
+    "url": "https://api.github.com/repos/perpetualKid/ORTS-MG"
+  },
+  "payload": {
+    "ref": "Core.GetText",
+    "ref_type": "branch",
+    "pusher_type": "user"
+  },
+  "public": true,
+  "created_at": "2020-11-25T16:12:36Z"
+}

--- a/tests/resources/push_event.json
+++ b/tests/resources/push_event.json
@@ -1,0 +1,39 @@
+{
+    "id": "14289834535",
+    "type": "PushEvent",
+    "actor": {
+     "id": 8739360,
+     "login": "orhanarifoglu",
+     "display_login": "orhanarifoglu",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/orhanarifoglu",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8739360?"
+    },
+    "repo": {
+      "id": 291596188,
+      "name": "orhanarifoglu/orhanarifoglu",
+      "url": "https://api.github.com/repos/orhanarifoglu/orhanarifoglu"
+    },
+    "payload": {
+      "push_id": 6080608029,
+      "size": 1,
+      "distinct_size": 1,
+      "ref": "refs/heads/master",
+      "head": "eb1a60c03544dcea290f2d57bb66ae188ce25778",
+      "before": "9b2afb3a8e03fb30cc09e5efb64823bde802cf59",
+      "commits": [
+        {
+          "sha": "eb1a60c03544dcea290f2d57bb66ae188ce25778",
+          "author": {
+            "email": "readme-bot@example.com",
+            "name": "readme-bot"
+          },
+          "message": "Charts Updated",
+          "distinct": true,
+          "url": "https://api.github.com/repos/user/user/commits/12345"
+        }
+      ]
+    },
+    "public": true,
+    "created_at": "2020-11-23T19:54:09Z"
+}

--- a/tests/resources/unknown_event.json
+++ b/tests/resources/unknown_event.json
@@ -1,0 +1,19 @@
+{
+  "id": "14304136554",
+  "type": "AmazingEvent",
+  "actor": {
+    "id": 7131143,
+    "login": "jon-betts",
+    "display_login": "jon-betts",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/jon-betts",
+    "avatar_url": "https://avatars.githubusercontent.com/u/7131143?"
+  },
+  "repo": {
+    "id": 311739396,
+    "name": "hypothesis/checkmate",
+    "url": "https://api.github.com/repos/hypothesis/checkmate"
+  },
+  "public": true,
+  "created_at": "2020-11-24T20:04:43Z"
+}


### PR DESCRIPTION
Hello! This PR adds initial support for Events (#25), specifically the repo events API `/repos/{owner}/{repo}/events`. There is a bit here, quick overview of the main changes:

  * Adds direct support for `CreateEvent` and `PushEvent` (see [EventType](https://github.com/XAMPPRocky/octocrab/pull/60/files#diff-279c8cd5a7a2067dc9b53f644006e103e949cce2085d0ea28b18d5153e2554daR24-R30)) , all other events are currently mapped to a `serde_json::Value` type.
  * Adds an [etag module](https://github.com/XAMPPRocky/octocrab/pull/60/files#diff-0d0e00934e22d61e855109d06fedb297be71f02211fa836055030479c1beed4a) for handling of etags, which are really necessary to use the Events API correctly. 
  * Adds some [high level tests](https://github.com/XAMPPRocky/octocrab/pull/60/files#diff-6a98530cb09e3005dbdc349918639b85df67aa68744d38d2392835efc26810e4) for the repo events calls using [wiremock](https://docs.rs/wiremock/0.4.3/wiremock/). These were useful to get the etag handling right, but not sure if you want these here as none exist so far.

I plan on adding the models for the rest of the events, and the other events API's over the next few weeks. But thought I'd raise this first as it is usable now and you may want to change a few things in how I've implemented it. Thanks!