### PR TITLE
Change absolutely specified API paths

### DIFF
--- a/src/api/actions.rs
+++ b/src/api/actions.rs
@@ -36,7 +36,7 @@ impl<'octo> ActionsHandler<'octo> {
         repository_id: u64,
     ) -> crate::Result<()> {
         let route = format!(
-            "/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
+            "orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
             org = org.as_ref(),
             secret_name = secret_name.as_ref(),
             repository_id = repository_id,
@@ -68,7 +68,7 @@ impl<'octo> ActionsHandler<'octo> {
         repository_id: u64,
     ) -> crate::Result<()> {
         let route = format!(
-            "/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
+            "orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
             org = org.as_ref(),
             secret_name = secret_name.as_ref(),
             repository_id = repository_id,
@@ -98,7 +98,7 @@ impl<'octo> ActionsHandler<'octo> {
         run_id: u64,
     ) -> crate::Result<()> {
         let route = format!(
-            "/repos/{owner}/{repo}/actions/runs/{run_id}/cancel",
+            "repos/{owner}/{repo}/actions/runs/{run_id}/cancel",
             owner = owner.as_ref(),
             repo = repo.as_ref(),
             run_id = run_id,
@@ -146,7 +146,7 @@ impl<'octo> ActionsHandler<'octo> {
         run_id: u64,
     ) -> crate::Result<bytes::Bytes> {
         let route = format!(
-            "/repos/{owner}/{repo}/actions/runs/{run_id}/logs",
+            "repos/{owner}/{repo}/actions/runs/{run_id}/logs",
             owner = owner.as_ref(),
             repo = repo.as_ref(),
             run_id = run_id,
@@ -177,7 +177,7 @@ impl<'octo> ActionsHandler<'octo> {
         archive_format: params::actions::ArchiveFormat,
     ) -> crate::Result<bytes::Bytes> {
         let route = format!(
-            "/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}",
+            "repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}",
             owner = owner.as_ref(),
             repo = repo.as_ref(),
             artifact_id = artifact_id,
@@ -207,7 +207,7 @@ impl<'octo> ActionsHandler<'octo> {
         run_id: u64,
     ) -> crate::Result<()> {
         let route = format!(
-            "/repos/{owner}/{repo}/actions/runs/{run_id}/logs",
+            "repos/{owner}/{repo}/actions/runs/{run_id}/logs",
             owner = owner.as_ref(),
             repo = repo.as_ref(),
             run_id = run_id,
@@ -235,7 +235,7 @@ impl<'octo> ActionsHandler<'octo> {
         &self,
         org: impl AsRef<str>,
     ) -> crate::Result<crate::models::PublicKey> {
-        let route = format!("/orgs/{org}/actions/secrets/public-key", org = org.as_ref());
+        let route = format!("orgs/{org}/actions/secrets/public-key", org = org.as_ref());
 
         self.crab.get(route, None::<&()>).await
     }
@@ -278,7 +278,7 @@ impl<'octo, 'r, 'text> RenderMarkdownBuilder<'octo, 'r, 'text> {
     pub async fn send(self) -> crate::Result<String> {
         self.handler
             .crab
-            ._post(self.handler.crab.absolute_url("/markdown")?, Some(&self))
+            ._post(self.handler.crab.absolute_url("markdown")?, Some(&self))
             .await?
             .text()
             .await

--- a/src/api/activity/notifications.rs
+++ b/src/api/activity/notifications.rs
@@ -36,7 +36,7 @@ impl<'octo> NotificationsHandler<'octo> {
     /// # }
     /// ```
     pub async fn get(&self, id: impl Into<u64>) -> crate::Result<Notification> {
-        let url = format!("/notifications/threads/{}", id.into());
+        let url = format!("notifications/threads/{}", id.into());
         self.crab.get(url, None::<&()>).await
     }
 
@@ -53,7 +53,7 @@ impl<'octo> NotificationsHandler<'octo> {
     /// # }
     /// ```
     pub async fn mark_as_read(&self, id: impl Into<u64>) -> crate::Result<()> {
-        let url = format!("/notifications/threads/{}", id.into());
+        let url = format!("notifications/threads/{}", id.into());
         let url = self.crab.absolute_url(url)?;
 
         let response = self.crab._patch(url, None::<&()>).await?;
@@ -87,7 +87,7 @@ impl<'octo> NotificationsHandler<'octo> {
             .into()
             .map(|last_read_at| Inner { last_read_at });
 
-        let url = format!("/repos/{}/{}/notifications", owner.as_ref(), repo.as_ref());
+        let url = format!("repos/{}/{}/notifications", owner.as_ref(), repo.as_ref());
         let url = self.crab.absolute_url(url)?;
 
         let response = self.crab._put(url, body.as_ref()).await?;
@@ -121,7 +121,7 @@ impl<'octo> NotificationsHandler<'octo> {
         let body = last_read_at
             .into()
             .map(|last_read_at| Inner { last_read_at });
-        let url = self.crab.absolute_url("/notifications")?;
+        let url = self.crab.absolute_url("notifications")?;
 
         let response = self.crab._put(url, body.as_ref()).await?;
         crate::map_github_error(response).await.map(drop)
@@ -143,7 +143,7 @@ impl<'octo> NotificationsHandler<'octo> {
         &self,
         thread: impl Into<u64>,
     ) -> crate::Result<ThreadSubscription> {
-        let url = format!("/notifications/threads/{}/subscription", thread.into());
+        let url = format!("notifications/threads/{}/subscription", thread.into());
 
         self.crab.get(url, None::<&()>).await
     }
@@ -170,7 +170,7 @@ impl<'octo> NotificationsHandler<'octo> {
             ignored: bool,
         }
 
-        let url = format!("/notifications/threads/{}/subscription", thread.into());
+        let url = format!("notifications/threads/{}/subscription", thread.into());
         let body = Inner { ignored };
 
         self.crab.get(url, Some(&body)).await
@@ -189,7 +189,7 @@ impl<'octo> NotificationsHandler<'octo> {
     /// ```
     pub async fn delete_thread_subscription(&self, thread: impl Into<u64>) -> crate::Result<()> {
         let url = self.crab.absolute_url(format!(
-            "/notifications/threads/{}/subscription",
+            "notifications/threads/{}/subscription",
             thread.into()
         ))?;
 
@@ -217,7 +217,7 @@ impl<'octo> NotificationsHandler<'octo> {
         owner: impl AsRef<str>,
         repo: impl AsRef<str>,
     ) -> ListNotificationsBuilder<'octo> {
-        let url = format!("/repos/{}/{}/notifications", owner.as_ref(), repo.as_ref());
+        let url = format!("repos/{}/{}/notifications", owner.as_ref(), repo.as_ref());
         ListNotificationsBuilder::new(self.crab, url)
     }
 
@@ -235,7 +235,7 @@ impl<'octo> NotificationsHandler<'octo> {
     /// # }
     /// ```
     pub fn list(&self) -> ListNotificationsBuilder<'octo> {
-        ListNotificationsBuilder::new(self.crab, "/notifications".to_string())
+        ListNotificationsBuilder::new(self.crab, "notifications".to_string())
     }
 }
 

--- a/src/api/current.rs
+++ b/src/api/current.rs
@@ -18,6 +18,6 @@ impl<'octo> CurrentAuthHandler<'octo> {
 
     /// Fetches information about the current user.
     pub async fn user(&self) -> Result<models::User> {
-        self.crab.get("/user", None::<&()>).await
+        self.crab.get("user", None::<&()>).await
     }
 }

--- a/src/api/gists.rs
+++ b/src/api/gists.rs
@@ -26,7 +26,7 @@ impl<'octo> GistHandler<'octo> {
     /// # }
     /// ```
     pub async fn check_is_starred(&self, id: &str) -> crate::Result<bool> {
-        let url = self.crab.absolute_url(format!("/gists/{}/star", id))?;
+        let url = self.crab.absolute_url(format!("gists/{}/star", id))?;
 
         let resp = self.crab._get(url, None::<&()>).await?;
 
@@ -70,7 +70,7 @@ impl<'octo> GistHandler<'octo> {
     /// # }
     /// ```
     pub async fn star(&self, id: &str) -> crate::Result<bool> {
-        let url = self.crab.absolute_url(format!("/gists/{}/star", id))?;
+        let url = self.crab.absolute_url(format!("gists/{}/star", id))?;
 
         let resp = self.crab._put(url, None::<&()>).await?;
 
@@ -92,7 +92,7 @@ impl<'octo> GistHandler<'octo> {
     /// # }
     /// ```
     pub async fn get(&self, name: impl AsRef<str>) -> crate::Result<String> {
-        let route = format!("/gitignore/templates/{name}", name = name.as_ref());
+        let route = format!("gitignore/templates/{name}", name = name.as_ref());
         let request = self
             .crab
             .client

--- a/src/api/gitignore.rs
+++ b/src/api/gitignore.rs
@@ -25,7 +25,7 @@ impl<'octo> GitignoreHandler<'octo> {
     /// # }
     /// ```
     pub async fn list(&self) -> crate::Result<Vec<String>> {
-        self.crab.get("/gitignore/templates", None::<&()>).await
+        self.crab.get("gitignore/templates", None::<&()>).await
     }
 
     /// Get the source of a single template.
@@ -36,7 +36,7 @@ impl<'octo> GitignoreHandler<'octo> {
     /// # }
     /// ```
     pub async fn get(&self, name: impl AsRef<str>) -> crate::Result<String> {
-        let route = format!("/gitignore/templates/{name}", name = name.as_ref());
+        let route = format!("gitignore/templates/{name}", name = name.as_ref());
         let request = self
             .crab
             .client

--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -43,7 +43,7 @@ impl<'octo> IssueHandler<'octo> {
     /// ```
     pub async fn get(&self, number: u64) -> Result<models::issues::Issue> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/{number}",
+            "repos/{owner}/{repo}/issues/{number}",
             owner = self.owner,
             repo = self.repo,
             number = number,
@@ -145,7 +145,7 @@ impl<'octo> IssueHandler<'octo> {
         reason: impl Into<Option<params::LockReason>>,
     ) -> Result<bool> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/{number}/lock",
+            "repos/{owner}/{repo}/issues/{number}/lock",
             owner = self.owner,
             repo = self.repo,
             number = number,
@@ -182,7 +182,7 @@ impl<'octo> IssueHandler<'octo> {
     /// ```
     pub async fn unlock(&self, number: u64) -> Result<bool> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/{number}/lock",
+            "repos/{owner}/{repo}/issues/{number}/lock",
             owner = self.owner,
             repo = self.repo,
             number = number,
@@ -214,7 +214,7 @@ impl<'octo> IssueHandler<'octo> {
         assignees: &[u64],
     ) -> Result<models::issues::Issue> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/{issue}/assignees",
+            "repos/{owner}/{repo}/issues/{issue}/assignees",
             owner = self.owner,
             repo = self.repo,
             issue = number
@@ -236,7 +236,7 @@ impl<'octo> IssueHandler<'octo> {
     /// ```
     pub async fn check_assignee(&self, assignee: impl AsRef<str>) -> Result<bool> {
         let route = format!(
-            "/repos/{owner}/{repo}/assignees/{assignee}",
+            "repos/{owner}/{repo}/assignees/{assignee}",
             owner = self.owner,
             repo = self.repo,
             assignee = assignee.as_ref()
@@ -309,7 +309,7 @@ impl<'octo, 'r> ListAssigneesBuilder<'octo, 'r> {
     /// Send the actual request.
     pub async fn send(self) -> Result<crate::Page<models::User>> {
         let route = format!(
-            "/repos/{owner}/{repo}/assignees",
+            "repos/{owner}/{repo}/assignees",
             owner = self.handler.owner,
             repo = self.handler.repo,
         );
@@ -332,7 +332,7 @@ impl<'octo> IssueHandler<'octo> {
     /// ```
     pub async fn add_labels(&self, number: u64, labels: &[String]) -> Result<Vec<models::Label>> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/{issue}/labels",
+            "repos/{owner}/{repo}/issues/{issue}/labels",
             owner = self.owner,
             repo = self.repo,
             issue = number
@@ -359,7 +359,7 @@ impl<'octo> IssueHandler<'octo> {
         label: impl AsRef<str>,
     ) -> Result<Vec<models::Label>> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
+            "repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
             owner = self.owner,
             repo = self.repo,
             issue_number = number,
@@ -385,7 +385,7 @@ impl<'octo> IssueHandler<'octo> {
         labels: &[String],
     ) -> Result<Vec<models::Label>> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/{issue}/labels",
+            "repos/{owner}/{repo}/issues/{issue}/labels",
             owner = self.owner,
             repo = self.repo,
             issue = number
@@ -413,7 +413,7 @@ impl<'octo> IssueHandler<'octo> {
         description: impl AsRef<str>,
     ) -> Result<models::Label> {
         let route = format!(
-            "/repos/{owner}/{repo}/labels",
+            "repos/{owner}/{repo}/labels",
             owner = self.owner,
             repo = self.repo,
         );
@@ -442,7 +442,7 @@ impl<'octo> IssueHandler<'octo> {
     /// ```
     pub async fn get_label(&self, name: impl AsRef<str>) -> Result<models::Label> {
         let route = format!(
-            "/repos/{owner}/{repo}/labels/{name}",
+            "repos/{owner}/{repo}/labels/{name}",
             owner = self.owner,
             repo = self.repo,
             name = name.as_ref(),
@@ -463,7 +463,7 @@ impl<'octo> IssueHandler<'octo> {
     /// ```
     pub async fn delete_label(&self, name: impl AsRef<str>) -> Result<models::Label> {
         let route = format!(
-            "/repos/{owner}/{repo}/labels/{name}",
+            "repos/{owner}/{repo}/labels/{name}",
             owner = self.owner,
             repo = self.repo,
             name = name.as_ref(),
@@ -527,7 +527,7 @@ impl<'octo> IssueHandler<'octo> {
         body: impl AsRef<str>,
     ) -> Result<models::issues::Comment> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/{issue}/comments",
+            "repos/{owner}/{repo}/issues/{issue}/comments",
             owner = self.owner,
             repo = self.repo,
             issue = number
@@ -550,7 +550,7 @@ impl<'octo> IssueHandler<'octo> {
     /// ```
     pub async fn get_comment(&self, comment_id: u64) -> Result<models::issues::Comment> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/comments/{comment_id}",
+            "repos/{owner}/{repo}/issues/comments/{comment_id}",
             owner = self.owner,
             repo = self.repo,
             comment_id = comment_id
@@ -575,7 +575,7 @@ impl<'octo> IssueHandler<'octo> {
         body: impl AsRef<str>,
     ) -> Result<models::issues::Comment> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/comments/{comment_id}",
+            "repos/{owner}/{repo}/issues/comments/{comment_id}",
             owner = self.owner,
             repo = self.repo,
             comment_id = comment_id
@@ -595,7 +595,7 @@ impl<'octo> IssueHandler<'octo> {
     /// ```
     pub async fn delete_comment(&self, comment_id: u64) -> Result<()> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/comments/{comment_id}",
+            "repos/{owner}/{repo}/issues/comments/{comment_id}",
             owner = self.owner,
             repo = self.repo,
             comment_id = comment_id
@@ -678,7 +678,7 @@ impl<'octo, 'r> ListCommentsBuilder<'octo, 'r> {
     /// Send the actual request.
     pub async fn send(self) -> Result<crate::Page<models::issues::Comment>> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/{issue}/comments",
+            "repos/{owner}/{repo}/issues/{issue}/comments",
             owner = self.handler.owner,
             repo = self.handler.repo,
             issue = self.issue_number,

--- a/src/api/issues/create.rs
+++ b/src/api/issues/create.rs
@@ -30,7 +30,7 @@ impl<'octo, 'r> CreateIssueBuilder<'octo, 'r> {
     /// Sends the actual request.
     pub async fn send(self) -> crate::Result<models::issues::Issue> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues",
+            "repos/{owner}/{repo}/issues",
             owner = self.handler.owner,
             repo = self.handler.repo,
         );

--- a/src/api/issues/list.rs
+++ b/src/api/issues/list.rs
@@ -116,7 +116,7 @@ impl<'octo, 'b, 'c, 'd> ListIssuesBuilder<'octo, 'b, 'c, 'd> {
     /// Sends the actual request.
     pub async fn send(self) -> crate::Result<crate::Page<models::issues::Issue>> {
         let url = format!(
-            "/repos/{owner}/{repo}/issues",
+            "repos/{owner}/{repo}/issues",
             owner = self.handler.owner,
             repo = self.handler.repo
         );

--- a/src/api/issues/list_labels.rs
+++ b/src/api/issues/list_labels.rs
@@ -37,7 +37,7 @@ impl<'octo, 'r> ListLabelsForIssueBuilder<'octo, 'r> {
     /// Send the actual request.
     pub async fn send(self) -> Result<crate::Page<models::Label>> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/{number}/labels",
+            "repos/{owner}/{repo}/issues/{number}/labels",
             owner = self.handler.owner,
             repo = self.handler.repo,
             number = self.number,
@@ -81,7 +81,7 @@ impl<'octo, 'r> ListLabelsForRepoBuilder<'octo, 'r> {
     /// Send the actual request.
     pub async fn send(self) -> Result<crate::Page<models::Label>> {
         let route = format!(
-            "/repos/{owner}/{repo}/labels",
+            "repos/{owner}/{repo}/labels",
             owner = self.handler.owner,
             repo = self.handler.repo,
         );

--- a/src/api/issues/update.rs
+++ b/src/api/issues/update.rs
@@ -73,7 +73,7 @@ impl<'octo, 'a, 'b, 'c, 'd, 'e> UpdateIssueBuilder<'octo, 'a, 'b, 'c, 'd, 'e> {
     /// Send the actual request.
     pub async fn send(self) -> Result<models::issues::Issue> {
         let route = format!(
-            "/repos/{owner}/{repo}/issues/{issue}",
+            "repos/{owner}/{repo}/issues/{issue}",
             owner = self.handler.owner,
             repo = self.handler.repo,
             issue = self.number,

--- a/src/api/licenses.rs
+++ b/src/api/licenses.rs
@@ -23,7 +23,7 @@ impl<'octo> LicenseHandler<'octo> {
     /// # }
     /// ```
     pub async fn list_commonly_used(&self) -> crate::Result<Vec<models::License>> {
-        self.crab.get("/licenses", None::<&()>).await
+        self.crab.get("licenses", None::<&()>).await
     }
 
     /// Get an individual license.
@@ -35,7 +35,7 @@ impl<'octo> LicenseHandler<'octo> {
     /// ```
     pub async fn get(&self, key: impl AsRef<str>) -> crate::Result<models::License> {
         self.crab
-            .get(format!("/licenses/{}", key.as_ref()), None::<&()>)
+            .get(format!("licenses/{}", key.as_ref()), None::<&()>)
             .await
     }
 }

--- a/src/api/markdown.rs
+++ b/src/api/markdown.rs
@@ -53,7 +53,7 @@ impl<'octo> MarkdownHandler<'octo> {
         let request = self
             .crab
             .client
-            .post(self.crab.absolute_url("/markdown/raw")?)
+            .post(self.crab.absolute_url("markdown/raw")?)
             .header(reqwest::header::CONTENT_TYPE, "text/x-markdown")
             .body(text.into());
 
@@ -104,7 +104,7 @@ impl<'octo, 'r, 'text> RenderMarkdownBuilder<'octo, 'r, 'text> {
     pub async fn send(self) -> crate::Result<String> {
         self.handler
             .crab
-            ._post(self.handler.crab.absolute_url("/markdown")?, Some(&self))
+            ._post(self.handler.crab.absolute_url("markdown")?, Some(&self))
             .await?
             .text()
             .await

--- a/src/api/orgs.rs
+++ b/src/api/orgs.rs
@@ -46,7 +46,7 @@ impl<'octo> OrgHandler<'octo> {
         role: Option<crate::params::orgs::Role>,
     ) -> crate::Result<crate::models::orgs::MembershipInvitation> {
         let url = format!(
-            "/orgs/{org}/memberships/{username}",
+            "orgs/{org}/memberships/{username}",
             org = self.owner,
             username = username.as_ref(),
         );
@@ -67,7 +67,7 @@ impl<'octo> OrgHandler<'octo> {
     /// ```
     pub async fn check_membership(&self, username: impl AsRef<str>) -> crate::Result<bool> {
         let url = format!(
-            "/orgs/{org}/members/{username}",
+            "orgs/{org}/members/{username}",
             org = self.owner,
             username = username.as_ref(),
         );
@@ -96,7 +96,7 @@ impl<'octo> OrgHandler<'octo> {
     /// # }
     /// ```
     pub async fn get(&self) -> crate::Result<crate::models::orgs::Organization> {
-        let route = format!("/orgs/{org}", org = self.owner);
+        let route = format!("orgs/{org}", org = self.owner);
 
         self.crab.get(route, None::<&()>).await
     }

--- a/src/api/orgs/list_repos.rs
+++ b/src/api/orgs/list_repos.rs
@@ -62,7 +62,7 @@ impl<'octo, 'b> ListReposBuilder<'octo, 'b> {
 
     /// Sends the actual request.
     pub async fn send(self) -> crate::Result<crate::Page<crate::models::Repository>> {
-        let url = format!("/orgs/{owner}/repos", owner = self.handler.owner);
+        let url = format!("orgs/{owner}/repos", owner = self.handler.owner);
         self.handler.crab.get(url, Some(&self)).await
     }
 }

--- a/src/api/pulls.rs
+++ b/src/api/pulls.rs
@@ -56,7 +56,7 @@ impl<'octo> PullRequestHandler<'octo> {
     /// ```
     pub async fn is_merged(&self, pr: u64) -> crate::Result<bool> {
         let route = format!(
-            "/repos/{owner}/{repo}/pulls/{pr}/merge",
+            "repos/{owner}/{repo}/pulls/{pr}/merge",
             owner = self.owner,
             repo = self.repo,
             pr = pr
@@ -78,7 +78,7 @@ impl<'octo> PullRequestHandler<'octo> {
     /// ```
     pub async fn get(&self, pr: u64) -> crate::Result<crate::models::pulls::PullRequest> {
         let url = format!(
-            "/repos/{owner}/{repo}/pulls/{pr}",
+            "repos/{owner}/{repo}/pulls/{pr}",
             owner = self.owner,
             repo = self.repo,
             pr = pr
@@ -96,7 +96,7 @@ impl<'octo> PullRequestHandler<'octo> {
     /// ```
     pub async fn get_diff(&self, pr: u64) -> crate::Result<String> {
         let route = format!(
-            "/repos/{owner}/{repo}/pulls/{pr}",
+            "repos/{owner}/{repo}/pulls/{pr}",
             owner = self.owner,
             repo = self.repo,
             pr = pr
@@ -122,7 +122,7 @@ impl<'octo> PullRequestHandler<'octo> {
     /// ```
     pub async fn get_patch(&self, pr: u64) -> crate::Result<String> {
         let route = format!(
-            "/repos/{owner}/{repo}/pulls/{pr}",
+            "repos/{owner}/{repo}/pulls/{pr}",
             owner = self.owner,
             repo = self.repo,
             pr = pr
@@ -205,7 +205,7 @@ impl<'octo> PullRequestHandler<'octo> {
     /// ```
     pub async fn list_reviews(&self, pr: u64) -> crate::Result<Page<crate::models::pulls::Review>> {
         let url = format!(
-            "/repos/{owner}/{repo}/pulls/{pr}/reviews",
+            "repos/{owner}/{repo}/pulls/{pr}/reviews",
             owner = self.owner,
             repo = self.repo,
             pr = pr

--- a/src/api/pulls/create.rs
+++ b/src/api/pulls/create.rs
@@ -54,7 +54,7 @@ impl<'octo, 'b> CreatePullRequestBuilder<'octo, 'b> {
     /// Sends the request to create the pull request.
     pub async fn send(self) -> crate::Result<crate::models::pulls::PullRequest> {
         let url = format!(
-            "/repos/{owner}/{repo}/pulls",
+            "repos/{owner}/{repo}/pulls",
             owner = self.handler.owner,
             repo = self.handler.repo
         );

--- a/src/api/pulls/list.rs
+++ b/src/api/pulls/list.rs
@@ -90,7 +90,7 @@ impl<'octo, 'b> ListPullRequestsBuilder<'octo, 'b> {
     /// Sends the actual request.
     pub async fn send(self) -> crate::Result<Page<crate::models::pulls::PullRequest>> {
         let url = format!(
-            "/repos/{owner}/{repo}/pulls",
+            "repos/{owner}/{repo}/pulls",
             owner = self.handler.owner,
             repo = self.handler.repo
         );

--- a/src/api/pulls/merge.rs
+++ b/src/api/pulls/merge.rs
@@ -60,7 +60,7 @@ impl<'octo, 'b> MergePullRequestsBuilder<'octo, 'b> {
     /// Sends the actual request.
     pub async fn send(self) -> crate::Result<crate::models::pulls::Merge> {
         let url = format!(
-            "/repos/{owner}/{repo}/pulls/{pull_number}/merge",
+            "repos/{owner}/{repo}/pulls/{pull_number}/merge",
             owner = self.handler.owner,
             repo = self.handler.repo,
             pull_number = self.pr_number,

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -36,7 +36,7 @@ impl<'octo> RepoHandler<'octo> {
     /// ```
     pub async fn license(&self) -> Result<models::repos::Content> {
         let url = format!(
-            "/repos/{owner}/{repo}/license",
+            "repos/{owner}/{repo}/license",
             owner = self.owner,
             repo = self.repo,
         );
@@ -61,7 +61,7 @@ impl<'octo> RepoHandler<'octo> {
         reference: &params::repos::Reference,
     ) -> Result<models::repos::Ref> {
         let url = format!(
-            "/repos/{owner}/{repo}/git/ref/{reference}",
+            "repos/{owner}/{repo}/git/ref/{reference}",
             owner = self.owner,
             repo = self.repo,
             reference = reference.ref_url(),
@@ -89,7 +89,7 @@ impl<'octo> RepoHandler<'octo> {
         sha: impl Into<String>,
     ) -> Result<models::repos::Ref> {
         let url = format!(
-            "/repos/{owner}/{repo}/git/refs",
+            "repos/{owner}/{repo}/git/refs",
             owner = self.owner,
             repo = self.repo,
         );
@@ -259,7 +259,7 @@ impl<'octo> RepoHandler<'octo> {
         reference: &params::repos::Reference,
     ) -> Result<models::CombinedStatus> {
         let url = format!(
-            "/repos/{owner}/{repo}/commits/{reference}/status",
+            "repos/{owner}/{repo}/commits/{reference}/status",
             owner = self.owner,
             repo = self.repo,
             reference = reference.ref_url(),
@@ -274,7 +274,7 @@ impl<'octo> RepoHandler<'octo> {
     /// # }
     /// ```
     pub async fn delete(self) -> Result<()> {
-        let url = format!("/repos/{owner}/{repo}", owner = self.owner, repo = self.repo);
+        let url = format!("repos/{owner}/{repo}", owner = self.owner, repo = self.repo);
         crate::map_github_error(self.crab._delete(self.crab.absolute_url(url)?, None::<&()>).await?)
             .await
             .map(drop)

--- a/src/api/repos/file.rs
+++ b/src/api/repos/file.rs
@@ -59,7 +59,7 @@ impl<'octo, 'r> UpdateFileBuilder<'octo, 'r> {
     /// Sends the actual request.
     pub async fn send(self) -> Result<models::repos::FileUpdate> {
         let url = format!(
-            "/repos/{owner}/{repo}/contents/{path}",
+            "repos/{owner}/{repo}/contents/{path}",
             owner = self.handler.owner,
             repo = self.handler.repo,
             path = self.path,

--- a/src/api/repos/forks.rs
+++ b/src/api/repos/forks.rs
@@ -44,7 +44,7 @@ impl<'octo, 'r> ListForksBuilder<'octo, 'r> {
     /// Sends the actual request.
     pub async fn send(self) -> crate::Result<crate::Page<crate::models::Repository>> {
         let url = format!(
-            "/repos/{owner}/{repo}/forks",
+            "repos/{owner}/{repo}/forks",
             owner = self.handler.owner,
             repo = self.handler.repo
         );
@@ -75,7 +75,7 @@ impl<'octo, 'r> CreateForkBuilder<'octo, 'r> {
     /// Sends the actual request.
     pub async fn send(self) -> crate::Result<crate::models::Repository> {
         let url = format!(
-            "/repos/{owner}/{repo}/forks",
+            "repos/{owner}/{repo}/forks",
             owner = self.handler.owner,
             repo = self.handler.repo
         );

--- a/src/api/repos/releases.rs
+++ b/src/api/repos/releases.rs
@@ -69,7 +69,7 @@ impl<'octo, 'r> ReleasesHandler<'octo, 'r> {
     /// ```
     pub async fn get_asset(&self, asset_id: usize) -> crate::Result<models::repos::Asset> {
         let url = format!(
-            "/repos/{owner}/{repo}/assets/{asset_id}",
+            "repos/{owner}/{repo}/assets/{asset_id}",
             owner = self.parent.owner,
             repo = self.parent.repo,
             asset_id = asset_id,
@@ -91,7 +91,7 @@ impl<'octo, 'r> ReleasesHandler<'octo, 'r> {
     /// ```
     pub async fn get_latest(&self) -> crate::Result<models::repos::Release> {
         let url = format!(
-            "/repos/{owner}/{repo}/releases/latest",
+            "repos/{owner}/{repo}/releases/latest",
             owner = self.parent.owner,
             repo = self.parent.repo,
         );
@@ -112,7 +112,7 @@ impl<'octo, 'r> ReleasesHandler<'octo, 'r> {
     /// ```
     pub async fn get_by_tag(&self, tag: &str) -> crate::Result<models::repos::Release> {
         let url = format!(
-            "/repos/{owner}/{repo}/releases/tags/{tag}",
+            "repos/{owner}/{repo}/releases/tags/{tag}",
             owner = self.parent.owner,
             repo = self.parent.repo,
             tag = tag,
@@ -145,7 +145,7 @@ impl<'octo, 'r> ReleasesHandler<'octo, 'r> {
         use snafu::GenerateBacktrace;
 
         let url = format!(
-            "/repos/{owner}/{repo}/assets/{asset_id}",
+            "repos/{owner}/{repo}/assets/{asset_id}",
             owner = self.parent.owner,
             repo = self.parent.repo,
             asset_id = asset_id,
@@ -198,7 +198,7 @@ impl<'octo, 'r1, 'r2> ListReleasesBuilder<'octo, 'r1, 'r2> {
     /// Sends the actual request.
     pub async fn send(self) -> crate::Result<crate::Page<crate::models::repos::Release>> {
         let url = format!(
-            "/repos/{owner}/{repo}/releases",
+            "repos/{owner}/{repo}/releases",
             owner = self.handler.parent.owner,
             repo = self.handler.parent.repo
         );
@@ -275,7 +275,7 @@ impl<'octo, 'repos, 'handler, 'tag_name, 'target_commitish, 'name, 'body> Create
     /// Sends the actual request.
     pub async fn send(self) -> crate::Result<crate::models::repos::Release> {
         let url = format!(
-            "/repos/{owner}/{repo}/releases",
+            "repos/{owner}/{repo}/releases",
             owner = self.handler.parent.owner,
             repo = self.handler.parent.repo
         );

--- a/src/api/repos/status.rs
+++ b/src/api/repos/status.rs
@@ -63,7 +63,7 @@ impl<'octo, 'r> CreateStatusBuilder<'octo, 'r> {
     /// Sends the actual request.
     pub async fn send(self) -> Result<models::repos::FileUpdate> {
         let url = format!(
-            "/repos/{owner}/{repo}/statuses/{sha}",
+            "repos/{owner}/{repo}/statuses/{sha}",
             owner = self.handler.owner,
             repo = self.handler.repo,
             sha = self.sha

--- a/src/api/repos/tags.rs
+++ b/src/api/repos/tags.rs
@@ -34,7 +34,7 @@ impl<'octo, 'r> ListTagsBuilder<'octo, 'r> {
     /// Sends the actual request.
     pub async fn send(self) -> crate::Result<crate::Page<crate::models::repos::Tag>> {
         let url = format!(
-            "/repos/{owner}/{repo}/tags",
+            "repos/{owner}/{repo}/tags",
             owner = self.handler.owner,
             repo = self.handler.repo
         );

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -194,7 +194,7 @@ impl<'octo, 'query, T: serde::de::DeserializeOwned> QueryHandler<'octo, 'query, 
     /// Send the actual request.
     pub async fn send(self) -> crate::Result<crate::Page<T>> {
         self.crab
-            .get(&format!("/search/{}", self.route), Some(&self))
+            .get(&format!("search/{}", self.route), Some(&self))
             .await
     }
 }

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -55,7 +55,7 @@ impl<'octo> TeamHandler<'octo> {
     /// ```
     pub async fn get(&self, team_slug: impl Into<String>) -> Result<models::teams::Team> {
         let url = format!(
-            "/orgs/{org}/teams/{team}",
+            "orgs/{org}/teams/{team}",
             org = self.owner,
             team = team_slug.into(),
         );
@@ -113,7 +113,7 @@ impl<'octo> TeamHandler<'octo> {
     /// ```
     pub async fn delete(&self, team_slug: impl Into<String>) -> Result<()> {
         let url = format!(
-            "/orgs/{org}/teams/{team}",
+            "orgs/{org}/teams/{team}",
             org = self.owner,
             team = team_slug.into(),
         );

--- a/src/api/teams/children.rs
+++ b/src/api/teams/children.rs
@@ -38,7 +38,7 @@ impl<'octo, 'r> ListChildTeamsBuilder<'octo, 'r> {
     /// Sends the actual request.
     pub async fn send(self) -> Result<Page<models::teams::RequestedTeam>> {
         let url = format!(
-            "/orgs/{org}/teams/{team}/teams",
+            "orgs/{org}/teams/{team}/teams",
             org = self.handler.owner,
             team = self.slug,
         );

--- a/src/api/teams/create.rs
+++ b/src/api/teams/create.rs
@@ -70,7 +70,7 @@ impl<'octo, 'h, 'a, 'b> CreateTeamBuilder<'octo, 'h, 'a, 'b> {
 
     /// Sends the actual request.
     pub async fn send(self) -> Result<models::teams::Team> {
-        let url = format!("/orgs/{org}/teams", org = self.handler.owner,);
+        let url = format!("orgs/{org}/teams", org = self.handler.owner,);
         self.handler.crab.post(url, Some(&self)).await
     }
 }

--- a/src/api/teams/edit.rs
+++ b/src/api/teams/edit.rs
@@ -54,7 +54,7 @@ impl<'octo, 'r> EditTeamBuilder<'octo, 'r> {
     /// Sends the actual request.
     pub async fn send(self) -> Result<models::teams::Team> {
         let url = format!(
-            "/orgs/{org}/teams/{team}",
+            "orgs/{org}/teams/{team}",
             org = self.handler.owner,
             team = self.slug,
         );

--- a/src/api/teams/list.rs
+++ b/src/api/teams/list.rs
@@ -34,7 +34,7 @@ impl<'octo, 'r> ListTeamsBuilder<'octo, 'r> {
 
     /// Sends the actual request.
     pub async fn send(self) -> Result<Page<models::teams::RequestedTeam>> {
-        let url = format!("/orgs/{owner}/teams", owner = self.handler.owner);
+        let url = format!("orgs/{owner}/teams", owner = self.handler.owner);
         self.handler.crab.get(url, Some(&self)).await
     }
 }

--- a/src/api/teams/team_repos.rs
+++ b/src/api/teams/team_repos.rs
@@ -37,7 +37,7 @@ impl<'octo> TeamRepoHandler<'octo> {
         repo_name: impl Into<String>,
     ) -> Result<models::Repository> {
         let url = format!(
-            "/orgs/{org}/teams/{team}/repos/{owner}/{repo}",
+            "orgs/{org}/teams/{team}/repos/{owner}/{repo}",
             org = self.org,
             team = self.team,
             owner = repo_owner.into(),
@@ -72,7 +72,7 @@ impl<'octo> TeamRepoHandler<'octo> {
         permission: impl Into<Option<params::teams::Permission>>,
     ) -> Result<()> {
         let url = format!(
-            "/orgs/{org}/teams/{team}/repos/{owner}/{repo}",
+            "orgs/{org}/teams/{team}/repos/{owner}/{repo}",
             org = self.org,
             team = self.team,
             owner = repo_owner.into(),
@@ -100,7 +100,7 @@ impl<'octo> TeamRepoHandler<'octo> {
         repo_name: impl Into<String>,
     ) -> Result<()> {
         let url = format!(
-            "/orgs/{org}/teams/{team}/repos/{owner}/{repo}",
+            "orgs/{org}/teams/{team}/repos/{owner}/{repo}",
             org = self.org,
             team = self.team,
             owner = repo_owner.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //! ```no_run
 //! # async fn run() -> octocrab::Result<()> {
 //! let user: octocrab::models::User = octocrab::instance()
-//!     .get("/user", None::<&()>)
+//!     .get("user", None::<&()>)
 //!     .await?;
 //! # Ok(())
 //! # }
@@ -104,7 +104,7 @@
 //! // You can also use `Octocrab::absolute_url` if you want to still to go to
 //! // the same base.
 //! let response =  octocrab
-//!     ._get(octocrab.absolute_url("/organizations")?, None::<&()>)
+//!     ._get(octocrab.absolute_url("organizations")?, None::<&()>)
 //!     .await?;
 //! # Ok(())
 //! # }
@@ -123,7 +123,7 @@
 //! #[async_trait::async_trait]
 //! impl OrganisationExt for Octocrab {
 //!   async fn list_every_organisation(&self) -> Result<Page<models::orgs::Organization>> {
-//!     self.get("/organizations", None::<&()>).await
+//!     self.get("organizations", None::<&()>).await
 //!   }
 //! }
 //! ```
@@ -449,7 +449,7 @@ impl Octocrab {
         body: &(impl serde::Serialize + ?Sized),
     ) -> crate::Result<R> {
         self.post(
-            "/graphql",
+            "graphql",
             Some(&serde_json::json!({
                 "query": body,
             })),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -666,4 +666,42 @@ mod tests {
             String::from(crate::GITHUB_BASE_URL) + "/help%20wanted"
         );
     }
+
+    #[test]
+    fn absolute_url_for_subdir() {
+        assert_eq!(
+            crate::OctocrabBuilder::new()
+                .base_url("https://git.example.com/api/v3/")
+                .unwrap()
+                .build()
+                .unwrap()
+                .absolute_url("/my/api")
+                .unwrap()
+                .as_str(),
+            String::from("https://git.example.com/my/api")
+        );
+    }
+
+    #[test]
+    fn relative_url() {
+        assert_eq!(
+            crate::instance().absolute_url("my/api").unwrap().as_str(),
+            String::from(crate::GITHUB_BASE_URL) + "/my/api"
+        );
+    }
+
+    #[test]
+    fn relative_url_for_subdir() {
+        assert_eq!(
+            crate::OctocrabBuilder::new()
+                .base_url("https://git.example.com/api/v3/")
+                .unwrap()
+                .build()
+                .unwrap()
+                .absolute_url("my/api")
+                .unwrap()
+                .as_str(),
+            String::from("https://git.example.com/api/v3/my/api")
+        );
+    }
 }


### PR DESCRIPTION
Related: #73 

Current octocrab does not support submounted API base url such as `"https://git.example.com/api/v3/"`.

This is because GitHub endpoints are coded to start with absolute `"/"` and passing `octocrab::absolute_url()` an absolute path will ignore `base_url`'s path info.

Note that only forms ending with `/`, e.g. `"https://git.example.com/api/v3/"` is accepted, not such like `"https://git.example.com/api/v3"`(This is url::Url's design). But it is OK for my use case.