### PR TITLE
Fix absolute API path for workflow API to support path prefixed base_url

### DIFF
--- a/src/api/workflows.rs
+++ b/src/api/workflows.rs
@@ -254,7 +254,7 @@ impl<'octo, 'b> ListRunsBuilder<'octo, 'b> {
     pub async fn send(self) -> Result<Page<models::workflows::Run>> {
         let url = match self.r#type {
             ListRunsRequestType::ByRepo => format!(
-                "/repos/{owner}/{repo}/actions/runs",
+                "repos/{owner}/{repo}/actions/runs",
                 owner = self.handler.owner,
                 repo = self.handler.repo
             ),


### PR DESCRIPTION
related fix: https://github.com/XAMPPRocky/octocrab/pull/74

The current implementation of workflow runs API does not consider `base_url` that has a path prefix.

https://github.com/XAMPPRocky/octocrab/blob/807b501c0e3e67bc52b98d9a69f594e78ad982f4/src/api/workflows.rs#L253-L270

This PR modifies that path fixed in the same way as the related PR, so that it can use a path prefix.
