### PR TITLE
Add `list_branches` method to `repos` module

### DIFF
--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -2,6 +2,7 @@
 
 use reqwest::header::ACCEPT;
 
+mod branches;
 mod commits;
 pub mod events;
 mod file;
@@ -23,6 +24,7 @@ pub use releases::ReleasesHandler;
 pub use stargazers::ListStarGazersBuilder;
 pub use status::{CreateStatusBuilder, ListStatusesBuilder};
 pub use tags::ListTagsBuilder;
+pub use branches::ListBranchesBuilder;
 
 /// Handler for GitHub's repository API.
 ///
@@ -301,6 +303,21 @@ impl<'octo> RepoHandler<'octo> {
     /// ```
     pub fn list_tags(&self) -> ListTagsBuilder<'_, '_> {
         ListTagsBuilder::new(self)
+    }
+
+    /// List branches from a repository.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let branches = octocrab::instance()
+    ///     .repos("owner", "repo")
+    ///     .list_branches()
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list_branches(&self) -> ListBranchesBuilder<'_, '_> {
+        ListBranchesBuilder::new(self)
     }
 
     /// List commits from a repository

--- a/src/api/repos/branches.rs
+++ b/src/api/repos/branches.rs
@@ -52,24 +52,3 @@ impl<'octo, 'r> ListBranchesBuilder<'octo, 'r> {
         self.handler.crab.get(url, Some(&self)).await
     }
 }
-
-#[cfg(test)]
-#[tokio::test]
-async fn test() {
-    let octocrab = crate::instance();
-    let branches = octocrab
-        .repos("rust-lang", "rust")
-        .list_branches()
-        .send()
-        .await
-        .unwrap();
-    let master_branch = crate::models::repos::Branch {
-        name: "master".to_string(),
-        commit: crate::models::repos::CommitObject {
-            sha: "35a0407814a6b5a04f0929105631e9c69e293e9d".to_string(),
-            url: url::Url::parse("https://api.github.com/repos/rust-lang/rust/commits/35a0407814a6b5a04f0929105631e9c69e293e9d").unwrap(),
-        },
-        protected: true,
-    };
-    assert!(branches.items.contains(&master_branch));
-}

--- a/src/api/repos/branches.rs
+++ b/src/api/repos/branches.rs
@@ -1,0 +1,75 @@
+use super::*;
+
+#[derive(serde::Serialize)]
+pub struct ListBranchesBuilder<'octo, 'r> {
+    #[serde(skip)]
+    handler: &'r RepoHandler<'octo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    protected: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+}
+
+impl<'octo, 'r> ListBranchesBuilder<'octo, 'r> {
+    pub fn new(handler: &'r RepoHandler<'octo>) -> Self {
+        Self {
+            handler,
+            protected: None,
+            per_page: None,
+            page: None,
+        }
+    }
+
+    /// Setting to true returns only protected branches. When set to false, only
+    /// unprotected branches are returned. Omitting this parameter returns all
+    /// branches.
+    pub fn protected(mut self, protected: impl Into<bool>) -> Self {
+        self.protected = Some(protected.into());
+        self
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.page = Some(page.into());
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(self) -> Result<crate::Page<models::repos::Branch>> {
+        let url = format!(
+            "repos/{owner}/{repo}/branches",
+            owner = self.handler.owner,
+            repo = self.handler.repo
+        );
+        self.handler.crab.get(url, Some(&self)).await
+    }
+}
+
+#[cfg(test)]
+#[tokio::test]
+async fn test() {
+    let octocrab = crate::instance();
+    let branches = octocrab
+        .repos("rust-lang", "rust")
+        .list_branches()
+        .send()
+        .await
+        .unwrap();
+    let master_branch = crate::models::repos::Branch {
+        name: "master".to_string(),
+        commit: crate::models::repos::CommitObject {
+            sha: "35a0407814a6b5a04f0929105631e9c69e293e9d".to_string(),
+            url: url::Url::parse("https://api.github.com/repos/rust-lang/rust/commits/35a0407814a6b5a04f0929105631e9c69e293e9d").unwrap(),
+        },
+        protected: true,
+    };
+    assert!(branches.items.contains(&master_branch));
+}

--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -239,6 +239,15 @@ pub struct ContentLinks {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
+pub struct Branch {
+    pub name: String,
+    pub commit: CommitObject,
+    pub protected: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub struct Tag {
     pub name: String,
     pub commit: CommitObject,


### PR DESCRIPTION
First of all, this library is great! But it seems that a critical [API](https://docs.github.com/en/rest/branches/branches#list-branches) is missing, so I simply added it and attached a small test, merge or close at will :)