### PR TITLE
Update dependencies to fix some warnings from cargo audit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/octocrab"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-reqwest = { version = "0.11.3", default-features = false, features = ["json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["json"] }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 serde_path_to_error = "0.1.4"
@@ -34,7 +34,7 @@ futures-util = { version = "0.3.15", optional = true }
 secrecy = "0.8.0"
 
 [dev-dependencies]
-tokio = { version = "1.6.1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.17.0", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 wiremock = "0.5.3"
 
 [features]


### PR DESCRIPTION
This updates the dep versions for `reqwest` and `tokio`.

This doesn't fix all the issues, because this crate still depends on chrono 0.4.19, which as a potential segfault. But there's no newer version of chrono yet. See https://github.com/chronotope/chrono/issues/674 for discussion of the 0.4.20 release.
