### PR TITLE
disable default-features on chrono to avoid triggering CVE-2020-26235 on audit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 serde_path_to_error = "0.1.4"
 async-trait = "0.1.50"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "0.4.19", default-features = false, features = ["serde", "clock"] }
 url = { version = "2.2.2", features = ["serde"] }
 hyperx = "1.3.0"
 snafu = { version = "0.7", features = ["backtraces"] }


### PR DESCRIPTION
The Chrono library depends on `time v0.1.43` when build with the default features. This will trigger a warning of CVE-2020-26235 when a project that depends on Octocrab uses `cargo-deny` or `cargo-audit`.

This PR disables the default-features and instead pulls in the "clock" feature for the `::now()` function, avoiding the warning.