### PR TITLE
Add support for getting a single repository

### DIFF
--- a/examples/get_repo.rs
+++ b/examples/get_repo.rs
@@ -1,0 +1,18 @@
+use octocrab::Octocrab;
+
+#[tokio::main]
+async fn main() -> octocrab::Result<()> {
+    let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env variable is required");
+
+    let octocrab = Octocrab::builder().personal_token(token).build()?;
+
+    let repo = octocrab.repos("rust-lang", "rust").get().await?;
+
+    println!(
+        "{} has {} stars",
+        repo.full_name,
+        repo.stargazers_count.unwrap_or(0)
+    );
+
+    Ok(())
+}

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -44,6 +44,25 @@ impl<'octo> RepoHandler<'octo> {
         self.crab.get(url, None::<&()>).await
     }
 
+    /// Fetches a single repository.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let repo = octocrab::instance()
+    ///     .repos("owner", "repo")
+    ///     .get()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get(&self) -> Result<models::Repository> {
+        let url = format!(
+            "repos/{owner}/{repo}",
+            owner = self.owner,
+            repo = self.repo,
+        );
+        self.crab.get(url, None::<&()>).await
+    }
+
     /// Fetches a single reference in the Git database.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {


### PR DESCRIPTION
Fixes #117 

- Add `get` method in `RepoHandler`
- Add `get_repo` example