### PR TITLE
feat: Add in "Basic" Auth option

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -31,6 +31,13 @@ impl fmt::Debug for AppAuth {
 pub enum Auth {
     /// No authentication
     None,
+    // Basic authentication
+    Basic{
+        /// The username
+        username: String,
+        /// The password
+        password: String,
+    },
     /// Authenticate using a Github personal access token
     PersonalToken(SecretString),
     /// Authenticate as a Github App

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -31,11 +31,11 @@ impl fmt::Debug for AppAuth {
 pub enum Auth {
     /// No authentication
     None,
-    // Basic authentication
+    // Basic HTTP authentication (username:password)
     Basic{
-        /// The username
+        /// Username
         username: String,
-        /// The password
+        /// Password
         password: String,
     },
     /// Authenticate using a Github personal access token

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,6 +299,13 @@ impl OctocrabBuilder {
         self
     }
 
+    /// Authenticate as a Basic Auth
+    /// username and password
+    pub fn basic_auth(mut self, username: String, password: String) -> Self {
+        self.auth = Auth::Basic{ username, password };
+        self
+    }
+
     /// Set the base url for `Octocrab`.
     pub fn base_url(mut self, base_url: impl reqwest::IntoUrl) -> Result<Self> {
         self.base_url = Some(base_url.into_url().context(crate::error::HttpSnafu)?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,7 @@ impl OctocrabBuilder {
             Auth::PersonalToken(token) => {
                 hmap.append(
                     reqwest::header::AUTHORIZATION,
-                    (String::from("token ") + token.expose_secret())
+                    (String::from("Basic ") + token.expose_secret())
                         .parse()
                         .unwrap(),
                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,7 @@ impl OctocrabBuilder {
             Auth::PersonalToken(token) => {
                 hmap.append(
                     reqwest::header::AUTHORIZATION,
-                    (String::from("Basic ") + token.expose_secret())
+                    (String::from("Bearer ") + token.expose_secret())
                         .parse()
                         .unwrap(),
                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,7 @@ impl OctocrabBuilder {
             Auth::PersonalToken(token) => {
                 hmap.append(
                     reqwest::header::AUTHORIZATION,
-                    (String::from("Bearer ") + token.expose_secret())
+                    (String::from("token ") + token.expose_secret())
                         .parse()
                         .unwrap(),
                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,10 @@ pub fn initialise(builder: OctocrabBuilder) -> Result<Arc<Octocrab>> {
     Ok(STATIC_INSTANCE.swap(Arc::from(builder.build()?)))
 }
 
+pub fn initialise_built(built: Octocrab) -> Result<Arc<Octocrab>> {
+    Ok(STATIC_INSTANCE.swap(Arc::from(built)))
+}
+
 /// Returns a new instance of [`Octocrab`]. If it hasn't been previously
 /// initialised it returns a default instance with no authentication set.
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,10 +241,6 @@ pub fn initialise(builder: OctocrabBuilder) -> Result<Arc<Octocrab>> {
     Ok(STATIC_INSTANCE.swap(Arc::from(builder.build()?)))
 }
 
-pub fn initialise_built(built: Octocrab) -> Result<Arc<Octocrab>> {
-    Ok(STATIC_INSTANCE.swap(Arc::from(built)))
-}
-
 /// Returns a new instance of [`Octocrab`]. If it hasn't been previously
 /// initialised it returns a default instance with no authentication set.
 /// ```
@@ -411,8 +407,11 @@ enum AuthState {
     /// No state, although Auth::PersonalToken may have caused
     /// an Authorization HTTP header to be set to provide authentication.
     None,
+    /// Basic Auth HTTP. (username:password)
     BasicAuth {
+        /// The username
         username: String,
+        /// The password
         password: String,
     },
     /// Github App authentication with the given app data


### PR DESCRIPTION
I have been using octocrab to pull repo content using my github personal access token, and noticed I was getting rate limited at the 60req/hr rather than the 5000req/hr. I believe that the `Bearer` system in place used for adding a personal access token does not work for simple repo scrapes.

Github has documentation on using personal access tokens in a "Basic" authorized request:
https://docs.github.com/en/rest/overview/other-authentication-methods#via-oauth-and-personal-access-tokens

Functionality wise I added in `.basic_auth(username, password)` to OctocrabBuilder.
This needed new fields for both `Auth` and `AuthState`.
In the `execute()` function, `AuthState` will match against `Basic`, and use the `reqwest.basic_auth(user, pass)` function to add in the authorization to the request using the initial values given to OctocrabBuilder.

I did notice your practices of using `Secret::expose()` for passwords. I did not use it for storing `password` in any of the structs/enums as I'm not familiar with how that crate works. Let me know if you have an idea for implementing that for this `password` field and I can add it in.

This helps out issue:
https://github.com/XAMPPRocky/octocrab/issues/218