### PR TITLE
ETagged cleanup

### DIFF
--- a/examples/create_repo_from_template.rs
+++ b/examples/create_repo_from_template.rs
@@ -4,7 +4,9 @@ use octocrab::Octocrab;
 async fn main() -> octocrab::Result<()> {
     let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env variable is required");
 
-    let octocrab = Octocrab::builder().personal_token(token.to_string()).build()?;
+    let octocrab = Octocrab::builder()
+        .personal_token(token.to_string())
+        .build()?;
 
     let repository = octocrab.repos("rust-lang", "rust-template");
     repository

--- a/src/api/actions.rs
+++ b/src/api/actions.rs
@@ -291,6 +291,21 @@ impl<'octo> ActionsHandler<'octo> {
         self.crab.get(route, None::<&()>).await
     }
 
+    /// Lists artifacts for a workflow run. Anyone with read access to the 
+    /// repository can use this endpoint. If the repository is private you 
+    /// must use an access token with the `repo` scope. GitHub Apps must have 
+    /// the `actions:read` permission to use this endpoint.
+    ///
+    /// ```no_run
+    /// octo.actions()
+    ///    .create_workflow_dispatch("org", "repo", "workflow.yaml")
+    ///    // required
+    ///    .ref_field(&ref)
+    ///    // optional
+    ///    .inputs(serde_json::json!({"my-key": "my-value"}))
+    ///    .send()
+    ///    .await?;
+    /// ```
     pub fn create_workflow_dispatch(
         &self,
         owner: impl Into<String>,

--- a/src/api/actions.rs
+++ b/src/api/actions.rs
@@ -311,11 +311,13 @@ impl<'octo> ActionsHandler<'octo> {
         owner: impl Into<String>,
         repo: impl Into<String>,
         workflow_id: impl Into<String>,
+        r#ref: impl Into<String>,
     ) -> WorkflowDispatchBuilder<'_> {
         WorkflowDispatchBuilder::new(self.crab,
             repo.into(),
             owner.into(),
-            workflow_id.into()
+            workflow_id.into(),
+            r#ref.into()
         )
     }
 }

