### PR TITLE
fix: type of `assignees` in `IssueHandler::add_assignees`

### DIFF
--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -5,8 +5,8 @@ mod list;
 mod list_labels;
 mod update;
 
-use crate::{models, params, Octocrab, Result};
 use crate::models::CommentId;
+use crate::{models, params, Octocrab, Result};
 
 pub use self::{
     create::CreateIssueBuilder,
@@ -205,14 +205,14 @@ impl<'octo> IssueHandler<'octo> {
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
     /// # let octocrab = octocrab::Octocrab::default();
-    /// let issue = octocrab.issues("owner", "repo").add_assignees(101, &[56982]).await?;
+    /// let issue = octocrab.issues("owner", "repo").add_assignees(101, &["username1", "username2"]).await?;
     /// # Ok(())
     /// # }
     /// ```
     pub async fn add_assignees(
         &self,
         number: u64,
-        assignees: &[u64],
+        assignees: &[&str],
     ) -> Result<models::issues::Issue> {
         let route = format!(
             "repos/{owner}/{repo}/issues/{issue}/assignees",


### PR DESCRIPTION
- close #86 
- update `assignees` parameter to `&[&str]` in `IssueHandler::add_assignees` to match [Github API Add Assignees to Issue Endpoint](https://docs.github.com/en/rest/reference/issues#add-assignees-to-an-issue)

`assignees` should be `&[&str]` as it represents a list of usernames for the users to assign to the issue.

https://github.com/XAMPPRocky/octocrab/blob/bb3f7bee6948f0986b37cbac3405710f128c6489/src/api/issues.rs#L212-L216