### PR TITLE
fix: Type changes in PullRequestEvent correctly

### DIFF
--- a/src/models/events/payload/pull_request.rs
+++ b/src/models/events/payload/pull_request.rs
@@ -58,7 +58,7 @@ pub enum PullRequestChanges {
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub struct PullRequestEventChangesFrom {
-    pub from: String,
+    pub from: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/models/events/payload/pull_request.rs
+++ b/src/models/events/payload/pull_request.rs
@@ -12,7 +12,7 @@ pub struct PullRequestEventPayload {
     /// The pull request this event corresponds to.
     pub pull_request: PullRequest,
     /// The changes to body or title if this event is of type [`PullRequestEventAction::Edited`].
-    pub changes: Option<PullRequestEventChangesFrom>,
+    pub changes: Option<PullRequestChanges>,
 }
 
 /// The action on a pull request this event corresponds to.
@@ -45,11 +45,10 @@ pub enum PullRequestEventAction {
 
 /// The change which occurred in an event of type [`PullRequestEventAction::Edited`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
 #[non_exhaustive]
-pub enum PullRequestChanges {
-    Title(PullRequestEventChangesFrom),
-    Body(PullRequestEventChangesFrom),
+pub struct PullRequestChanges {
+    title: Option<PullRequestEventChangesFrom>,
+    body: Option<PullRequestEventChangesFrom>,
 }
 
 /// The previous value of the item (either the body or title) of a pull request which has changed. Only
@@ -58,7 +57,7 @@ pub enum PullRequestChanges {
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub struct PullRequestEventChangesFrom {
-    pub from: Option<String>,
+    pub from: String,
 }
 
 #[cfg(test)]
@@ -104,9 +103,12 @@ mod test {
         let deserialized = serde_json::from_value::<PullRequestChanges>(json).unwrap();
         assert_eq!(
             deserialized,
-            PullRequestChanges::Title(PullRequestEventChangesFrom {
-                from: "test".to_owned()
-            })
+            PullRequestChanges {
+                title: Some(PullRequestEventChangesFrom {
+                    from: "test".to_owned()
+                }),
+                body: None,
+            },
         );
     }
 
@@ -120,9 +122,25 @@ mod test {
         let deserialized = serde_json::from_value::<PullRequestChanges>(json).unwrap();
         assert_eq!(
             deserialized,
-            PullRequestChanges::Body(PullRequestEventChangesFrom {
-                from: "test".to_owned()
-            })
+            PullRequestChanges {
+                title: None,
+                body: Some(PullRequestEventChangesFrom {
+                    from: "test".to_owned()
+                }),
+            },
+        );
+    }
+
+    #[test]
+    fn should_deserialize_empty_changes() {
+        let json = json!({});
+        let deserialized = serde_json::from_value::<PullRequestChanges>(json).unwrap();
+        assert_eq!(
+            deserialized,
+            PullRequestChanges {
+                title: None,
+                body: None,
+            },
         );
     }
 


### PR DESCRIPTION
Closes #227 

Both `title` and `body` in `changes` object can be undefined, so typing by `Option<PullRequestEventChangesFrom>` resolves the issue.