### PR TITLE
Get file contents when inlined by GitHub

### DIFF
--- a/examples/get_content.rs
+++ b/examples/get_content.rs
@@ -17,5 +17,15 @@ async fn main() -> octocrab::Result<()> {
         content.items.into_iter().count()
     );
 
+    let file_data = octocrab
+        .repos("rust-lang", "rust")
+        .get_content()
+        .path("Cargo.toml")
+        .send()
+        .await?
+        .file_data()?
+        .unwrap();
+    println!("Cargo.tmpl:\n{}", String::from_utf8(file_data).unwrap());
+
     Ok(())
 }


### PR DESCRIPTION
On get_content, when the path is a file,  github response includes the actual file contents (unless it's too large) using the enconding and content fields.  Check https://docs.github.com/en/rest/reference/repos#get-repository-content for an example

This PR adds a (hopefully) quick way to get the data from the response.