### PR TITLE
Allow deserializing IDs as strings.

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -5,7 +5,7 @@ use std::ops::{Deref, DerefMut};
 
 use chrono::{DateTime, Utc};
 use reqwest::Url;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de, Deserializer};
 
 pub mod activity;
 pub mod events;
@@ -24,7 +24,7 @@ macro_rules! id_type {
     // creates a function named `$func_name`.
     // The `ident` designator is used for variable/function names.
     ($($name:ident),+) => {$(
-        #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+        #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
         pub struct $name(pub BaseIdType);
         impl fmt::Display for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -57,6 +57,29 @@ macro_rules! id_type {
                 &self.0
             }
         }
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where D: Deserializer<'de>
+            {
+                struct IdVisitor;
+                impl<'de> de::Visitor<'de> for IdVisitor {
+                    type Value = $name;
+                    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+                        where E: de::Error {
+                        Ok($name(value))
+                    }
+                    fn visit_str<E>(self, id: &str) -> Result<Self::Value, E>
+                        where E: de::Error {
+                        id.parse::<u64>().map(|x|$name(x)).map_err(de::Error::custom)
+                    }
+                    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                        write!(f, "expected {} as number or string", stringify!($name)) // TODO: $name
+                    }
+                }
+
+                deserializer.deserialize_any(IdVisitor)
+            }
+         }
     )+};
 }
 


### PR DESCRIPTION
Fixes #123. It turns out that the notifications API returns
NotificationIDs in JSON as strings, not integers (e.g.: `id1: "1234"`).
See for example:
https://docs.github.com/en/rest/reference/activity#list-notifications-for-the-authenticated-user--code-samples

This PR adds an explicit Deserializer for each ID type that allows
either raw integers or string-encoded integers. It fixes the behavior when I run
```
GITHUB_TOKEN=... cargo run --example notifications
```

(We could have done this just for NotificationID, but it seemed easier
to just do for every ID type, and perhaps will help future-proof this
library.)