### PR TITLE
Change committer/author type to User

### DIFF
--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -32,8 +32,10 @@ pub struct Commit {
     pub html_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comments_url: Option<String>,
-    pub author: User,
-    pub committer: User,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<User>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub committer: Option<User>,
 }
 
 /// The author of a commit, identified by its name and email.

--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -32,8 +32,8 @@ pub struct Commit {
     pub html_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comments_url: Option<String>,
-    pub author: GitUser,
-    pub committer: GitUser,
+    pub author: User,
+    pub committer: User,
 }
 
 /// The author of a commit, identified by its name and email.


### PR DESCRIPTION
There is already a User type defined, so I directly used that type (The original GitUser type actually matches the author/committer fields of the commit field, see https://docs.github.com/en/rest/reference/search#search-commits). The committer could be empty, so I make both author and committer to be an Option.

I checked all the other uses of GitUser and corresponding Github API, it seems only this place needs to be updated.