### PR TITLE
Bump jsonwebtoken to version 8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ once_cell = "1.7.2"
 arc-swap = "1.3.0"
 base64 = "0.13.0"
 bytes = "1.0.1"
-jsonwebtoken = "7"
+jsonwebtoken = "8"
 futures-core = { version = "0.3.15", optional = true }
 futures-util = { version = "0.3.15", optional = true }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4,17 +4,26 @@ use crate::models::AppId;
 use crate::Result;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use serde::Serialize;
+use std::fmt;
 use std::time::SystemTime;
 
 use snafu::*;
 
 /// The data necessary to authenticate as a Github App
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AppAuth {
     /// Github's app ID
     pub app_id: AppId,
     /// The app's RSA private key
     pub key: EncodingKey,
+}
+
+impl fmt::Debug for AppAuth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AppAuth")
+            .field("app_id", &self.app_id)
+            .finish_non_exhaustive()
+    }
 }
 
 /// The forms of authentication we support


### PR DESCRIPTION
jsonwebtoken did drop its Debug impl on EncodingKey. The MSRV to use finish_non_exhaustive here is 1.53. Not entirely sure if that's acceptable to you.