### PR TITLE
Add an entrypoint for whole repo's issue comments

### DIFF
--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -630,6 +630,23 @@ impl<'octo> IssueHandler<'octo> {
     pub fn list_comments(&self, issue_number: u64) -> ListCommentsBuilder<'_, '_> {
         ListCommentsBuilder::new(self, issue_number)
     }
+
+    /// Lists comments for issues in the whole repo.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let comment = octocrab::instance()
+    ///     .issues("owner", "repo")
+    ///     .list_issue_comments()
+    ///     .per_page(100)
+    ///     .page(2u32)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list_issue_comments(&self) -> ListIssueCommentsBuilder<'_, '_> {
+        ListIssueCommentsBuilder::new(self)
+    }
 }
 
 #[derive(serde::Serialize)]
@@ -682,6 +699,49 @@ impl<'octo, 'r> ListCommentsBuilder<'octo, 'r> {
             owner = self.handler.owner,
             repo = self.handler.repo,
             issue = self.issue_number,
+        );
+
+        self.handler.crab.get(route, Some(&self)).await
+    }
+}
+
+#[derive(serde::Serialize)]
+pub struct ListIssueCommentsBuilder<'octo, 'r> {
+    #[serde(skip)]
+    handler: &'r IssueHandler<'octo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+}
+
+impl<'octo, 'r> ListIssueCommentsBuilder<'octo, 'r> {
+    pub(crate) fn new(handler: &'r IssueHandler<'octo>) -> Self {
+        Self {
+            handler,
+            per_page: None,
+            page: None,
+        }
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.page = Some(page.into());
+        self
+    }
+
+    /// Send the actual request.
+    pub async fn send(self) -> Result<crate::Page<models::issues::Comment>> {
+        let route = format!(
+            "repos/{owner}/{repo}/issues/comments",
+            owner = self.handler.owner,
+            repo = self.handler.repo,
         );
 
         self.handler.crab.get(route, Some(&self)).await

--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -713,6 +713,12 @@ pub struct ListIssueCommentsBuilder<'octo, 'r> {
     per_page: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
     page: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sort: Option<params::issues::Sort>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    direction: Option<params::Direction>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    since: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl<'octo, 'r> ListIssueCommentsBuilder<'octo, 'r> {
@@ -721,6 +727,9 @@ impl<'octo, 'r> ListIssueCommentsBuilder<'octo, 'r> {
             handler,
             per_page: None,
             page: None,
+            sort: None,
+            direction: None,
+            since: None,
         }
     }
 
@@ -733,6 +742,24 @@ impl<'octo, 'r> ListIssueCommentsBuilder<'octo, 'r> {
     /// Page number of the results to fetch.
     pub fn page(mut self, page: impl Into<u32>) -> Self {
         self.page = Some(page.into());
+        self
+    }
+
+    /// Specify sort results by. Can be either `created`, `updated`,
+    pub fn sort(mut self, sort: impl Into<params::issues::Sort>) -> Self {
+        self.sort = Some(sort.into());
+        self
+    }
+
+    /// The direction of the sort. Can be either ascending or descending.
+    pub fn direction(mut self, direction: impl Into<params::Direction>) -> Self {
+        self.direction = Some(direction.into());
+        self
+    }
+
+    /// Only show comments updated after the given time.
+    pub fn since(mut self, since: impl Into<chrono::DateTime<chrono::Utc>>) -> Self {
+        self.since = Some(since.into());
         self
     }
 


### PR DESCRIPTION
Added an entrypoint for `"repos/{owner}/{repo}/issues/comments"`.

ref: https://docs.github.com/en/rest/reference/issues#list-issue-comments-for-a-repository