### PR TITLE
Fix request_installation_auth_token

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -783,7 +783,7 @@ impl Octocrab {
             let result =
                 self.client
                     .post(self.absolute_url(format!(
-                        "/app/installations/{}/access_tokens",
+                        "app/installations/{}/access_tokens",
                         installation
                     ))?)
                     .bearer_auth(app.generate_bearer_token()?)


### PR DESCRIPTION
request_installation_auth_token fails when base_url is like `https://hostname/api/v3`.
This PR fixes this issue.