### PR TITLE
Add webhook models

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -11,6 +11,7 @@ pub mod activity;
 pub mod apps;
 pub mod events;
 pub mod gists;
+pub mod hooks;
 pub mod issues;
 pub mod orgs;
 pub mod pulls;

--- a/src/models/hooks.rs
+++ b/src/models/hooks.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Hook {
+    #[serde(rename = "type")]
+    pub typ: String,
+    pub id: u64,
+    pub name: String,
+    pub events: Vec<String>,
+    pub config: Config,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ping_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deliveries_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Config {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub insecure_ssl: Option<String>,
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret: Option<String>,
+}


### PR DESCRIPTION
This adds models that are useful for creating webhooks.

The GitHub API has 2 types of webhooks - one for repositories and one for organizations. I'm not entirely sure if they differ in any way.

This should at least cover what's used for getting/creating an organization webhook.