### PR TITLE
add new `exclude_pull_requests` option to `list_runs`

### DIFF
--- a/src/api/workflows.rs
+++ b/src/api/workflows.rs
@@ -147,6 +147,8 @@ pub struct ListRunsBuilder<'octo, 'b> {
     per_page: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
     page: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exclude_pull_requests: Option<bool>,
 }
 
 impl<'octo, 'b> ListRunsBuilder<'octo, 'b> {
@@ -160,6 +162,7 @@ impl<'octo, 'b> ListRunsBuilder<'octo, 'b> {
             status: None,
             per_page: None,
             page: None,
+            exclude_pull_requests: None,
         }
     }
 
@@ -198,6 +201,12 @@ impl<'octo, 'b> ListRunsBuilder<'octo, 'b> {
     /// Page number of the results to fetch.
     pub fn page(mut self, page: impl Into<u32>) -> Self {
         self.page = Some(page.into());
+        self
+    }
+
+    /// Whether to exclude the pull requests or not.
+    pub fn exclude_pull_requests(mut self, exclude_pull_requests: impl Into<bool>) -> Self {
+        self.exclude_pull_requests = Some(exclude_pull_requests.into());
         self
     }
 

--- a/src/models/workflows.rs
+++ b/src/models/workflows.rs
@@ -45,7 +45,8 @@ pub struct Run {
     // ref: https://docs.github.com/en/rest/reference/actions#list-workflow-runs
     pub head_commit: HeadCommit,
     pub repository: Repository,
-    pub head_repository: Repository,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_repository: Option<Repository>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This PR adds a new `exclude_pull_requests` option to `list_runs` that
allows user to skip retrieving the pull requests for the response
runs. This is [supported in the official Github API](https://docs.github.com/en/rest/reference/actions#list-workflow-runs--parameters)

This PR also makes the `head_repository` field in the `Run` optional,
as I've seen some API responses returning `head_repository` as `null`,
causing octocrab to err out.

```json
    {
            "event": "pull_request",
            "head_branch": "static-analysis-fixes",
            "head_commit": {
               ...
            },
            "head_repository": null,
            "head_sha": "0069e368cbdf15d9b2e694c1f94d0626ec19c34e",
            "id": 370724462,
            "name": "KinD integration",
            "previous_attempt_url": null,
            "pull_requests": [],
            ...
        },
```

error is shown as `serde` error, and expected Repository struct

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>