### PR TITLE
fix: unified to use raw identifier instead of rename

### DIFF
--- a/src/models/activity.rs
+++ b/src/models/activity.rs
@@ -40,8 +40,7 @@ pub struct Subject {
     pub title: String,
     pub url: Option<Url>,
     pub latest_comment_url: Option<Url>,
-    #[serde(rename = "type")]
-    pub type_: String,
+    pub r#type: String,
 }
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]

--- a/src/models/hooks.rs
+++ b/src/models/hooks.rs
@@ -3,8 +3,7 @@ use super::*;
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Hook {
-    #[serde(rename = "type")]
-    pub typ: String,
+    pub r#type: String,
     pub id: u64,
     pub name: String,
     pub events: Vec<String>,


### PR DESCRIPTION
I found an implementation that uses [serde(rename)](https://serde.rs/field-attrs.html#rename) to use the `type` key, but the rest of the code basically uses the [raw identifiers](https://doc.rust-lang.org/rust-by-example/compatibility/raw_identifiers.html), so it needs to be fixed to align the implementation.