### PR TITLE
Add list_files to pull API for getting pull request file diffs

### DIFF
--- a/src/api/pulls.rs
+++ b/src/api/pulls.rs
@@ -239,6 +239,23 @@ impl<'octo> PullRequestHandler<'octo> {
         self.http_get(url, None::<&()>).await
     }
 
+    /// List all `FileDiff`s associated with the pull request.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let files = octocrab::instance().pulls("owner", "repo").list_files(101).await?;
+    /// # Ok(())
+    /// # }
+    pub async fn list_files(&self, pr: u64) -> crate::Result<Page<crate::models::pulls::FileDiff>> {
+        let url = format!(
+            "repos/{owner}/{repo}/pulls/{pr}/files",
+            owner = self.owner,
+            repo = self.repo,
+            pr = pr
+        );
+
+        self.http_get(url, None::<&()>).await
+    }
+
     /// Creates a new `ListCommentsBuilder` that can be configured to list and
     /// filter `Comments` for a particular pull request. If no pull request is
     /// specified, lists comments for the whole repo.

--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -355,6 +355,35 @@ pub enum MergeableState {
     Unstable,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FileDiff {
+    pub sha: String,
+    pub filename: String,
+    pub status: FileDiffStatus,
+    pub additions: u64,
+    pub deletions: u64,
+    pub changes: u64,
+    pub blob_url: Url,
+    pub raw_url: Url,
+    pub contents_url: Url,
+    pub patch: Option<String>,
+    pub previous_filename: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum FileDiffStatus {
+    Added,
+    Removed,
+    Modified,
+    Renamed,
+    Copied,
+    Changed,
+    Unchanged,
+}
+
 #[cfg(test)]
 mod test {
     #[test]


### PR DESCRIPTION
Wrapper for GET `/repos/{owner}/{repo}/pulls/{pull_number}/files`,
using Page<> as appropriate.

New model is based off the API specification here:

https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files

According to that, the only optional fields are patch and
previous_filename.