### PR TITLE
Change author/commiter type back to GitUser

### DIFF
--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -33,9 +33,9 @@ pub struct Commit {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comments_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub author: Option<User>,
+    pub author: Option<GitUser>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub committer: Option<User>,
+    pub committer: Option<GitUser>,
 }
 
 /// The author of a commit, identified by its name and email.


### PR DESCRIPTION
Changing committer/author type from `GitUser` to type `User` by PR #83  causes deserialization errors on few endpoints, as all fields that a `User` struct needs are not satisfied by the response data. One example is  [this](https://docs.github.com/en/rest/reference/repos#create-or-update-file-contents--code-samples) resource which provides data that cannot be converted to an `User` type.
So this PR roll-backs the changes done on #83  and set the committer/author type back to `GitUser`.
