### PR TITLE
Improvements to the team-repos API

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -60,35 +60,37 @@ macro_rules! id_type {
     )+};
 }
 
-id_type!(ActorId, // A Bot, EnterpriseUserAccount, Mannequin, Organization or User
-         AppId,
-         ArtifactId,
-         AssetId,
-         CardId,
-         CheckRunId,
-         CommentId,
-         InstallationId,
-         IssueEventId,
-         IssueId,
-         JobId,
-         LabelId,
-         MilestoneId,
-         NotificationId,
-         OrgId,
-         ProjectId,
-         ProjectColumnId,
-         PullRequestId,
-         PushId,
-         ReleaseId,
-         RepositoryId,
-         ReviewId,
-         RunId,
-         StatusId,
-         TeamId,
-         ThreadId,
-         UserId,
-         UserOrOrgId,
-         WorkflowId);
+id_type!(
+    ActorId, // A Bot, EnterpriseUserAccount, Mannequin, Organization or User
+    AppId,
+    ArtifactId,
+    AssetId,
+    CardId,
+    CheckRunId,
+    CommentId,
+    InstallationId,
+    IssueEventId,
+    IssueId,
+    JobId,
+    LabelId,
+    MilestoneId,
+    NotificationId,
+    OrgId,
+    ProjectId,
+    ProjectColumnId,
+    PullRequestId,
+    PushId,
+    ReleaseId,
+    RepositoryId,
+    ReviewId,
+    RunId,
+    StatusId,
+    TeamId,
+    ThreadId,
+    UserId,
+    UserOrOrgId,
+    WorkflowId
+);
 
 macro_rules! convert_into {
     ($($from:ident -> $to:ident),+) => {$(
@@ -487,9 +489,13 @@ pub struct Code {
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct Permissions {
-    admin: bool,
-    push: bool,
-    pull: bool,
+    pub admin: bool,
+    pub push: bool,
+    pub pull: bool,
+    #[serde(default)]
+    pub triage: bool,
+    #[serde(default)]
+    pub maintain: bool,
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Please let me know if there's anything that should be changed for style/documentation.  

* `models::Permissions` has `triage` and `maintain` defaulted to `false` if absent because certain endpoints seem to only return `admin`, `push`, and `pull`.  
* Rustfmt seemed to disagree with the repo on how the `models::id_type!` invocation should be indented, I can revert that if needed.
* `api::teams::team_repos::check_manages` needs to use the raw Reqwest Request because the github API requires you set a different `Accepts` header if you want to get back the `Repository` JSON.