--- a/src/api/actions.rs
+++ b/src/api/actions.rs
@@ -13,14 +13,10 @@ pub struct WorkflowDispatchBuilder<'octo> {
 }
 
 impl<'octo> WorkflowDispatchBuilder<'octo> {
-    pub(crate) fn new(crab: &'octo Octocrab, owner: String, repo: String, workflow_id: String) -> Self {
-        Self { crab, owner, repo, workflow_id, data: Default::default() }
-    }
-
-    /// Required
-    pub fn ref_field(mut self, ref_attr: impl Into<String>) -> Self {
-        self.data.ref_field = ref_attr.into();
-        self
+    pub(crate) fn new(crab: &'octo Octocrab, owner: String, repo: String, workflow_id: String, r#ref: String) -> Self {
+        let mut this = Self { crab, owner, repo, workflow_id, data: Default::default() };
+        this.data.r#ref = r#ref;
+        this
     }
 
     /// Input keys and values configured in the workflow file. The maximum number of properties is 10.

--- a/src/api/actions.rs
+++ b/src/api/actions.rs
@@ -23,7 +23,11 @@ impl<'octo> WorkflowDispatchBuilder<'octo> {
         self
     }
 
-    /// Optional
+    /// Input keys and values configured in the workflow file. The maximum number of properties is 10.
+    /// Any default properties configured in the workflow file will be used when inputs are omitted.
+    ///
+    /// # Panics
+    /// If `inputs` is not `Value::Object`.
     pub fn inputs(mut self, inputs: serde_json::Value) -> Self {
         assert!(inputs.is_object(), "Inputs should be a JSON object");
         self.data.inputs = inputs;

--- a/src/api/activity/notifications.rs
+++ b/src/api/activity/notifications.rs
@@ -1,8 +1,8 @@
 //! Github Notifications API
 
-use crate::models::{NotificationId, ThreadId};
 use crate::models::activity::Notification;
 use crate::models::activity::ThreadSubscription;
+use crate::models::{NotificationId, ThreadId};
 use crate::Octocrab;
 use crate::Page;
 
@@ -142,7 +142,7 @@ impl<'octo> NotificationsHandler<'octo> {
     /// ```
     pub async fn get_thread_subscription(
         &self,
-        thread: ThreadId
+        thread: ThreadId,
     ) -> crate::Result<ThreadSubscription> {
         let url = format!("notifications/threads/{}/subscription", thread);
 
@@ -189,10 +189,9 @@ impl<'octo> NotificationsHandler<'octo> {
     /// # }
     /// ```
     pub async fn delete_thread_subscription(&self, thread: ThreadId) -> crate::Result<()> {
-        let url = self.crab.absolute_url(format!(
-            "notifications/threads/{}/subscription",
-            thread
-        ))?;
+        let url = self
+            .crab
+            .absolute_url(format!("notifications/threads/{}/subscription", thread))?;
 
         let response = self.crab._delete(url, None::<&()>).await?;
         crate::map_github_error(response).await.map(drop)

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -5,17 +5,17 @@ use reqwest::header::ACCEPT;
 pub mod events;
 mod file;
 pub mod forks;
+mod generate;
 pub mod releases;
 mod status;
 mod tags;
-mod generate;
 
 use crate::{models, params, Octocrab, Result};
 pub use file::UpdateFileBuilder;
+pub use generate::GenerateRepositoryBuilder;
 pub use releases::ReleasesHandler;
 pub use status::CreateStatusBuilder;
 pub use tags::ListTagsBuilder;
-pub use generate::GenerateRepositoryBuilder;
 
 /// Handler for GitHub's repository API.
 ///
@@ -323,15 +323,16 @@ impl<'octo> RepoHandler<'octo> {
     ///     .await
     /// # }
     /// ```
-    pub fn generate(
-        &self,
-        name: &str,
-    ) -> GenerateRepositoryBuilder<'_, '_> {
+    pub fn generate(&self, name: &str) -> GenerateRepositoryBuilder<'_, '_> {
         GenerateRepositoryBuilder::new(self, name)
     }
 
     /// Retrieve the contents of a file in raw format
-    pub async fn raw_file(self, reference: impl Into<params::repos::Commitish>, path: impl AsRef<str>) -> Result<reqwest::Response> {
+    pub async fn raw_file(
+        self,
+        reference: impl Into<params::repos::Commitish>,
+        path: impl AsRef<str>,
+    ) -> Result<reqwest::Response> {
         let url = self.crab.absolute_url(format!(
             "repos/{owner}/{repo}/contents/{path}",
             owner = self.owner,
@@ -362,7 +363,10 @@ impl<'octo> RepoHandler<'octo> {
     }
 
     /// Stream the repository contents as a .tar.gz
-    pub async fn download_tarball(&self, reference: impl Into<params::repos::Commitish>) -> Result<reqwest::Response> {
+    pub async fn download_tarball(
+        &self,
+        reference: impl Into<params::repos::Commitish>,
+    ) -> Result<reqwest::Response> {
         let url = self.crab.absolute_url(format!(
             "repos/{owner}/{repo}/tarball/{reference}",
             owner = self.owner,

--- a/src/api/repos/generate.rs
+++ b/src/api/repos/generate.rs
@@ -1,4 +1,4 @@
-use crate::{Error, repos::RepoHandler};
+use crate::{repos::RepoHandler, Error};
 
 #[derive(serde::Serialize)]
 pub struct GenerateRepositoryBuilder<'octo, 'r> {
@@ -58,16 +58,18 @@ impl<'octo, 'r> GenerateRepositoryBuilder<'octo, 'r> {
             owner = self.handler.owner,
             repo = self.handler.repo
         );
-        let request = self.handler
+        let request = self
+            .handler
             .crab
             .client
             .post(self.handler.crab.absolute_url(url)?)
             .body(serde_json::to_string(&self).unwrap())
-            .header(reqwest::header::ACCEPT, "application/vnd.github.baptiste-preview+json");
+            .header(
+                reqwest::header::ACCEPT,
+                "application/vnd.github.baptiste-preview+json",
+            );
 
         let response = self.handler.crab.execute(request).await?;
-        crate::map_github_error(response)
-            .await
-            .map(drop)
+        crate::map_github_error(response).await.map(drop)
     }
 }

--- a/src/api/teams/create.rs
+++ b/src/api/teams/create.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::params;
 use crate::models::TeamId;
+use crate::params;
 
 #[derive(serde::Serialize)]
 pub struct CreateTeamBuilder<'octo, 'h, 'a, 'b> {

--- a/src/api/teams/edit.rs
+++ b/src/api/teams/edit.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::params;
 use crate::models::TeamId;
+use crate::params;
 
 #[derive(serde::Serialize)]
 pub struct EditTeamBuilder<'octo, 'r> {

--- a/src/models/events/payload.rs
+++ b/src/models/events/payload.rs
@@ -23,9 +23,9 @@ pub use member::*;
 pub use pull_request::*;
 pub use pull_request_review_comment::*;
 pub use push::*;
-pub use workflow_run::*;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
+pub use workflow_run::*;
 
 /// The payload in an event type.
 ///

--- a/src/models/events/payload/pull_request.rs
+++ b/src/models/events/payload/pull_request.rs
@@ -63,9 +63,9 @@ pub struct PullRequestEventChangesFrom {
 
 #[cfg(test)]
 mod test {
-    use serde_json::json;
     use super::{PullRequestChanges, PullRequestEventAction, PullRequestEventChangesFrom};
     use crate::models::events::{payload::EventPayload, Event};
+    use serde_json::json;
 
     #[test]
     fn should_deserialize_action_from_snake_case() {

--- a/src/models/workflows.rs
+++ b/src/models/workflows.rs
@@ -97,7 +97,6 @@ pub struct Step {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[non_exhaustive]
 pub struct WorkflowDispatch {
-    #[serde(rename = "ref")]
-    pub ref_field: String,
+    pub r#ref: String,
     pub inputs: serde_json::Value,
 }

--- a/src/models/workflows.rs
+++ b/src/models/workflows.rs
@@ -93,3 +93,11 @@ pub struct Step {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<chrono::DateTime<chrono::Utc>>,
 }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
+pub struct WorkflowDispatch {
+    #[serde(rename = "ref")]
+    pub ref_field: String,
+    pub inputs: serde_json::Value,
+}


### PR DESCRIPTION
This cleans up some of the duplicated code around creating ETagged pages, should be merged after #153 #151

Previously there was some boilerplate code around this, this should make it easier to make a few more requests ETagged with minimal code duplication.

Essentially this adds a `FromResponse` implementation for `Etagged<Page<T>>` and an `_get_with_etag` helper.