### PR TITLE
Add a function that exposes the installation token

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,6 +467,21 @@ impl Octocrab {
             },
         }
     }
+
+    /// Similar to `installation`, but also eagerly caches the installation
+    /// token and returns the token. The returned token can be used to make
+    /// https git requests to e.g. clone repositories that the installation
+    /// has access to.
+    ///
+    /// See also https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#http-based-git-access-by-an-installation
+    pub async fn installation_and_token(
+        &self,
+        id: InstallationId,
+    ) -> Result<(Octocrab, SecretString)> {
+        let crab = self.installation(id);
+        let token = crab.request_installation_auth_token().await?;
+        Ok((crab, token))
+    }
 }
 
 /// # GitHub API Methods


### PR DESCRIPTION
You can use the installation token to access git repos using a regular git
client, so it's useful to expose this beyong the octocrab client once it
has been generated.

I've added a `installation_and_token` function which calls `installation` to
create an `Octocrab` instance for the installation and also forces the cache
of the installation token to be populated then returns both. This means that
the user has to get the token at the same time as they're getting the
installation client. But also that you can't try and get an installation
token from a client that isn't configured for authorising as an installation.