### PR TITLE
Support for Updating gists via PATCH

### DIFF
--- a/src/api/gists.rs
+++ b/src/api/gists.rs
@@ -18,6 +18,7 @@ impl<'octo> GistsHandler<'octo> {
     }
 
     /// Create a new gist.
+    ///
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
     /// let gitignore = octocrab::instance()
@@ -37,6 +38,7 @@ impl<'octo> GistsHandler<'octo> {
     }
 
     /// Update an existing gist.
+    ///
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
     /// let gitignore = octocrab::instance()
@@ -59,6 +61,7 @@ impl<'octo> GistsHandler<'octo> {
     }
 
     /// Get a single gist.
+    ///
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
     /// let gist = octocrab::instance().gists().get("00000000000000000000000000000000").await?;
@@ -85,16 +88,19 @@ impl<'octo> CreateGistBuilder<'octo> {
         }
     }
 
+    /// Set a description for the gist to be created.
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.data.description = Some(description.into());
         self
     }
 
+    /// Set the `public` flag of the gist to be created.
     pub fn public(mut self, public: bool) -> Self {
         self.data.public = Some(public);
         self
     }
 
+    /// Add a file to the gist with `filename` and `content`.
     pub fn file(mut self, filename: impl Into<String>, content: impl Into<String>) -> Self {
         let file = CreateGistFile {
             filename: Default::default(),
@@ -104,6 +110,7 @@ impl<'octo> CreateGistBuilder<'octo> {
         self
     }
 
+    /// Send the `CreateGist` request to Github for execution.
     pub async fn send(self) -> Result<Gist> {
         self.crab.post("gists", Some(&self.data)).await
     }
@@ -140,15 +147,21 @@ impl<'octo> UpdateGistBuilder<'octo> {
             data: Default::default()
         }
     }
-   
+
+    /// Update the description of the the gist with the content provided by `description`.
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.data.description = Some(description.into());
         self
     }
 
+    /// Update the file with the `filename`. 
+    ///
+    /// The update operation is chosen in further calls to the returned builder.
     pub fn file(self, filename: impl Into<String>) -> UpdateGistFileBuilder<'octo> {
         UpdateGistFileBuilder::new(self, filename)
     }
+
+    /// Send the `UpdateGist` command to Github for execution.
     pub async fn send(self) -> Result<Gist> {
         self.crab.patch(self.gist_path, Some(&self.data)).await
     }
@@ -187,29 +200,41 @@ impl<'octo> UpdateGistFileBuilder<'octo> {
         self.builder
     }
 
+    /// Delete the file from the gist.
     pub fn delete(mut self) -> UpdateGistBuilder<'octo> {
         self.file = None;
         self.build()
     }
 
+    /// Rename the file to `filename`.
     pub fn rename_to(mut self, filename: impl Into<String>) -> Self {
         self.file.get_or_insert_with(Default::default).filename = Some(filename.into());
         self
     }
 
+    /// Update the content of the file and overwrite it with `content`.
     pub fn with_content(mut self, content: impl Into<String>) -> Self {
         self.file.get_or_insert_with(Default::default).content = Some(content.into());
         self
     }
 
+    /// Overwrite the Description of the gist with `description`.
+    ///
+    /// This will finalize the update operation and will continue to operate on the gist itself.
     pub fn description(self, description: impl Into<String>) -> UpdateGistBuilder<'octo> {
         self.build().description(description)
     }
 
+    /// Update the next file identified by `filename`.
+    ///
+    /// This will finalize the update operation and will continue to operate on the gist itself.
     pub fn file(self, filename: impl Into<String>) -> UpdateGistFileBuilder<'octo> {
         self.build().file(filename)
     }
 
+    /// Send the `UpdateGist` command to Github for execution.
+    /// 
+    /// This will finalize the update operation before sending.
     pub async fn send(self) -> Result<Gist> {
         self.build().send().await
     }

--- a/src/api/gists.rs
+++ b/src/api/gists.rs
@@ -36,6 +36,28 @@ impl<'octo> GistsHandler<'octo> {
         CreateGistBuilder::new(self.crab)
     }
 
+    /// Update an existing gist.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let gitignore = octocrab::instance()
+    ///   .gists()
+    ///   .update("aa5a315d61ae9438b18d")
+    ///   // Optional Parameters
+    ///   .description("Updated!")
+    ///   .file("hello_world.rs")
+    ///   .rename_to("fibonacci.rs")
+    ///   .with_content("fn main() {\n println!(\"I should be a Fibonacci!\");\n}")
+    ///   .file("delete_me.rs")
+    ///   .delete()
+    ///   .send()
+    ///   .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn update(&self, id: impl AsRef<str>) -> UpdateGistBuilder<'octo> {
+        UpdateGistBuilder::new(self.crab, format!("gists/{id}", id=id.as_ref()))
+    }
+
     /// Get a single gist.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
