### PR TITLE
Add endpoint for getting repo metrics

### DIFF
--- a/examples/get_repo.rs
+++ b/examples/get_repo.rs
@@ -8,7 +8,7 @@ async fn main() -> octocrab::Result<()> {
 
     let repo = octocrab.repos("rust-lang", "rust").get().await?;
 
-    let repo_metrics = octocrab.repos("rust-lang", "rust").get_metrics().await?;
+    let repo_metrics = octocrab.repos("rust-lang", "rust").get_community_profile_metrics().await?;
 
     println!(
         "{} has {} stars and {}% health percentage",

--- a/examples/get_repo.rs
+++ b/examples/get_repo.rs
@@ -8,10 +8,13 @@ async fn main() -> octocrab::Result<()> {
 
     let repo = octocrab.repos("rust-lang", "rust").get().await?;
 
+    let repo_metrics = octocrab.repos("rust-lang", "rust").get_metrics().await?;
+
     println!(
-        "{} has {} stars",
+        "{} has {} stars and {}% health percentage",
         repo.full_name.unwrap(),
-        repo.stargazers_count.unwrap_or(0)
+        repo.stargazers_count.unwrap_or(0),
+        repo_metrics.health_percentage
     );
 
     Ok(())

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -66,6 +66,22 @@ impl<'octo> RepoHandler<'octo> {
         self.crab.get(url, None::<&()>).await
     }
 
+
+    /// Fetches a repository's metrics.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let repo = octocrab::instance()
+    ///     .repos("owner", "repo")
+    ///     .get_metrics()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_metrics(&self) -> Result<models::RepositoryMetrics> {
+        let url = format!("repos/{owner}/{repo}/community/profile", owner = self.owner, repo = self.repo,);
+        self.crab.get(url, None::<&()>).await
+    }
+
     /// Fetches a single reference in the Git database.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -77,7 +77,7 @@ impl<'octo> RepoHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_metrics(&self) -> Result<models::RepositoryMetrics> {
+    pub async fn get_community_profile_metrics(&self) -> Result<models::RepositoryMetrics> {
         let url = format!("repos/{owner}/{repo}/community/profile", owner = self.owner, repo = self.repo,);
         self.crab.get(url, None::<&()>).await
     }

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -72,7 +72,7 @@ impl<'octo> RepoHandler<'octo> {
     /// # async fn run() -> octocrab::Result<()> {
     /// let repo = octocrab::instance()
     ///     .repos("owner", "repo")
-    ///     .get_metrics()
+    ///     .get_community_profile_metrics()
     ///     .await?;
     /// # Ok(())
     /// # }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,6 @@
 //! Serde mappings from GitHub's JSON to structs.
 
+use std::collections::HashMap;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 
@@ -521,6 +522,25 @@ pub struct Repository {
     pub network_count: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub license: Option<License>,
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RepositoryFile {
+    pub name : Option<String>,
+    pub key: Option<String>,
+    pub url : Option<Url>,
+    pub html_url : Option<Url>,
+}
+
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RepositoryMetrics {
+    pub health_percentage : u64,
+    pub description: Option<String>,
+    pub documentation : Option<String>,
+    pub files: HashMap<String, Option<RepositoryFile>>,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub content_reports_enabled: Option<bool>
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This PR adds support for getting repository metrics : `/repos/{owner}/{repo}/community/profile`



Note : I'm not sure what the guide for contributing is but please, let me know if my PR is missing something.