### PR TITLE
Add global events api

### DIFF
--- a/examples/poll_events.rs
+++ b/examples/poll_events.rs
@@ -1,0 +1,31 @@
+use octocrab::{etag::Etagged, models::events::Event, Page};
+use std::collections::VecDeque;
+
+const DELAY_MS: u64 = 500;
+const TRACKING_CAPACITY: usize = 200;
+
+#[tokio::main]
+async fn main() -> octocrab::Result<()> {
+    let mut etag = None;
+    let mut seen = VecDeque::with_capacity(TRACKING_CAPACITY);
+    let octo = octocrab::instance();
+    loop {
+        let response: Etagged<Page<Event>> = octo.events().etag(etag).per_page(100).send().await?;
+        if let Some(page) = response.value {
+            for event in page {
+                if !seen.contains(&event.id) {
+                    println!(
+                        "New event : id = {:?}, type = {:?}, time = {:?}",
+                        event.id, event.r#type, event.created_at,
+                    );
+                    if seen.len() == TRACKING_CAPACITY {
+                        seen.pop_back();
+                    }
+                    seen.push_front(event.id);
+                }
+            }
+        }
+        etag = response.etag;
+        tokio::time::sleep(tokio::time::Duration::from_millis(DELAY_MS)).await;
+    }
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,7 @@
 pub mod actions;
 pub mod activity;
 pub mod current;
+pub mod events;
 pub mod gitignore;
 pub mod issues;
 pub mod licenses;

--- a/src/api/events.rs
+++ b/src/api/events.rs
@@ -1,0 +1,88 @@
+//! GitHub Events
+use crate::{
+    etag::{EntityTag, Etagged},
+    models::events,
+    FromResponse, Octocrab, Page,
+};
+use hyperx::header::{ETag, IfNoneMatch, TypedHeaders};
+use reqwest::{header::HeaderMap, Method, StatusCode};
+
+pub struct EventsBuilder<'octo> {
+    crab: &'octo Octocrab,
+    headers: Headers,
+    params: Params,
+}
+
+struct Headers {
+    etag: Option<EntityTag>,
+}
+
+#[derive(serde::Serialize)]
+struct Params {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+}
+
+impl<'octo> EventsBuilder<'octo> {
+    pub(crate) fn new(crab: &'octo Octocrab) -> Self {
+        Self {
+            crab,
+            headers: Headers { etag: None },
+            params: Params {
+                per_page: None,
+                page: None,
+            },
+        }
+    }
+
+    /// Etag for this request.
+    pub fn etag(mut self, etag: Option<EntityTag>) -> Self {
+        self.headers.etag = etag;
+        self
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.params.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.params.page = Some(page.into());
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(self) -> crate::Result<Etagged<Page<events::Event>>> {
+        let url = format!("{base_url}events", base_url = self.crab.base_url);
+        let mut headers = HeaderMap::new();
+        if let Some(etag) = self.headers.etag {
+            headers.encode(&IfNoneMatch::Items(vec![etag]));
+        }
+        let builder = self
+            .crab
+            .client
+            .request(Method::GET, &url)
+            .headers(headers)
+            .query(&self.params);
+        let response = self.crab.execute(builder).await?;
+        let etag = response
+            .headers()
+            .decode::<ETag>()
+            .ok()
+            .map(|ETag(tag)| tag);
+        if response.status() == StatusCode::NOT_MODIFIED {
+            Ok(Etagged { etag, value: None })
+        } else {
+            <Page<events::Event>>::from_response(crate::map_github_error(response).await?)
+                .await
+                .map(|page| Etagged {
+                    etag,
+                    value: Some(page),
+                })
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,8 +168,8 @@ use auth::Auth;
 
 pub use self::{
     api::{
-        actions, activity, current, gitignore, issues, licenses, markdown, orgs, pulls, repos,
-        search, teams, workflows,
+        actions, activity, current, events, gitignore, issues, licenses, markdown, orgs, pulls,
+        repos, search, teams, workflows,
     },
     error::{Error, GitHubError},
     from_response::FromResponse,
@@ -450,6 +450,12 @@ impl Octocrab {
         repo: impl Into<String>,
     ) -> workflows::WorkflowsHandler {
         workflows::WorkflowsHandler::new(self, owner.into(), repo.into())
+    }
+
+    /// Creates an [`events::EventsBuilder`] that allows you to access
+    /// GitHub's events API.
+    pub fn events(&self) -> events::EventsBuilder {
+        events::EventsBuilder::new(self)
     }
 }
 

--- a/tests/mock_error.rs
+++ b/tests/mock_error.rs
@@ -1,0 +1,22 @@
+use serde_json::json;
+use wiremock::{
+    matchers::{method, path_regex},
+    Mock, MockServer, ResponseTemplate,
+};
+
+// Sets up a handler on the mock server which will return a 500 with the given message. This
+// will be mapped internally into a GitHub json error, making it much easier to identify the cause
+// of these test failures.
+//
+// This handler should always come after your real expectations as it will match any GET request.
+pub async fn setup_error_handler(mock_server: &MockServer, message: &str) {
+    Mock::given(method("GET"))
+        .and(path_regex(".*"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!( {
+            "documentation_url": "",
+            "errors": None::<Vec<serde_json::Value>>,
+            "message": message,
+        })))
+        .mount(&mock_server)
+        .await;
+}


### PR DESCRIPTION
This adds support for the global events API. Thanks!

Note, this doesn't respect, or give a way to access, the `X-Poll-Interval` header which is documented [here](https://docs.github.com/en/rest/reference/activity#events). This is set to 60 seconds by default on the `events` API, which seems way too high given we can get ~80 new events per second on average from that API.

[This community post](https://github.community/t/fetching-events-from-public-event-api/120332) suggests that poll limit may not be enforced. I've yet to hit an issue with continual polling, as long as the rate limits are obeyed.