### PR TITLE
Add support for updating releases

### DIFF
--- a/src/api/repos/releases.rs
+++ b/src/api/repos/releases.rs
@@ -232,7 +232,7 @@ impl<'octo, 'r1, 'r2> ListReleasesBuilder<'octo, 'r1, 'r2> {
     }
 }
 
-/// A builder pattern struct for listing releases.
+/// A builder pattern struct for creating releases.
 ///
 /// created by [`ReleasesHandler::create`].
 #[derive(serde::Serialize)]


### PR DESCRIPTION
Fixes #115 

- Added builder `UpdateReleaseBuilder`
- Added method `update` in `ReleasesHandler`