### PR TITLE
Support workflows/runs/jobs list API for github action

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -10,3 +10,4 @@ pub mod pulls;
 pub mod repos;
 pub mod search;
 pub mod teams;
+pub mod workflows;

--- a/src/api/workflows.rs
+++ b/src/api/workflows.rs
@@ -1,0 +1,5 @@
+pub struct WorkflowsHandler<'octo> {
+    crab: &'octo Octocrab,
+    owner: String,
+    repo: String,
+}

--- a/src/api/workflows.rs
+++ b/src/api/workflows.rs
@@ -70,7 +70,7 @@ impl<'octo> WorkflowsHandler<'octo> {
     /// use octocrab::params::workflows::Filter;
     ///
     /// let issue = octocrab.workflows("owner", "repo")
-    ///     .list_jobs(1234)
+    ///     .list_jobs(1234u32)
     ///     // Optional Parameters
     ///     .per_page(100)
     ///     .page(1u8)
@@ -264,5 +264,30 @@ impl<'octo, 'b> ListJobsBuilder<'octo, 'b> {
             run_id = self.run_id,
         );
         self.handler.crab.get(url, Some(&self)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn serialize() {
+        use crate::params::workflows::Filter;
+
+        let octocrab = crate::Octocrab::default();
+        let handler = octocrab.workflows("rust-lang", "rust");
+        let list_jobs = handler
+            .list_jobs(1234u32)
+            .filter(Filter::All)
+            .per_page(100)
+            .page(1u8);
+
+        assert_eq!(
+            serde_json::to_value(list_jobs).unwrap(),
+            serde_json::json!({
+                "filter": "all",
+                "per_page": 100,
+                "page": 1,
+            })
+        )
     }
 }

--- a/src/api/workflows.rs
+++ b/src/api/workflows.rs
@@ -1,4 +1,4 @@
-use crate::{models, Octocrab, Result};
+use crate::{models, Octocrab, Page, Result};
 
 pub struct WorkflowsHandler<'octo> {
     crab: &'octo Octocrab,
@@ -16,5 +16,67 @@ impl<'octo> WorkflowsHandler<'octo> {
             owner: owner,
             repo: repo,
         }
+    }
+
+    /// List workflow definitions in the repository.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// # let octocrab = octocrab::Octocrab::default();
+    ///
+    /// let issue = octocrab.workflows("owner", "repo")
+    ///     .list()
+    ///     // Optional Parameters
+    ///     .per_page(100)
+    ///     .page(1u8)
+    ///     // Send the request
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list(&self) -> ListWorkflowsBuilder<'_, '_> {
+        ListWorkflowsBuilder::new(self)
+    }
+}
+
+#[derive(serde::Serialize)]
+pub struct ListWorkflowsBuilder<'octo, 'b> {
+    #[serde(skip)]
+    handler: &'b WorkflowsHandler<'octo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+}
+
+impl<'octo, 'b> ListWorkflowsBuilder<'octo, 'b> {
+    pub(crate) fn new(handler: &'b WorkflowsHandler<'octo>) -> Self {
+        Self {
+            handler,
+            per_page: None,
+            page: None,
+        }
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.page = Some(page.into());
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(self) -> Result<Page<models::workflows::WorkFlow>> {
+        let url = format!(
+            "repos/{owner}/{repo}/actions/workflows",
+            owner = self.handler.owner,
+            repo = self.handler.repo
+        );
+        self.handler.crab.get(url, Some(&self)).await
     }
 }

--- a/src/api/workflows.rs
+++ b/src/api/workflows.rs
@@ -1,5 +1,20 @@
+use crate::{models, Octocrab, Result};
+
 pub struct WorkflowsHandler<'octo> {
     crab: &'octo Octocrab,
     owner: String,
     repo: String,
+}
+
+/// Handler for GitHub's workflows API for actions.
+///
+/// Created with [`Octocrab::workflows`].
+impl<'octo> WorkflowsHandler<'octo> {
+    pub fn new(crab: &'octo Octocrab, owner: String, repo: String) -> Self {
+        Self {
+            crab,
+            owner: owner,
+            repo: repo,
+        }
+    }
 }

