### PR TITLE
Support IssuesEvent

### DIFF
--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -1,6 +1,6 @@
 pub mod payload;
 
-use self::payload::{CreateEventPayload, EventPayload, PushEventPayload};
+use self::payload::{CreateEventPayload, EventPayload, IssuesEventPayload, PushEventPayload};
 use chrono::{DateTime, Utc};
 use reqwest::Url;
 use serde::{de::Error, Deserialize, Serialize};
@@ -26,6 +26,7 @@ pub struct Event {
 pub enum EventType {
     PushEvent,
     CreateEvent,
+    IssuesEvent,
     UnknownEvent(String),
 }
 
@@ -101,6 +102,7 @@ fn deserialize_event_type(event_type: &str) -> EventType {
     match event_type {
         "CreateEvent" => EventType::CreateEvent,
         "PushEvent" => EventType::PushEvent,
+        "IssuesEvent" => EventType::IssuesEvent,
         unknown => EventType::UnknownEvent(unknown.to_owned()),
     }
 }
@@ -115,6 +117,9 @@ fn deserialize_payload(
         }
         EventType::CreateEvent => {
             serde_json::from_value::<CreateEventPayload>(data).map(EventPayload::CreateEvent)?
+        }
+        EventType::IssuesEvent => {
+            serde_json::from_value::<IssuesEventPayload>(data).map(EventPayload::IssuesEvent)?
         }
         _ => EventPayload::UnknownEvent(data),
     };
