### PR TITLE
Make all UpdateGistFile fields optional

### DIFF
--- a/src/api/gists.rs
+++ b/src/api/gists.rs
@@ -220,7 +220,9 @@ struct UpdateGist {
 
 #[derive(Debug, Default, Serialize)]
 pub struct UpdateGistFile {
+    #[serde(skip_serializing_if = "Option::is_none")]
     filename: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<String>
 }
 


### PR DESCRIPTION
GitHub REST API allows omitting unchanged fields of a gist file but doesn't allow them to be explicitly null.

This PR fixes that by skipping serializing these fields when they are null.