### PR TITLE
Support commit comment and delete events

### DIFF
--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -1,9 +1,9 @@
 pub mod payload;
 
 use self::payload::{
-    CommitCommentEventPayload, CreateEventPayload, EventPayload, IssueCommentEventPayload,
-    IssuesEventPayload, PullRequestEventPayload, PullRequestReviewCommentEventPayload,
-    PushEventPayload,
+    CommitCommentEventPayload, CreateEventPayload, DeleteEventPayload, EventPayload,
+    IssueCommentEventPayload, IssuesEventPayload, PullRequestEventPayload,
+    PullRequestReviewCommentEventPayload, PushEventPayload,
 };
 use chrono::{DateTime, Utc};
 use reqwest::Url;
@@ -30,6 +30,7 @@ pub struct Event {
 pub enum EventType {
     PushEvent,
     CreateEvent,
+    DeleteEvent,
     IssuesEvent,
     IssueCommentEvent,
     CommitCommentEvent,
@@ -110,6 +111,7 @@ fn deserialize_event_type(event_type: &str) -> EventType {
     match event_type {
         "CreateEvent" => EventType::CreateEvent,
         "PushEvent" => EventType::PushEvent,
+        "DeleteEvent" => EventType::DeleteEvent,
         "IssuesEvent" => EventType::IssuesEvent,
         "IssueCommentEvent" => EventType::IssueCommentEvent,
         "CommitCommentEvent" => EventType::CommitCommentEvent,
@@ -129,6 +131,9 @@ fn deserialize_payload(
         }
         EventType::CreateEvent => {
             serde_json::from_value::<CreateEventPayload>(data).map(EventPayload::CreateEvent)?
+        }
+        EventType::DeleteEvent => {
+            serde_json::from_value::<DeleteEventPayload>(data).map(EventPayload::DeleteEvent)?
         }
         EventType::IssuesEvent => {
             serde_json::from_value::<IssuesEventPayload>(data).map(EventPayload::IssuesEvent)?
@@ -200,6 +205,13 @@ mod test {
         let json = include_str!("../../tests/resources/commit_comment_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
         assert_eq!(event.r#type, EventType::CommitCommentEvent);
+    }
+
+    #[test]
+    fn should_deserialize_delete_event() {
+        let json = include_str!("../../tests/resources/delete_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        assert_eq!(event.r#type, EventType::DeleteEvent);
     }
 
     #[test]

--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -1,8 +1,9 @@
 pub mod payload;
 
 use self::payload::{
-    CreateEventPayload, EventPayload, IssueCommentEventPayload, IssuesEventPayload,
-    PullRequestEventPayload, PullRequestReviewCommentEventPayload, PushEventPayload,
+    CommitCommentEventPayload, CreateEventPayload, EventPayload, IssueCommentEventPayload,
+    IssuesEventPayload, PullRequestEventPayload, PullRequestReviewCommentEventPayload,
+    PushEventPayload,
 };
 use chrono::{DateTime, Utc};
 use reqwest::Url;
@@ -31,6 +32,7 @@ pub enum EventType {
     CreateEvent,
     IssuesEvent,
     IssueCommentEvent,
+    CommitCommentEvent,
     PullRequestEvent,
     PullRequestReviewCommentEvent,
     UnknownEvent(String),
@@ -110,6 +112,7 @@ fn deserialize_event_type(event_type: &str) -> EventType {
         "PushEvent" => EventType::PushEvent,
         "IssuesEvent" => EventType::IssuesEvent,
         "IssueCommentEvent" => EventType::IssueCommentEvent,
+        "CommitCommentEvent" => EventType::CommitCommentEvent,
         "PullRequestEvent" => EventType::PullRequestEvent,
         "PullRequestReviewCommentEvent" => EventType::PullRequestReviewCommentEvent,
         unknown => EventType::UnknownEvent(unknown.to_owned()),
@@ -132,6 +135,8 @@ fn deserialize_payload(
         }
         EventType::IssueCommentEvent => serde_json::from_value::<IssueCommentEventPayload>(data)
             .map(EventPayload::IssueCommentEvent)?,
+        EventType::CommitCommentEvent => serde_json::from_value::<CommitCommentEventPayload>(data)
+            .map(EventPayload::CommitCommentEvent)?,
         EventType::PullRequestEvent => serde_json::from_value::<PullRequestEventPayload>(data)
             .map(|payload| EventPayload::PullRequestEvent(Box::new(payload)))?,
         EventType::PullRequestReviewCommentEvent => {
@@ -188,6 +193,13 @@ mod test {
         let json = include_str!("../../tests/resources/pull_request_review_comment_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
         assert_eq!(event.r#type, EventType::PullRequestReviewCommentEvent);
+    }
+
+    #[test]
+    fn should_deserialize_commit_comment_event() {
+        let json = include_str!("../../tests/resources/commit_comment_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        assert_eq!(event.r#type, EventType::CommitCommentEvent);
     }
 
     #[test]

--- a/src/models/events/payload.rs
+++ b/src/models/events/payload.rs
@@ -1,3 +1,4 @@
+mod commit_comment;
 mod create;
 mod issue_comment;
 mod issues;
@@ -6,6 +7,7 @@ mod pull_request_review_comment;
 mod push;
 
 use crate::models::repos::GitUser;
+pub use commit_comment::*;
 pub use create::*;
 pub use issue_comment::*;
 pub use issues::*;
@@ -28,6 +30,7 @@ pub enum EventPayload {
     CreateEvent(CreateEventPayload),
     IssuesEvent(IssuesEventPayload),
     IssueCommentEvent(IssueCommentEventPayload),
+    CommitCommentEvent(CommitCommentEventPayload),
     PullRequestEvent(Box<PullRequestEventPayload>),
     PullRequestReviewCommentEvent(Box<PullRequestReviewCommentEventPayload>),
     UnknownEvent(serde_json::Value),

--- a/src/models/events/payload.rs
+++ b/src/models/events/payload.rs
@@ -1,5 +1,6 @@
 mod commit_comment;
 mod create;
+mod delete;
 mod issue_comment;
 mod issues;
 mod pull_request;
@@ -9,6 +10,7 @@ mod push;
 use crate::models::repos::GitUser;
 pub use commit_comment::*;
 pub use create::*;
+pub use delete::*;
 pub use issue_comment::*;
 pub use issues::*;
 pub use pull_request::*;
@@ -28,6 +30,7 @@ use serde::{Deserialize, Serialize};
 pub enum EventPayload {
     PushEvent(PushEventPayload),
     CreateEvent(CreateEventPayload),
+    DeleteEvent(DeleteEventPayload),
     IssuesEvent(IssuesEventPayload),
     IssueCommentEvent(IssueCommentEventPayload),
     CommitCommentEvent(CommitCommentEventPayload),

--- a/src/models/events/payload/commit_comment.rs
+++ b/src/models/events/payload/commit_comment.rs
@@ -1,0 +1,26 @@
+use crate::models::issues::Comment;
+use serde::{Deserialize, Serialize};
+
+/// The payload in a [`super::EventPayload::CommitCommentEvent`] type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CommitCommentEventPayload {
+    /// The comment this event corresponds to.
+    pub comment: Comment,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::models::events::{payload::EventPayload, Event};
+
+    #[test]
+    fn should_deserialize_with_correct_payload() {
+        let json = include_str!("../../../../tests/resources/commit_comment_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        if let Some(EventPayload::CommitCommentEvent(payload)) = event.payload {
+            assert_eq!(payload.comment.id, 46377107);
+        } else {
+            panic!("unexpected event payload encountered: {:#?}", event.payload);
+        }
+    }
+}

--- a/src/models/events/payload/delete.rs
+++ b/src/models/events/payload/delete.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+/// The payload in a [`super::EventPayload::DeleteEvent`] type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DeleteEventPayload {
+    /// The ref which was deleted.
+    pub r#ref: String,
+    /// The type of the ref which was deleted.
+    pub ref_type: String,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::models::events::{payload::EventPayload, Event};
+
+    #[test]
+    fn should_deserialize_with_correct_payload() {
+        let json = include_str!("../../../../tests/resources/delete_event.json");
+        let event: Event = serde_json::from_str(json).unwrap();
+        if let Some(EventPayload::DeleteEvent(payload)) = event.payload {
+            assert_eq!(payload.r#ref, "test2");
+            assert_eq!(payload.ref_type, "branch");
+        } else {
+            panic!("unexpected event payload encountered: {:#?}", event.payload);
+        }
+    }
+}

--- a/tests/resources/commit_comment_event.json
+++ b/tests/resources/commit_comment_event.json
@@ -1,0 +1,55 @@
+{
+    "id": "14949276083",
+    "type": "CommitCommentEvent",
+    "actor": {
+        "id": 1102174,
+        "login": "wayofthepie",
+        "display_login": "wayofthepie",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/wayofthepie",
+        "avatar_url": "https://avatars.githubusercontent.com/u/1102174?"
+    },
+    "repo": {
+        "id": 316335970,
+        "name": "wayofthepie/test-events",
+        "url": "https://api.github.com/repos/wayofthepie/test-events"
+    },
+    "payload": {
+        "comment": {
+            "url": "https://api.github.com/repos/wayofthepie/test-events/comments/46377107",
+            "html_url": "https://github.com/wayofthepie/test-events/commit/d287fa985a6501fe8cbda3957e10949512c5d4c6#commitcomment-46377107",
+            "id": 46377107,
+            "node_id": "MDEzOkNvbW1pdENvbW1lbnQ0NjM3NzEwNw==",
+            "user": {
+                "login": "wayofthepie",
+                "id": 1102174,
+                "node_id": "MDQ6VXNlcjExMDIxNzQ=",
+                "avatar_url": "https://avatars.githubusercontent.com/u/1102174?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/wayofthepie",
+                "html_url": "https://github.com/wayofthepie",
+                "followers_url": "https://api.github.com/users/wayofthepie/followers",
+                "following_url": "https://api.github.com/users/wayofthepie/following{/other_user}",
+                "gists_url": "https://api.github.com/users/wayofthepie/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/wayofthepie/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/wayofthepie/subscriptions",
+                "organizations_url": "https://api.github.com/users/wayofthepie/orgs",
+                "repos_url": "https://api.github.com/users/wayofthepie/repos",
+                "events_url": "https://api.github.com/users/wayofthepie/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/wayofthepie/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "position": null,
+            "line": null,
+            "path": null,
+            "commit_id": "d287fa985a6501fe8cbda3957e10949512c5d4c6",
+            "created_at": "2021-01-26T11:17:08Z",
+            "updated_at": "2021-01-26T11:17:08Z",
+            "author_association": "OWNER",
+            "body": "Commit comment?"
+        }
+    },
+    "public": true,
+    "created_at": "2021-01-26T11:17:08Z"
+}

--- a/tests/resources/delete_event.json
+++ b/tests/resources/delete_event.json
@@ -1,24 +1,24 @@
 {
-  "id": "14316142282",
-  "type": "DeleteEvent",
-  "actor": {
-    "id": 7158903,
-    "login": "perpetualKid",
-    "display_login": "perpetualKid",
-    "gravatar_id": "",
-    "url": "https://api.github.com/users/perpetualKid",
-    "avatar_url": "https://avatars.githubusercontent.com/u/7158903?"
-  },
-  "repo": {
-    "id": 137481275,
-    "name": "perpetualKid/ORTS-MG",
-    "url": "https://api.github.com/repos/perpetualKid/ORTS-MG"
-  },
-  "payload": {
-    "ref": "Core.GetText",
-    "ref_type": "branch",
-    "pusher_type": "user"
-  },
-  "public": true,
-  "created_at": "2020-11-25T16:12:36Z"
+    "id": "14950187263",
+    "type": "DeleteEvent",
+    "actor": {
+        "id": 1102174,
+        "login": "wayofthepie",
+        "display_login": "wayofthepie",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/wayofthepie",
+        "avatar_url": "https://avatars.githubusercontent.com/u/1102174?"
+    },
+    "repo": {
+        "id": 316335970,
+        "name": "wayofthepie/test-events",
+        "url": "https://api.github.com/repos/wayofthepie/test-events"
+    },
+    "payload": {
+        "ref": "test2",
+        "ref_type": "branch",
+        "pusher_type": "user"
+    },
+    "public": true,
+    "created_at": "2021-01-26T12:42:51Z"
 }


### PR DESCRIPTION
These are small but odd as the actual events differ slightly from the docs:

  * `DeleteEvent` has a field `pusher_type` which is not documented. I have left this out for now (https://github.com/github/docs/issues/3192).
  * `CommitCommentEvent` has an action field documented, but it only appears in webhooks not when calling the API's. I have left this out for now too, it seems to only have a single value anyway, `created` (https://github.com/github/docs/issues/3190).

Thanks!