### PR TITLE
Update reqwest, tokio, & bytes crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/octocrab"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-reqwest = { version = "0.10.10", features = ["json"] }
+reqwest = { version = "0.11.0", features = ["json"] }
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.51"
 serde_path_to_error = "0.1.2"
@@ -27,13 +27,13 @@ snafu = { version = "0.6.6", features = ["backtraces"] }
 once_cell = "1.3.1"
 arc-swap = "1.0.0"
 base64 = "0.13"
-bytes = "0.5.6"
+bytes = "1.0.0"
 futures-core = { version = "0.3.6", optional = true }
 futures-util = { version = "0.3.6", optional = true }
 doc-cfg = "0.1.0"
 
 [dev-dependencies]
-tokio = { version = "0.2", default-features = false, features = ["macros"] }
+tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = []


### PR DESCRIPTION
These all need to be updated together, AFAICT. This updates them to:

* reqwest 0.11.0
* tokio 1.0
* bytes 1.0.0