@@ -101,4 +123,94 @@ struct CreateGistFile {
     #[serde(skip_serializing_if = "Option::is_none")]
     filename: Option<String>,
     content: String,
+}
+
+#[derive(Debug)]
+pub struct UpdateGistBuilder<'octo> {
+    crab: &'octo Octocrab,
+    gist_path: String,
+    data: UpdateGist
+}
+
+impl<'octo> UpdateGistBuilder<'octo> {
+    fn new(crab: &'octo Octocrab, gist_path: String) -> Self {
+        Self {
+            crab,
+            gist_path,
+            data: Default::default()
+        }
+    }
+   
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.data.description = Some(description.into());
+        self
+    }
+
+    pub fn file(self, filename: impl Into<String>) -> UpdateGistFileBuilder<'octo> {
+        UpdateGistFileBuilder::new(self, filename)
+    }
+    pub async fn send(self) -> Result<Gist> {
+        self.crab.patch(self.gist_path, Some(&self.data)).await
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+struct UpdateGist {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    files: Option<BTreeMap<String, Option<UpdateGistFile>>>
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct UpdateGistFile {
+    filename: Option<String>,
+    content: Option<String>
+}
+
+pub struct UpdateGistFileBuilder<'octo> {
+    builder: UpdateGistBuilder<'octo>,
+    filename: String,
+    file: Option<UpdateGistFile>
+}
+impl<'octo> UpdateGistFileBuilder<'octo> {
+    fn new(builder: UpdateGistBuilder<'octo>, filename: impl Into<String>) -> Self {
+        Self {
+            builder,
+            filename: filename.into(),
+            file: None
+        }
+    }
+
+    fn build(mut self) -> UpdateGistBuilder<'octo> {
+        self.builder.data.files.get_or_insert_with(BTreeMap::new).insert(self.filename, self.file);
+        self.builder
+    }
+
+    pub fn delete(mut self) -> UpdateGistBuilder<'octo> {
+        self.file = None;
+        self.build()
+    }
+
+    pub fn rename_to(mut self, filename: impl Into<String>) -> Self {
+        self.file.get_or_insert_with(Default::default).filename = Some(filename.into());
+        self
+    }
+
+    pub fn with_content(mut self, content: impl Into<String>) -> Self {
+        self.file.get_or_insert_with(Default::default).content = Some(content.into());
+        self
+    }
+
+    pub fn description(self, description: impl Into<String>) -> UpdateGistBuilder<'octo> {
+        self.build().description(description)
+    }
+
+    pub fn file(self, filename: impl Into<String>) -> UpdateGistFileBuilder<'octo> {
+        self.build().file(filename)
+    }
+
+    pub async fn send(self) -> Result<Gist> {
+        self.build().send().await
+    }
 }

--- a/src/api/gists.rs
+++ b/src/api/gists.rs
@@ -184,36 +184,44 @@ pub struct UpdateGistFile {
 pub struct UpdateGistFileBuilder<'octo> {
     builder: UpdateGistBuilder<'octo>,
     filename: String,
-    file: Option<UpdateGistFile>
+    file: Option<UpdateGistFile>,
+    ready: bool
 }
+
 impl<'octo> UpdateGistFileBuilder<'octo> {
     fn new(builder: UpdateGistBuilder<'octo>, filename: impl Into<String>) -> Self {
         Self {
             builder,
             filename: filename.into(),
-            file: None
+            file: None,
+            ready: false
         }
     }
 
     fn build(mut self) -> UpdateGistBuilder<'octo> {
-        self.builder.data.files.get_or_insert_with(BTreeMap::new).insert(self.filename, self.file);
+        if self.ready {
+            self.builder.data.files.get_or_insert_with(BTreeMap::new).insert(self.filename, self.file);
+        }
         self.builder
     }
 
     /// Delete the file from the gist.
     pub fn delete(mut self) -> UpdateGistBuilder<'octo> {
+        self.ready = true;
         self.file = None;
         self.build()
     }
 
     /// Rename the file to `filename`.
     pub fn rename_to(mut self, filename: impl Into<String>) -> Self {
+        self.ready = true;
         self.file.get_or_insert_with(Default::default).filename = Some(filename.into());
         self
     }
 
     /// Update the content of the file and overwrite it with `content`.
     pub fn with_content(mut self, content: impl Into<String>) -> Self {
+        self.ready = true;
         self.file.get_or_insert_with(Default::default).content = Some(content.into());
         self
     }


### PR DESCRIPTION
I did not add any tests, but this is according to the [github api reference](https://github.com/github/rest-api-description/blob/main/descriptions/api.github.com/api.github.com.yaml).

This has been manually tested against the github API and verified to be working.

I chose a fluent style for the builders. What might be controversial is the way updates to files are implemented, as the different update operations are too complex to sanely encode in a single builder method, i chose to switch with the `.file("filename")` method to a builder of an update operation on the file which exposes the same methods as the `UpdateGistBuilder` and delegates those to the this builder.