### PR TITLE
Add gist commit list and revisions

### DIFF
--- a/src/api/gists/list_commits.rs
+++ b/src/api/gists/list_commits.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+#[derive(serde::Serialize)]
+pub struct ListCommitsBuilder<'octo, 'b> {
+    #[serde(skip)]
+    handler: &'b GistsHandler<'octo>,
+    #[serde(skip)]
+    gist_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+}
+
+impl<'octo, 'b> ListCommitsBuilder<'octo, 'b> {
+    pub(crate) fn new(handler: &'b GistsHandler<'octo>, gist_id: String) -> Self {
+        Self {
+            handler,
+            gist_id,
+            per_page: None,
+            page: None,
+        }
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.page = Some(page.into());
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(self) -> crate::Result<crate::Page<crate::models::gists::GistCommit>> {
+        let url = format!("gists/{gist_id}/commits", gist_id = self.gist_id);
+        self.handler.crab.get(url, Some(&self)).await
+    }
+}
+

--- a/src/models/gists.rs
+++ b/src/models/gists.rs
@@ -31,3 +31,35 @@ pub struct GistFile {
     pub size: u64,
     pub truncated: bool,
 }
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize)]
+pub struct GistCommit {
+    pub user: User,
+    pub version: String,
+    pub committed_at: DateTime<Utc>,
+    pub change_status: GistChangeStatus,
+    pub url: Url
+}
+
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize)]
+pub struct GistChangeStatus {
+    pub total: u64,
+    pub additions: u64,
+    pub deletions: u64
+}
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize)]
+pub struct GistRevision {
+    pub id: String,
+    pub node_id: String,
+    pub public: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub description: Option<String>,
+    pub files: BTreeMap<String, GistFile>,
+    pub url: Url,
+}


### PR DESCRIPTION
Hi,

This adds support for the [list gist commits][1] and [get gist revision][2] API endpoints.

Thanks!

[1]: https://docs.github.com/en/rest/reference/gists#list-gist-commits
[2]: https://docs.github.com/en/rest/reference/gists#get-a-gist-revision