### PR TITLE
Make team description nullable

### DIFF
--- a/src/models/teams.rs
+++ b/src/models/teams.rs
@@ -9,7 +9,7 @@ pub struct Team {
     pub html_url: Url,
     pub name: String,
     pub slug: String,
-    pub description: String,
+    pub description: Option<String>,
     pub privacy: String,
     pub permission: String,
     pub members_url: Url,


### PR DESCRIPTION
I've been running octocrab against the `/events` API and noticed an error this morning. I tracked it down to a nullable field in the `Team` model. Turns out description here can be null. Example event that caused the error https://gist.github.com/wayofthepie/acdd6c61749558770ce999acc7ecf447#file-team_null_description_event-json-L383. 

I can't seem to reproduce this by creating a team with no description, and it's also not documented as nullable in the GitHub docs (though they don't seem to document that very well :smile:), so not sure if it's a bug in GitHub or not. Probably better to have this nullable anyway. This is a breaking change but not sure if I should bump the version in this PR or not. Thanks!

Edit: Ah through the UI creating a team sets description to "", but with an API call you can set it as null, e.g.
```
$ curl -q -s \
    -H "Accept: application/vnd.github.v3+json" \
    -d '{"name":"null-desc", "description": null }' \
    https://api.github.com/orgs/some-org/teams
```