### PR TITLE
Fix: Release creation requires POST request, not GET

### DIFF
--- a/src/api/repos/releases.rs
+++ b/src/api/repos/releases.rs
@@ -279,6 +279,6 @@ impl<'octo, 'repos, 'handler, 'tag_name, 'target_commitish, 'name, 'body> Create
             owner = self.handler.parent.owner,
             repo = self.handler.parent.repo
         );
-        self.handler.parent.crab.get(url, Some(&self)).await
+        self.handler.parent.crab.post(url, Some(&self)).await
     }
 }


### PR DESCRIPTION
See https://docs.github.com/en/rest/reference/repos#create-a-release

With the current GET request, the following error occurs:

```
Error: JSON Error in [0]: invalid type: map, expected a string representing an URL at line 1 column 1
```
