### PR TITLE
Include the detailed errors in the `Display` implementation of `GitHubError`.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -53,7 +53,7 @@ impl fmt::Display for GitHubError {
 
         if let Some(errors) = &self.errors.as_ref().filter(|errors| !errors.is_empty()) {
             write!(f, "\nErrors:")?;
-            for error in errors {
+            for error in errors.iter() {
                 write!(f, "\n- {}", error)?;
             }
         }


### PR DESCRIPTION
This is particularly important for validation errors, where `message` will be set by GitHub to "Validation error", which does not provide any useful detail to actually troubleshoot the failing call.