### PR TITLE
Adjust JWT token issuance and expiration times to allow some clock drift while authenticating with App API

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -59,10 +59,13 @@ pub fn create_jwt(
 
     let now = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs() as usize;
 
+    // Github only allows JWTs that expire in the next 10 minutes.
+    // The token is issued 60 seconds in the past and expires in 9 minutes,
+    // to allow some clock drift.
     let claims = Claims {
         iss: github_app_id,
-        iat: now,
-        exp: now + (10 * 60),
+        iat: now - 60,
+        exp: now + (9 * 60),
     };
 
     let header = Header::new(Algorithm::RS256);


### PR DESCRIPTION
The following is conjecture on my part but the fix appears to be working.

`create_jwt` in `auth.rs` creates a JWT which expires in exactly 10 minutes. GitHub only accepts tokens that expire in less than 10 minutes, so if your clock is too far ahead of GitHub's servers you'll generate one which will immediately get rejected.

The funny part is that if your clock offset and latency are just right, you'll only get occasional failures, which is very fun to debug.

Adjusting IAT was taken from [the GitHub docs](https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-a-github-app), idea to have token expire in 9 minutes was suggested [here](https://github.com/probot/probot/issues/942).  


Thanks for creating this library, other than this issue I'm having a good time working with it.


