### PR TITLE
Support subdirectory-mounted API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -688,4 +688,34 @@ mod tests {
             String::from(crate::GITHUB_BASE_URL) + "/help%20wanted"
         );
     }
+
+    #[test]
+    fn root_mounted_ok() {
+        assert_eq!(
+            crate::OctocrabBuilder::new()
+                .base_url("https://git.example.com")
+                .unwrap()
+                .build()
+                .unwrap()
+                .absolute_url("/my/api")
+                .unwrap()
+                .as_str(),
+            String::from("https://git.example.com/my/api")
+        );
+    }
+
+    #[test]
+    fn subdir_mounted_ok() {
+        assert_eq!(
+            crate::OctocrabBuilder::new()
+                .base_url("https://git.example.com/api/v3")
+                .unwrap()
+                .build()
+                .unwrap()
+                .absolute_url("/my/api")
+                .unwrap()
+                .as_str(),
+            String::from("https://git.example.com/api/v3/my/api")
+        );
+    }
 }


### PR DESCRIPTION
My company utilizes GHES and its v3 API is mounted under the url like `https://git.example.com/api/v3`

And this is usual way for GHES users, since GitHub itself shows as default below.

https://docs.github.com/en/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#current-version

octocrab does not support subdirectory now(ignored if set). So it is very helpful for us that this patch is accepted.

Thank you!