### PR TITLE
Make gist commit user and change status nullable

### DIFF
--- a/src/models/gists.rs
+++ b/src/models/gists.rs
@@ -46,9 +46,9 @@ pub struct GistCommit {
 #[non_exhaustive]
 #[derive(Debug, Deserialize)]
 pub struct GistChangeStatus {
-    pub total: u64,
-    pub additions: u64,
-    pub deletions: u64
+    pub total: Option<u64>,
+    pub additions: Option<u64>,
+    pub deletions: Option<u64>
 }
 
 #[non_exhaustive]

--- a/src/models/gists.rs
+++ b/src/models/gists.rs
@@ -35,7 +35,7 @@ pub struct GistFile {
 #[non_exhaustive]
 #[derive(Debug, Deserialize)]
 pub struct GistCommit {
-    pub user: User,
+    pub user: Option<User>,
     pub version: String,
     pub committed_at: DateTime<Utc>,
     pub change_status: GistChangeStatus,


### PR DESCRIPTION
Hi, it seems gist commit `change_status` values and `user` can be null, this fixes that.

Thanks