### PR TITLE
Ensure nullable user on pull request comments can be parsed

### DIFF
--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -239,7 +239,7 @@ pub struct Comment {
     pub original_commit_id: String,
     #[serde(default)]
     pub in_reply_to_id: Option<u64>,
-    pub user: User,
+    pub user: Option<User>,
     pub body: String,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,


### PR DESCRIPTION
Ensures pull request comments can still be parsed properly in case the user of a comment is set to null. This seems to happen for comments of deleted users.

Fixes #205. 