### PR TITLE
Add various enhancements

### DIFF
--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -343,6 +343,32 @@ impl<'octo> IssueHandler<'octo> {
             .await
     }
 
+    /// Removes `label` from an issue.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let removed_labels = octocrab::instance()
+    ///     .issues("owner", "repo")
+    ///     .remove_label(101, "my_label")
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn remove_label(
+        &self,
+        number: u64,
+        label: impl AsRef<str>,
+    ) -> Result<Vec<models::Label>> {
+        let route = format!(
+            "/repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
+            owner = self.owner,
+            repo = self.repo,
+            issue_number = number,
+            name = label.as_ref(),
+        );
+
+        self.crab.delete(route, None::<&()>).await
+    }
+
     /// Replaces all labels for an issue.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {

--- a/src/api/pulls.rs
+++ b/src/api/pulls.rs
@@ -203,7 +203,7 @@ impl<'octo> PullRequestHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn list_reviews(&self, pr: u64) -> crate::Result<Vec<crate::models::pulls::Review>> {
+    pub async fn list_reviews(&self, pr: u64) -> crate::Result<Page<crate::models::pulls::Review>> {
         let url = format!(
             "/repos/{owner}/{repo}/pulls/{pr}/reviews",
             owner = self.owner,

--- a/src/api/pulls.rs
+++ b/src/api/pulls.rs
@@ -194,6 +194,24 @@ impl<'octo> PullRequestHandler<'octo> {
     pub fn list(&self) -> list::ListPullRequestsBuilder {
         list::ListPullRequestsBuilder::new(self)
     }
+
+    /// Lists all of the `Review`s associated with the pull request.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let reviews = octocrab::instance().pulls("owner", "repo").list_reviews(101).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list_reviews(&self, pr: u64) -> crate::Result<Vec<crate::models::pulls::Review>> {
+        let url = format!(
+            "/repos/{owner}/{repo}/pulls/{pr}/reviews",
+            owner = self.owner,
+            repo = self.repo,
+            pr = pr
+        );
+
+        self.http_get(url, None::<&()>).await
+    }
 }
 
 impl<'octo> PullRequestHandler<'octo> {

--- a/src/api/pulls/merge.rs
+++ b/src/api/pulls/merge.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+/// A builder pattern struct for merging pull requests.
+///
+/// created by [`PullRequestHandler::merge`]
+///
+/// [`PullRequestHandler::merge`]: ./struct.PullRequestHandler.html#method.merge
+#[derive(serde::Serialize)]
+pub struct MergePullRequestsBuilder<'octo, 'b> {
+    #[serde(skip)]
+    handler: &'b PullRequestHandler<'octo>,
+    #[serde(skip)]
+    pr_number: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit_title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    merge_method: Option<crate::params::pulls::MergeMethod>,
+}
+
+impl<'octo, 'b> MergePullRequestsBuilder<'octo, 'b> {
+    pub(crate) fn new(handler: &'b PullRequestHandler<'octo>, pr_number: u64) -> Self {
+        Self {
+            handler,
+            pr_number,
+            commit_title: None,
+            commit_message: None,
+            sha: None,
+            merge_method: None,
+        }
+    }
+
+    /// Title for the automatic commit message.
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.commit_title = Some(title.into());
+        self
+    }
+
+    /// Extra detail to append to automatic commit message.
+    pub fn message(mut self, msg: impl Into<String>) -> Self {
+        self.commit_message = Some(msg.into());
+        self
+    }
+
+    /// SHA that pull request head must match to allow merge.
+    pub fn sha(mut self, sha: impl Into<String>) -> Self {
+        self.sha = Some(sha.into());
+        self
+    }
+
+    /// Merge method to use. Default is `Merge`.
+    pub fn method(mut self, method: impl Into<crate::params::pulls::MergeMethod>) -> Self {
+        self.merge_method = Some(method.into());
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(self) -> crate::Result<crate::models::pulls::Merge> {
+        let url = format!(
+            "/repos/{owner}/{repo}/pulls/{pull_number}/merge",
+            owner = self.handler.owner,
+            repo = self.handler.repo,
+            pull_number = self.pr_number,
+        );
+
+        self.handler.http_put(url, Some(&self)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn serialize() {
+        let octocrab = crate::Octocrab::default();
+        let handler = octocrab.pulls("rust-lang", "rust");
+        let merge = handler
+            .merge(80818)
+            .title("just testing!")
+            .message("promise!")
+            .sha("luckily this won't deserialize ;)")
+            .method(crate::params::pulls::MergeMethod::Squash);
+
+        assert_eq!(
+            serde_json::to_value(merge).unwrap(),
+            serde_json::json!({
+                "commit_title": "just testing!",
+                "commit_message": "promise!",
+                "sha": "luckily this won't deserialize ;)",
+                "merge_method": "squash",
+            })
+        )
+    }
+}

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -254,7 +254,7 @@ impl<'octo> RepoHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_combined_status_for_ref(
+    pub async fn combined_status_for_ref(
         &self,
         reference: &params::repos::Reference,
     ) -> Result<models::CombinedStatus> {

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -241,4 +241,29 @@ impl<'octo> RepoHandler<'octo> {
     pub fn events(&self) -> events::ListRepoEventsBuilder<'_, '_> {
         events::ListRepoEventsBuilder::new(self)
     }
+
+    /// Gets the combined status for the specified reference.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// use octocrab::params::repos::Reference;
+    ///
+    /// let master = octocrab::instance()
+    ///     .repos("owner", "repo")
+    ///     .get_combined_status_for_ref(&Reference::Branch("main".to_string()))
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_combined_status_for_ref(
+        &self,
+        reference: &params::repos::Reference,
+    ) -> Result<models::CombinedStatus> {
+        let url = format!(
+            "/repos/{owner}/{repo}/commits/{reference}/status",
+            owner = self.owner,
+            repo = self.repo,
+            reference = reference.ref_url(),
+        );
+        self.crab.get(url, None::<&()>).await
+    }
 }

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -249,7 +249,7 @@ impl<'octo> RepoHandler<'octo> {
     ///
     /// let master = octocrab::instance()
     ///     .repos("owner", "repo")
-    ///     .get_combined_status_for_ref(&Reference::Branch("main".to_string()))
+    ///     .combined_status_for_ref(&Reference::Branch("main".to_string()))
     ///     .await?;
     /// # Ok(())
     /// # }

--- a/src/api/repos/status.rs
+++ b/src/api/repos/status.rs
@@ -1,6 +1,5 @@
 use super::*;
-use crate::models::{Status, StatusState, User};
-use chrono::{DateTime, Utc};
+use crate::models::StatusState;
 
 #[derive(serde::Serialize)]
 pub struct CreateStatusBuilder<'octo, 'r> {

--- a/src/models.rs
+++ b/src/models.rs
@@ -476,6 +476,7 @@ pub enum StatusState {
     Failure,
     Pending,
     Success,
+    Error,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -440,13 +440,19 @@ pub enum CheckStatus {
     InProgress,
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct CombinedStatus {
     pub state: StatusState,
     pub sha: String,
     pub total_count: i64,
     pub statuses: Vec<Status>,
+    #[serde(skip_serializing)]
+    pub repository: Option<Repository>,
+    #[serde(skip_serializing)]
+    pub commit_url: Option<Url>,
+    #[serde(skip_serializing)]
+    pub url: Option<Url>,
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
@@ -467,6 +473,8 @@ pub struct Status {
     pub state: StatusState,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub creator: Option<User>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
 }
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -190,3 +190,24 @@ pub enum ReviewState {
     Pending,
     ChangesRequested,
 }
+
+/// The complete list of actions that can trigger the sending of a
+/// `pull_request` webhook
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PullRequestAction {
+    Opened,
+    Edited,
+    Closed,
+    Assigned,
+    Unassigned,
+    ReviewRequested,
+    ReviewRequestRemoved,
+    ReadyForReview,
+    Labeled,
+    Unlabeled,
+    Synchronize,
+    Locked,
+    Unlocked,
+    Reopened,
+}

--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -43,6 +43,8 @@ pub struct PullRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mergeable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub mergeable_state: Option<MergeableState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub merged_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub merge_commit_sha: Option<String>,
@@ -266,6 +268,29 @@ pub struct Merge {
     pub sha: Option<String>,
     pub message: Option<String>,
     pub merged: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum MergeableState {
+    /// The head ref is out of date.
+    Behind,
+    /// The merge is blocked, eg. the base branch is protected by a required
+    /// status check that is pending
+    Blocked,
+    /// Mergeable and passing commit status.
+    Clean,
+    /// The merge commit cannot be cleanly created.
+    Dirty,
+    /// The merge is blocked due to the pull request being a draft.
+    Draft,
+    /// Mergeable with passing commit status and pre-receive hooks.
+    HasHooks,
+    /// The state cannot currently be determined.
+    Unknown,
+    /// Mergeable with non-passing commit status.
+    Unstable,
 }
 
 #[cfg(test)]

--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -183,7 +183,7 @@ pub struct Review {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ReviewState {
     Approved,

--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -189,6 +189,7 @@ pub enum ReviewState {
     Approved,
     Pending,
     ChangesRequested,
+    Commented,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -222,3 +222,12 @@ pub enum PullRequestAction {
     Unlocked,
     Reopened,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub struct Merge {
+    pub sha: Option<String>,
+    pub message: Option<String>,
+    pub merged: bool,
+}

--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -191,10 +191,20 @@ pub enum ReviewState {
     ChangesRequested,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PullRequestReviewAction {
+    Submitted,
+    Edited,
+    Dismissed,
+}
+
 /// The complete list of actions that can trigger the sending of a
 /// `pull_request` webhook
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum PullRequestAction {
     Opened,
     Edited,

--- a/src/params.rs
+++ b/src/params.rs
@@ -247,11 +247,12 @@ pub mod repos {
         FullName,
     }
 
-    /// A Git reference, either a branch or a tag.
+    /// A Git reference, either a branch, tag, or ref.
     #[derive(Debug, Clone)]
     pub enum Reference {
         Branch(String),
         Tag(String),
+        Commit(String),
     }
 
     impl Reference {
@@ -259,11 +260,15 @@ pub mod repos {
             match self {
                 Self::Branch(branch) => format!("heads/{}", branch),
                 Self::Tag(tag) => format!("tags/{}", tag),
+                Self::Commit(sha) => sha.clone(),
             }
         }
 
         pub fn full_ref_url(&self) -> String {
-            format!("refs/{}", self.ref_url())
+            match self {
+                Self::Branch(_) | Self::Tag(_) => format!("refs/{}", self.ref_url()),
+                Self::Commit(sha) => sha.clone(),
+            }
         }
     }
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -256,7 +256,7 @@ pub mod repos {
         FullName,
     }
 
-    /// A Git reference, either a branch, tag, or ref.
+    /// A Git reference, either a branch, tag, or rev.
     #[derive(Debug, Clone)]
     pub enum Reference {
         Branch(String),

--- a/src/params.rs
+++ b/src/params.rs
@@ -211,6 +211,15 @@ pub mod pulls {
             f.write_str(text)
         }
     }
+
+    #[derive(Debug, Copy, Clone, PartialEq, serde::Serialize)]
+    #[serde(rename_all = "snake_case")]
+    #[non_exhaustive]
+    pub enum MergeMethod {
+        Merge,
+        Squash,
+        Rebase,
+    }
 }
 
 pub mod repos {


### PR DESCRIPTION
When using crate to create a Github action to automerge PRs, I ran into several missing pieces that I've added in this PR. These may seem a bit scattershot, so I can split out things in multiple PRs if you want me to.

1. Adds `PullRequestHandler::merge` which returns a `MergePullRequestsBuilder` that can be used to set the various options available when merging a PR.
1. Adds a `PullRequestHandler::list_reviews` to list all of the reviews that have been made on a PR.
1. Adds `RepoHandler::combined_status_for_ref` to retrieve all of the statuses for a particular reference
1. Adds various `params` and `models` for the above, as well as adding some missing fields (eg. `PullRequest::mergeable_state`)
1. Adds some models for data that are specific to [actions](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows), namely `PullRequestReviewAction` and `PullRequestAction`
1. Implemented a custom deserialize for `ReviewState`, as Github has a weird difference in that enumeration, as when making an API request, it is `SCREAMING_SNAKE_CASE` but when it's a webhook payload (which is what the action actually sees), it just `snake_case`