--- a/src/api/workflows.rs
+++ b/src/api/workflows.rs
@@ -10,7 +10,7 @@ pub struct WorkflowsHandler<'octo> {
 ///
 /// Created with [`Octocrab::workflows`].
 impl<'octo> WorkflowsHandler<'octo> {
-    pub fn new(crab: &'octo Octocrab, owner: String, repo: String) -> Self {
+    pub(crate) fn new(crab: &'octo Octocrab, owner: String, repo: String) -> Self {
         Self {
             crab,
             owner: owner,
@@ -178,6 +178,7 @@ impl<'octo, 'b> ListRunsBuilder<'octo, 'b> {
         self
     }
 
+    /// Sends the actual request.
     pub async fn send(self) -> Result<Page<models::workflows::Run>> {
         let url = format!(
             "repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",

--- a/src/api/workflows.rs
+++ b/src/api/workflows.rs
@@ -37,6 +37,31 @@ impl<'octo> WorkflowsHandler<'octo> {
     pub fn list(&self) -> ListWorkflowsBuilder<'_, '_> {
         ListWorkflowsBuilder::new(self)
     }
+
+    /// List runs in the specified workflow.
+    /// workflow_file_or_id can be either file name or numeric expression.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// # let octocrab = octocrab::Octocrab::default();
+    ///
+    /// let issue = octocrab.workflows("owner", "repo")
+    ///     .list_runs("ci.yml")
+    ///     // Optional Parameters
+    ///     .actor("octocat")
+    ///     .branch("master")
+    ///     .event("push")
+    ///     .status("success")
+    ///     .per_page(100)
+    ///     .page(1u8)
+    ///     // Send the request
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list_runs(&self, workflow_file_or_id: impl Into<String>) -> ListRunsBuilder<'_, '_> {
+        ListRunsBuilder::new(self, workflow_file_or_id.into())
+    }
 }
 
 #[derive(serde::Serialize)]
@@ -76,6 +101,89 @@ impl<'octo, 'b> ListWorkflowsBuilder<'octo, 'b> {
             "repos/{owner}/{repo}/actions/workflows",
             owner = self.handler.owner,
             repo = self.handler.repo
+        );
+        self.handler.crab.get(url, Some(&self)).await
+    }
+}
+
+#[derive(serde::Serialize)]
+pub struct ListRunsBuilder<'octo, 'b> {
+    #[serde(skip)]
+    handler: &'b WorkflowsHandler<'octo>,
+    #[serde(skip)]
+    workflow_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    actor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    event: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+}
+
+impl<'octo, 'b> ListRunsBuilder<'octo, 'b> {
+    pub(crate) fn new(handler: &'b WorkflowsHandler<'octo>, workflow_id: String) -> Self {
+        Self {
+            handler,
+            workflow_id: workflow_id,
+            actor: None,
+            branch: None,
+            event: None,
+            status: None,
+            per_page: None,
+            page: None,
+        }
+    }
+
+    /// Someone who runs workflows. Use the login to specify a user.
+    pub fn actor(mut self, actor: impl Into<String>) -> Self {
+        self.actor = Some(actor.into());
+        self
+    }
+
+    /// A branch associated with workflows. Use the name of the branch of the push.
+    pub fn branch(mut self, branch: impl Into<String>) -> Self {
+        self.branch = Some(branch.into());
+        self
+    }
+
+    /// An event associated with workflows. Can be e.g. pusu, pull_request, issue,
+    /// ... and many variations. See official "Events that trigger workflows." doc.
+    pub fn event(mut self, event: impl Into<String>) -> Self {
+        self.event = Some(event.into());
+        self
+    }
+
+    /// A status associated with workflows.
+    /// status or conclusion can be specified. e.g. success, in_progress, waiting...
+    pub fn status(mut self, status: impl Into<String>) -> Self {
+        self.status = Some(status.into());
+        self
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.page = Some(page.into());
+        self
+    }
+
+    pub async fn send(self) -> Result<Page<models::workflows::Run>> {
+        let url = format!(
+            "repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
+            owner = self.handler.owner,
+            repo = self.handler.repo,
+            workflow_id = self.workflow_id
         );
         self.handler.crab.get(url, Some(&self)).await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ use auth::Auth;
 pub use self::{
     api::{
         actions, activity, current, gitignore, issues, licenses, markdown, orgs, pulls, repos,
-        search, teams,
+        search, teams, workflows,
     },
     error::{Error, GitHubError},
     from_response::FromResponse,
@@ -429,6 +429,16 @@ impl Octocrab {
     /// you to access GitHub's teams API.
     pub fn teams(&self, owner: impl Into<String>) -> teams::TeamHandler {
         teams::TeamHandler::new(self, owner.into())
+    }
+
+    /// Creates a [`workflows::WorkflowsHandler`] for the specified repository that allows
+    /// you to access GitHub's workflows API.
+    pub fn workflows(
+        &self,
+        owner: impl Into<String>,
+        repo: impl Into<String>,
+    ) -> workflows::WorkflowsHandler {
+        workflows::WorkflowsHandler::new(self, owner.into(), repo.into())
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -10,6 +10,7 @@ pub mod orgs;
 pub mod pulls;
 pub mod repos;
 pub mod teams;
+pub mod workflows;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]

--- a/src/models/workflows.rs
+++ b/src/models/workflows.rs
@@ -48,6 +48,8 @@ pub struct Run {
     pub head_repository: Repository,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct HeadCommit {
     pub id: String,
     pub tree_id: String,

--- a/src/models/workflows.rs
+++ b/src/models/workflows.rs
@@ -33,8 +33,28 @@ pub struct Run {
     pub updated_at: chrono::DateTime<chrono::Utc>,
     pub url: Url,
     pub html_url: Url,
+    pub jobs_url: Url,
+    pub logs_url: Url,
+    pub check_suite_url: Url,
+    pub artifacts_url: Url,
+    pub cancel_url: Url,
+    pub rerun_url: Url,
+    pub workflow_url: Url,
+    pub pull_requests: Vec<super::pulls::PullRequest>,
     // TODO: other attrs
     // ref: https://docs.github.com/en/rest/reference/actions#list-workflow-runs
+    pub head_commit: HeadCommit,
+    pub repository: Repository,
+    pub head_repository: Repository,
+}
+
+pub struct HeadCommit {
+    pub id: String,
+    pub tree_id: String,
+    pub message: String,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub author: super::repos::GitUser,
+    pub committer: super::repos::GitUser,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/models/workflows.rs
+++ b/src/models/workflows.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct WorkFlow {
+    pub id: i64,
+    pub node_id: String,
+    pub name: String,
+    pub path: String,
+    pub state: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub url: Url,
+    pub html_url: Url,
+    pub badge_url: Url,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Run {
+    pub id: i64,
+    pub workflow_id: i64,
+    pub node_id: String,
+    pub name: String,
+    pub head_branch: String,
+    pub head_sha: String,
+    pub run_number: i64,
+    pub event: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conclusion: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub url: Url,
+    pub html_url: Url,
+    // TODO: other attrs
+    // ref: https://docs.github.com/en/rest/reference/actions#list-workflow-runs
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Job {
+    pub id: i64,
+    pub run_id: i64,
+    pub node_id: String,
+    pub head_sha: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conclusion: Option<String>,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub name: String,
+    pub url: Url,
+    pub html_url: Url,
+    pub run_url: Url,
+    pub check_run_url: Url,
+    pub steps: Vec<Step>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Step {
+    pub name: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conclusion: Option<String>,
+    pub number: i64,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<chrono::DateTime<chrono::Utc>>,
+}

--- a/src/page.rs
+++ b/src/page.rs
@@ -90,8 +90,13 @@ impl<T: serde::de::DeserializeOwned> crate::FromResponse for Page<T> {
                 last,
             })
         } else {
+            let attr = vec!["items", "workflows", "workflow_runs", "jobs"]
+                .into_iter()
+                .find(|v| !json.get(v).is_none())
+                .unwrap();
+
             Ok(Self {
-                items: serde_json::from_value(json.get("items").cloned().unwrap())
+                items: serde_json::from_value(json.get(attr).cloned().unwrap())
                     .context(crate::error::Serde)?,
                 incomplete_results: json
                     .get("incomplete_results")

--- a/src/params.rs
+++ b/src/params.rs
@@ -319,3 +319,13 @@ pub mod teams {
         Triage,
     }
 }
+
+pub mod workflows {
+    #[derive(Debug, Clone, Copy, serde::Serialize)]
+    #[serde(rename_all = "snake_case")]
+    #[non_exhaustive]
+    pub enum Filter {
+        Latest,
+        All,
+    }
+}


### PR DESCRIPTION
* Listing workflows/runs/jobs for one repository.
* Added `workflows` namespace and `Octocrab::workflow()`, because actions API has lots of endpoints, so it seems better to be split by each purpose.
* Support yet other complicated JSON response forms like:

```javascript
{
  "total_count": 2,
  "jobs": [ // not "items" :( can be "workflows", "workflow_runs"
    {
      "id": 399444496,
      "run_id": 29679449,
      //...
    },
    {
      "id": 399444497,
      "run_id": 29679450,
      //...
    }
  ]
}
```

* APIs:
  * https://docs.github.com/en/rest/reference/actions#list-repository-workflows
  * https://docs.github.com/en/rest/reference/actions#list-workflow-runs
  * https://docs.github.com/en/rest/reference/actions#list-jobs-for-a-workflow-run