@@ -138,6 +143,13 @@ mod test {
         let json = include_str!("../../tests/resources/create_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
         assert_eq!(event.r#type, EventType::CreateEvent);
+    }
+
+    #[test]
+    fn should_deserialize_issues_event() {
+        let json = include_str!("../../tests/resources/issues_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        assert_eq!(event.r#type, EventType::IssuesEvent);
     }
 
     #[test]

--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -161,7 +161,7 @@ mod test {
 
     #[test]
     fn should_deserialize_unknown_event_payload() {
-        let json = include_str!("../../tests/resources/delete_event.json");
+        let json = include_str!("../../tests/resources/unknown_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
         assert!(event.payload.is_some());
         let payload = event.payload.unwrap();

--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -123,98 +123,21 @@ fn deserialize_payload(
 
 #[cfg(test)]
 mod test {
-    use super::{Actor, Event, EventPayload, EventType, Repository};
-    use crate::models::repos::GitUser;
-    use chrono::DateTime;
+    use super::{Event, EventPayload, EventType};
     use reqwest::Url;
 
     #[test]
     fn should_deserialize_push_event() {
         let json = include_str!("../../tests/resources/push_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        assert_eq!(event.id, "14289834535".to_owned());
         assert_eq!(event.r#type, EventType::PushEvent);
-        assert_eq!(
-            event.actor,
-            Actor {
-                id: 8739360,
-                login: "orhanarifoglu".to_string(),
-                display_login: "orhanarifoglu".to_string(),
-                gravatar_id: "".to_string(),
-                url: Url::parse("https://api.github.com/users/orhanarifoglu").unwrap(),
-                avatar_url: Url::parse("https://avatars.githubusercontent.com/u/8739360?").unwrap(),
-            }
-        );
-        assert_eq!(
-            event.repo,
-            Repository {
-                id: 291596188,
-                name: "orhanarifoglu/orhanarifoglu".to_string(),
-                url: Url::parse("https://api.github.com/repos/orhanarifoglu/orhanarifoglu")
-                    .unwrap()
-            }
-        );
-        assert!(event.public);
-        assert_eq!(
-            event.created_at,
-            DateTime::parse_from_rfc3339("2020-11-23T19:54:09Z").unwrap()
-        );
     }
 
     #[test]
-    fn should_deserialize_push_event_with_correct_payload() {
-        let json = include_str!("../../tests/resources/push_event.json");
-        let event: Event = serde_json::from_str(json).unwrap();
-        assert!(event.payload.is_some());
-        let payload = event.payload.unwrap();
-        match payload {
-            EventPayload::PushEvent(payload) => {
-                assert_eq!(payload.push_id, 6080608029);
-                assert_eq!(payload.size, 1);
-                assert_eq!(payload.distinct_size, 1);
-                assert_eq!(payload.r#ref, "refs/heads/master");
-                assert_eq!(payload.head, "eb1a60c03544dcea290f2d57bb66ae188ce25778");
-                assert_eq!(payload.before, "9b2afb3a8e03fb30cc09e5efb64823bde802cf59");
-                assert_eq!(payload.commits.len(), 1);
-                let commit = payload.commits.get(0).unwrap();
-                assert_eq!(commit.sha, "eb1a60c03544dcea290f2d57bb66ae188ce25778");
-                assert_eq!(
-                    commit.author,
-                    GitUser {
-                        name: "readme-bot".to_string(),
-                        email: "readme-bot@example.com".to_string()
-                    }
-                );
-                assert_eq!(commit.message, "Charts Updated");
-                assert_eq!(commit.distinct, true);
-                assert_eq!(
-                    commit.url,
-                    Url::parse("https://api.github.com/repos/user/user/commits/12345").unwrap()
-                );
-            }
-            _ => panic!("unexpected event deserialized"),
-        }
-    }
-
-    #[test]
-    fn should_deserialize_create_event_with_correct_payload() {
+    fn should_deserialize_create_event() {
         let json = include_str!("../../tests/resources/create_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        assert!(event.payload.is_some());
-        let payload = event.payload.unwrap();
-        match payload {
-            EventPayload::CreateEvent(payload) => {
-                assert_eq!(payload.r#ref, Some("url-normalisation".to_string()));
-                assert_eq!(payload.ref_type, "branch");
-                assert_eq!(payload.master_branch, "main");
-                assert_eq!(
-                    payload.description,
-                    Some("Your friendly URL vetting service".to_string())
-                );
-                assert_eq!(payload.pusher_type, "user");
-            }
-            _ => panic!("unexpected event deserialized"),
-        }
+        assert_eq!(event.r#type, EventType::CreateEvent);
     }
 
     #[test]
@@ -250,18 +173,6 @@ mod test {
                 assert_eq!(map.get("ref_type").unwrap(), "branch");
                 assert_eq!(map.get("pusher_type").unwrap(), "user");
             }
-            _ => panic!("unexpected event deserialized"),
-        }
-    }
-
-    #[test]
-    fn should_deserialize_null_description_as_none() {
-        let json = include_str!("../../tests/resources/create_event_with_null_description.json");
-        let event: Event = serde_json::from_str(json).unwrap();
-        assert!(event.payload.is_some());
-        let payload = event.payload.unwrap();
-        match payload {
-            EventPayload::CreateEvent(payload) => assert_eq!(payload.description, None),
             _ => panic!("unexpected event deserialized"),
         }
     }

--- a/src/models/events/payload.rs
+++ b/src/models/events/payload.rs
@@ -1,8 +1,10 @@
 mod create;
+mod issues;
 mod push;
 
 use crate::models::repos::GitUser;
 pub use create::*;
+pub use issues::*;
 pub use push::*;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -18,6 +20,7 @@ use serde::{Deserialize, Serialize};
 pub enum EventPayload {
     PushEvent(PushEventPayload),
     CreateEvent(CreateEventPayload),
+    IssuesEvent(IssuesEventPayload),
     UnknownEvent(serde_json::Value),
 }
 

--- a/src/models/events/payload.rs
+++ b/src/models/events/payload.rs
@@ -1,4 +1,9 @@
+mod create;
+mod push;
+
 use crate::models::repos::GitUser;
+pub use create::*;
+pub use push::*;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 
@@ -14,31 +19,6 @@ pub enum EventPayload {
     PushEvent(PushEventPayload),
     CreateEvent(CreateEventPayload),
     UnknownEvent(serde_json::Value),
-}
-
-/// The payload in a [`EventPayload::PushEvent`] type.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
-pub struct PushEventPayload {
-    pub push_id: u64,
-    pub size: u64,
-    pub distinct_size: u64,
-    pub r#ref: String,
-    pub head: String,
-    pub before: String,
-    pub commits: Vec<Commit>,
-}
-
-/// The payload in a [`EventPayload::CreateEvent`] type.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
-pub struct CreateEventPayload {
-    // a null ref will occur on the initial create event
-    pub r#ref: Option<String>,
-    pub ref_type: String,
-    pub master_branch: String,
-    pub description: Option<String>,
-    pub pusher_type: String,
 }
 
 /// A git commit in specific payload types.

--- a/src/models/events/payload/create.rs
+++ b/src/models/events/payload/create.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-/// The payload in a [`EventPayload::CreateEvent`] type.
+/// The payload in a [`super::EventPayload::CreateEvent`] type.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct CreateEventPayload {

--- a/src/models/events/payload/create.rs
+++ b/src/models/events/payload/create.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+
+/// The payload in a [`EventPayload::CreateEvent`] type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CreateEventPayload {
+    // a null ref will occur on the initial create event
+    pub r#ref: Option<String>,
+    pub ref_type: String,
+    pub master_branch: String,
+    pub description: Option<String>,
+    pub pusher_type: String,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::models::events::{payload::EventPayload, Event};
+
+    #[test]
+    fn should_deserialize_create_event_with_correct_payload() {
+        let json = include_str!("../../../../tests/resources/create_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        assert!(event.payload.is_some());
+        let payload = event.payload.unwrap();
+        match payload {
+            EventPayload::CreateEvent(payload) => {
+                assert_eq!(payload.r#ref, Some("url-normalisation".to_string()));
+                assert_eq!(payload.ref_type, "branch");
+                assert_eq!(payload.master_branch, "main");
+                assert_eq!(
+                    payload.description,
+                    Some("Your friendly URL vetting service".to_string())
+                );
+                assert_eq!(payload.pusher_type, "user");
+            }
+            _ => panic!("unexpected event deserialized"),
+        }
+    }
+
+    #[test]
+    fn should_deserialize_null_description_as_none() {
+        let json =
+            include_str!("../../../../tests/resources/create_event_with_null_description.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        assert!(event.payload.is_some());
+        let payload = event.payload.unwrap();
+        match payload {
+            EventPayload::CreateEvent(payload) => assert_eq!(payload.description, None),
+            _ => panic!("unexpected event deserialized"),
+        }
+    }
+}

--- a/src/models/events/payload/issues.rs
+++ b/src/models/events/payload/issues.rs
@@ -1,0 +1,130 @@
+use crate::models::{issues::Issue, Label, User};
+use serde::{Deserialize, Serialize};
+
+/// The payload in a [`super::EventPayload::IssuesEvent`] type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct IssuesEventPayload {
+    /// The action this event represents.
+    pub action: IssuesEventAction,
+    /// The issue this event corresponds to.
+    pub issue: Issue,
+    /// The changes to body or title if this event is of type [`IssuesEventAction::Edited`].
+    pub changes: Option<IssuesEventChanges>,
+    /// The optional user who was assigned or unassigned from the issue.
+    ///
+    /// Set when they type is [`IssuesEventAction::Assigned`] or
+    /// [`IssuesEventAction::Unassigned`].
+    pub assignee: Option<User>,
+    /// The optional label added or removed from the issue.
+    ///
+    /// Set when the type is [`IssuesEventAction::Labeled`] or
+    /// [`IssuesEventAction::Unlabeled`].
+    pub label: Option<Label>,
+}
+
+/// The change which occurred in an event of type [`IssuesEventAction::Edited`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum IssuesEventChanges {
+    Title(IssuesEventChangesFrom),
+    Body(IssuesEventChangesFrom),
+}
+
+/// The previous value of the item (either the body or title) of an issue which has changed. Only
+/// available in an event of type [`IssuesEventAction::Edited`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct IssuesEventChangesFrom {
+    pub from: String,
+}
+
+/// The action on an issue this event corresponds to.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum IssuesEventAction {
+    Opened,
+    Closed,
+    Reopened,
+    /// Only available on webhook events.
+    Edited,
+    /// Only available on webhook events.
+    Assigned,
+    /// Only available on webhook events.
+    Unassigned,
+    /// Only available on webhook events.
+    Labeled,
+    /// Only available on webhook events.
+    Unlabeled,
+}
+
+#[cfg(test)]
+mod test {
+    use super::{IssuesEventAction, IssuesEventChanges, IssuesEventChangesFrom};
+    use crate::models::events::{payload::EventPayload, Event};
+    use serde_json::json;
+
+    #[test]
+    fn should_deserialize_action_from_lowercase() {
+        let actions = vec![
+            (r#""opened""#, IssuesEventAction::Opened),
+            (r#""closed""#, IssuesEventAction::Closed),
+            (r#""edited""#, IssuesEventAction::Edited),
+            (r#""reopened""#, IssuesEventAction::Reopened),
+            (r#""assigned""#, IssuesEventAction::Assigned),
+            (r#""unassigned""#, IssuesEventAction::Unassigned),
+            (r#""labeled""#, IssuesEventAction::Labeled),
+            (r#""unlabeled""#, IssuesEventAction::Unlabeled),
+        ];
+        for (action_str, action) in actions {
+            let deserialized = serde_json::from_str(&action_str).unwrap();
+            assert_eq!(action, deserialized);
+        }
+    }
+
+    #[test]
+    fn should_deserialize_title_changes() {
+        let json = json!({
+            "title": {
+                "from": "test"
+            }
+        });
+        let deserialized = serde_json::from_value::<IssuesEventChanges>(json).unwrap();
+        assert_eq!(
+            deserialized,
+            IssuesEventChanges::Title(IssuesEventChangesFrom {
+                from: "test".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn should_deserialize_body_changes() {
+        let json = json!({
+            "body": {
+                "from": "test"
+            }
+        });
+        let deserialized = serde_json::from_value::<IssuesEventChanges>(json).unwrap();
+        assert_eq!(
+            deserialized,
+            IssuesEventChanges::Body(IssuesEventChangesFrom {
+                from: "test".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn should_deserialize_with_correct_payload() {
+        let json = include_str!("../../../../tests/resources/issues_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        if let Some(EventPayload::IssuesEvent(payload)) = event.payload {
+            assert_eq!(payload.action, IssuesEventAction::Opened);
+            assert_eq!(payload.issue.id, 786747990);
+        } else {
+            panic!("unexpected event payload encountered: {:#?}", event.payload);
+        }
+    }
+}

--- a/src/models/events/payload/push.rs
+++ b/src/models/events/payload/push.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+
+use super::Commit;
+
+/// The payload in a [`EventPayload::PushEvent`] type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PushEventPayload {
+    pub push_id: u64,
+    pub size: u64,
+    pub distinct_size: u64,
+    pub r#ref: String,
+    pub head: String,
+    pub before: String,
+    pub commits: Vec<Commit>,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::models::{
+        events::{payload::EventPayload, Event},
+        repos::GitUser,
+    };
+    use reqwest::Url;
+
+    #[test]
+    fn should_deserialize_push_event_with_correct_payload() {
+        let json = include_str!("../../../../tests/resources/push_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        assert!(event.payload.is_some());
+        let payload = event.payload.unwrap();
+        match payload {
+            EventPayload::PushEvent(payload) => {
+                assert_eq!(payload.push_id, 6080608029);
+                assert_eq!(payload.size, 1);
+                assert_eq!(payload.distinct_size, 1);
+                assert_eq!(payload.r#ref, "refs/heads/master");
+                assert_eq!(payload.head, "eb1a60c03544dcea290f2d57bb66ae188ce25778");
+                assert_eq!(payload.before, "9b2afb3a8e03fb30cc09e5efb64823bde802cf59");
+                assert_eq!(payload.commits.len(), 1);
+                let commit = payload.commits.get(0).unwrap();
+                assert_eq!(commit.sha, "eb1a60c03544dcea290f2d57bb66ae188ce25778");
+                assert_eq!(
+                    commit.author,
+                    GitUser {
+                        name: "readme-bot".to_string(),
+                        email: "readme-bot@example.com".to_string()
+                    }
+                );
+                assert_eq!(commit.message, "Charts Updated");
+                assert_eq!(commit.distinct, true);
+                assert_eq!(
+                    commit.url,
+                    Url::parse("https://api.github.com/repos/user/user/commits/12345").unwrap()
+                );
+            }
+            _ => panic!("unexpected event deserialized"),
+        }
+    }
+}

--- a/tests/resources/issues_event.json
+++ b/tests/resources/issues_event.json
@@ -1,0 +1,68 @@
+{
+    "id": "14830571677",
+    "type": "IssuesEvent",
+    "actor": {
+        "id": 1102174,
+        "login": "wayofthepie",
+        "display_login": "wayofthepie",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/wayofthepie",
+        "avatar_url": "https://avatars.githubusercontent.com/u/1102174?"
+    },
+    "repo": {
+        "id": 316335970,
+        "name": "wayofthepie/test-events",
+        "url": "https://api.github.com/repos/wayofthepie/test-events"
+    },
+    "payload": {
+        "action": "opened",
+        "issue": {
+            "url": "https://api.github.com/repos/wayofthepie/test-events/issues/6",
+            "repository_url": "https://api.github.com/repos/wayofthepie/test-events",
+            "labels_url": "https://api.github.com/repos/wayofthepie/test-events/issues/6/labels{/name}",
+            "comments_url": "https://api.github.com/repos/wayofthepie/test-events/issues/6/comments",
+            "events_url": "https://api.github.com/repos/wayofthepie/test-events/issues/6/events",
+            "html_url": "https://github.com/wayofthepie/test-events/issues/6",
+            "id": 786747990,
+            "node_id": "MDU6SXNzdWU3ODY3NDc5OTA=",
+            "number": 6,
+            "title": "Test",
+            "user": {
+                "login": "wayofthepie",
+                "id": 1102174,
+                "node_id": "MDQ6VXNlcjExMDIxNzQ=",
+                "avatar_url": "https://avatars0.githubusercontent.com/u/1102174?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/wayofthepie",
+                "html_url": "https://github.com/wayofthepie",
+                "followers_url": "https://api.github.com/users/wayofthepie/followers",
+                "following_url": "https://api.github.com/users/wayofthepie/following{/other_user}",
+                "gists_url": "https://api.github.com/users/wayofthepie/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/wayofthepie/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/wayofthepie/subscriptions",
+                "organizations_url": "https://api.github.com/users/wayofthepie/orgs",
+                "repos_url": "https://api.github.com/users/wayofthepie/repos",
+                "events_url": "https://api.github.com/users/wayofthepie/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/wayofthepie/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "labels": [],
+            "state": "open",
+            "locked": false,
+            "assignee": null,
+            "assignees": [],
+            "milestone": null,
+            "comments": 0,
+            "created_at": "2021-01-15T09:33:54Z",
+            "updated_at": "2021-01-15T09:33:54Z",
+            "closed_at": null,
+            "author_association": "OWNER",
+            "active_lock_reason": null,
+            "body": "",
+            "performed_via_github_app": null
+        }
+    },
+    "public": true,
+    "created_at": "2021-01-15T09:33:54Z"
+}

--- a/tests/resources/unknown_event.json
+++ b/tests/resources/unknown_event.json
@@ -1,19 +1,24 @@
 {
-  "id": "14304136554",
+  "id": "14316142282",
   "type": "AmazingEvent",
   "actor": {
-    "id": 7131143,
-    "login": "jon-betts",
-    "display_login": "jon-betts",
+    "id": 7158903,
+    "login": "perpetualKid",
+    "display_login": "perpetualKid",
     "gravatar_id": "",
-    "url": "https://api.github.com/users/jon-betts",
-    "avatar_url": "https://avatars.githubusercontent.com/u/7131143?"
+    "url": "https://api.github.com/users/perpetualKid",
+    "avatar_url": "https://avatars.githubusercontent.com/u/7158903?"
   },
   "repo": {
-    "id": 311739396,
-    "name": "hypothesis/checkmate",
-    "url": "https://api.github.com/repos/hypothesis/checkmate"
+    "id": 137481275,
+    "name": "perpetualKid/ORTS-MG",
+    "url": "https://api.github.com/repos/perpetualKid/ORTS-MG"
+  },
+  "payload": {
+    "ref": "Core.GetText",
+    "ref_type": "branch",
+    "pusher_type": "user"
   },
   "public": true,
-  "created_at": "2020-11-24T20:04:43Z"
+  "created_at": "2020-11-25T16:12:36Z"
 }


### PR DESCRIPTION
  * Adds support for events of type `IssuesEvent`.
  * Factors out create and push events into their own modules under `payload`, the API stays the same, re-export from `payload`. But this makes it a bit cleaner, especially as the other event types get added.

Quick note, the events API is not documented very well on the official GitHub docs. For `IssuesEvent` events, [the docs](https://docs.github.com/en/developers/webhooks-and-events/github-event-types#issuesevent) specify 7 actions, however only 3 of those are available when calling the events API's, the rest (along with lots more) are only available via webhooks - see [this thread](https://github.com/igrigorik/gharchive.org/issues/183) for more info. 

I plan on adding support for webhooks once all event types are in octocrab anyway, so I've added all fields mentioned in the docs here, whether they are only available on webhooks or not. Thanks.