### PR TITLE
allow fields in `PullRequest` and `Repository` to be empty

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -338,61 +338,102 @@ pub struct Milestone {
 #[non_exhaustive]
 pub struct Repository {
     pub id: RepositoryId,
-    pub node_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
     pub name: String,
-    pub full_name: String,
-    pub owner: User,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub full_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<User>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub private: Option<bool>,
-    pub html_url: Url,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub html_url: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub fork: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fork: Option<bool>,
     pub url: Url,
-    pub archive_url: Url,
-    pub assignees_url: Url,
-    pub blobs_url: Url,
-    pub branches_url: Url,
-    pub collaborators_url: Url,
-    pub comments_url: Url,
-    pub commits_url: Url,
-    pub compare_url: Url,
-    pub contents_url: Url,
-    pub contributors_url: Url,
-    pub deployments_url: Url,
-    pub downloads_url: Url,
-    pub events_url: Url,
-    pub forks_url: Url,
-    pub git_commits_url: Url,
-    pub git_refs_url: Url,
-    pub git_tags_url: Url,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archive_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignees_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blobs_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branches_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collaborators_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comments_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commits_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compare_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contents_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contributors_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployments_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub downloads_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub events_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forks_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_commits_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_refs_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_tags_url: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_url: Option<Url>,
-    pub issue_comment_url: Url,
-    pub issue_events_url: Url,
-    pub issues_url: Url,
-    pub keys_url: Url,
-    pub labels_url: Url,
-    pub languages_url: Url,
-    pub merges_url: Url,
-    pub milestones_url: Url,
-    pub notifications_url: Url,
-    pub pulls_url: Url,
-    pub releases_url: Url,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issue_comment_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issue_events_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issues_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keys_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub languages_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merges_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub milestones_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notifications_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pulls_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub releases_url: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ssh_url: Option<String>,
-    pub stargazers_url: Url,
-    pub statuses_url: Url,
-    pub subscribers_url: Url,
-    pub subscription_url: Url,
-    pub tags_url: Url,
-    pub teams_url: Url,
-    pub trees_url: Url,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stargazers_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub statuses_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscribers_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub teams_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trees_url: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub clone_url: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mirror_url: Option<Url>,
-    pub hooks_url: Url,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hooks_url: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub svn_url: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -5,24 +5,37 @@ use super::*;
 pub struct PullRequest {
     pub url: String,
     pub id: PullRequestId,
-    pub node_id: String,
-    pub html_url: Url,
-    pub diff_url: Url,
-    pub patch_url: Url,
-    pub issue_url: Url,
-    pub commits_url: Url,
-    pub review_comments_url: Url,
-    pub review_comment_url: Url,
-    pub comments_url: Url,
-    pub statuses_url: Url,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub html_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub patch_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issue_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commits_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_comments_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_comment_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comments_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub statuses_url: Option<Url>,
     pub number: u64,
-    pub state: IssueState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<IssueState>,
     #[serde(default)]
     pub locked: bool,
     #[serde(default)]
     pub maintainer_can_modify: bool,
-    pub title: String,
-    pub user: User,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<User>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -35,7 +48,8 @@ pub struct PullRequest {
     pub milestone: Option<Milestone>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_lock_reason: Option<String>,
-    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -50,9 +64,13 @@ pub struct PullRequest {
     pub merge_commit_sha: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub assignee: Option<User>,
-    pub assignees: Vec<User>,
-    pub requested_reviewers: Vec<User>,
-    pub requested_teams: Vec<teams::RequestedTeam>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignees: Option<Vec<User>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_reviewers: Option<Vec<User>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_teams: Option<Vec<teams::RequestedTeam>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rebaseable: Option<bool>,
     pub head: Head,
     pub base: Base,
@@ -61,7 +79,8 @@ pub struct PullRequest {
     pub links: Option<Links>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author_association: Option<String>,
-    pub draft: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub draft: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo: Option<Repository>,
 }
@@ -83,11 +102,13 @@ pub struct Head {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct Base {
-    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
     #[serde(rename = "ref")]
     pub ref_field: String,
     pub sha: String,
-    pub user: User,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<User>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo: Option<Repository>,
 }


### PR DESCRIPTION
Fixes #125

As discussed in the PR, the `PullRequest` response in `list_runs`
does not match with the type that expects a lot of fields to not be
empty. This PR fixes by that wrapping those fields with `Option` and
thus making them optional.

As `PullRequest` also contains a field `repo` of type `Repository`
whose response also only includes only some of those fields (thus
causing error when serializing), this PR also fixes that by making
even those fields optional by wrapping them with `Option`.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
