### PR TITLE
Feature/api rate limit

### DIFF
--- a/examples/get_rate_limit.rs
+++ b/examples/get_rate_limit.rs
@@ -1,0 +1,13 @@
+use octocrab::Octocrab;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ratelimit = octocrab::instance().ratelimit().get().await?;
+    println!("{}", serde_json::to_string_pretty(&ratelimit)?);
+
+    let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env variable is required");
+    let octocrab = Octocrab::builder().personal_token(token).build()?;
+    let ratelimit = octocrab.ratelimit().get().await?;
+    println!("{}", serde_json::to_string_pretty(&ratelimit)?);
+    Ok(())
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,6 +10,7 @@ pub mod licenses;
 pub mod markdown;
 pub mod orgs;
 pub mod pulls;
+pub mod ratelimit;
 pub mod repos;
 pub mod search;
 pub mod teams;

--- a/src/api/ratelimit.rs
+++ b/src/api/ratelimit.rs
@@ -1,0 +1,30 @@
+//! Github RateLimit API
+
+use crate::{models, Octocrab, Result};
+
+/// Handler for GitHub's rate_limit API.
+///
+/// Created with [`Octocrab::ratelimit`].
+pub struct RateLimitHandler<'octo> {
+    crab: &'octo Octocrab,
+}
+
+impl<'octo> RateLimitHandler<'octo> {
+    pub(crate) fn new(crab: &'octo Octocrab) -> Self {
+        Self { crab }
+    }
+
+    /// Get the rate limit.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let ratelimit = octocrab::instance()
+    ///     .ratelimit()
+    ///     .get()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get(&self) -> Result<models::RateLimit> {
+        self.crab.get("rate_limit", None::<&()>).await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ use models::{AppId, InstallationId, InstallationToken};
 pub use self::{
     api::{
         actions, activity, apps, current, events, gists, gitignore, issues, licenses, markdown,
-        orgs, pulls, repos, search, teams, workflows,
+        orgs, pulls, repos, search, teams, workflows, ratelimit,
     },
     error::{Error, GitHubError},
     from_response::FromResponse,
@@ -573,6 +573,11 @@ impl Octocrab {
     /// GitHub's Gists API.
     pub fn gists(&self) -> gists::GistsHandler {
         gists::GistsHandler::new(self)
+    }
+
+    /// Creates a [`ratelimit::RateLimitHandler`] that returns the API rate limit.
+    pub fn ratelimit(&self) -> ratelimit::RateLimitHandler {
+        ratelimit::RateLimitHandler::new(self)
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -759,3 +759,30 @@ pub struct PublicKey {
     pub key_id: String,
     pub key: String,
 }
+
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RateLimit {
+    pub resources: Resources,
+    pub rate:      Rate,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Resources {
+    pub core:                        Rate,
+    pub search:                      Rate,
+    pub graphql:                     Option<Rate>,
+    pub integration_manifest:        Option<Rate>,
+    pub scim:                        Option<Rate>,
+    pub source_import:               Option<Rate>,
+    pub code_scanning_upload:        Option<Rate>,
+    pub actions_runner_registration: Option<Rate>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Rate {
+    pub limit:     usize,
+    pub used:      usize,
+    pub remaining: usize,
+    pub reset:     usize,
+}


### PR DESCRIPTION
Hi, this pr adds support for the `rate_limit` api: https://docs.github.com/en/rest/reference/rate-limit.

Closes #176