### PR TITLE
Add encoding field to content

### DIFF
--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -155,6 +155,7 @@ pub struct Content {
     pub name: String,
     pub path: String,
     pub sha: String,
+    pub encoding: String,
     /// File content, Base64 encoded
     pub content: Option<String>,
     pub size: i64,


### PR DESCRIPTION
As per [the doc in github](https://docs.github.com/en/rest/repos/contents#get-repository-content) for files that are large i.e) 1-100MB "the content field will be an empty string and the encoding field will be "none"."

When encoding is none, the user can then use it to download the content via download_url.
Having this field, lets the octocrab sdk be in tune with the API doc of github.