### PR TITLE
Add OAuth + device  flow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ futures-core = { version = "0.3.15", optional = true }
 futures-util = { version = "0.3.15", optional = true }
 secrecy = "0.8.0"
 cfg-if = "1.0.0"
+either = "1.8.0"
 
 [dev-dependencies]
 tokio = { version = "1.17.0", default-features = false, features = [

--- a/examples/device_flow.rs
+++ b/examples/device_flow.rs
@@ -1,0 +1,40 @@
+use std::time::Duration;
+const CLIENT_ID: &'static str = "********************";
+
+#[tokio::main]
+async fn main() -> octocrab::Result<()> {
+    let codes = octocrab::auth::authenticate_as_device(
+        secrecy::Secret::from(String::from(CLIENT_ID)),
+        ["public_repo", "read:org"],
+    )
+    .await?;
+    println!(
+        "Go to {} and enter code {}",
+        codes.verification_uri, codes.user_code
+    );
+    let mut interval = Duration::from_secs(codes.interval);
+    let mut clock = tokio::time::interval(interval);
+    let auth = loop {
+        clock.tick().await;
+        match codes.poll_once().await? {
+            Ok(auth) => break auth,
+            Err(cont) => match cont {
+                octocrab::auth::Continue::SlowDown => {
+                    // We were request to slow down. We add five seconds to the polling
+                    // duration.
+                    interval += Duration::from_secs(5);
+                    clock = tokio::time::interval(interval);
+                    // The first tick happens instantly, so we tick that off immediately.
+                    clock.tick().await;
+                }
+                octocrab::auth::Continue::AuthorizationPending => {
+                    // The user has not clicked authorize yet, but nothing has gone wrong.
+                    // We keep polling.
+                }
+            },
+        }
+    };
+
+    println!("Authorization succeeded with access to {:?}", auth.scope);
+    return Ok(());
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3,8 +3,9 @@
 use crate::models::AppId;
 use crate::Result;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
-use secrecy::SecretString;
-use serde::Serialize;
+use reqwest::header::ACCEPT;
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::time::SystemTime;
 
@@ -32,7 +33,7 @@ pub enum Auth {
     /// No authentication
     None,
     // Basic HTTP authentication (username:password)
-    Basic{
+    Basic {
         /// Username
         username: String,
         /// Password
@@ -42,6 +43,8 @@ pub enum Auth {
     PersonalToken(SecretString),
     /// Authenticate as a Github App
     App(AppAuth),
+    /// Authenticate as a Github OAuth App
+    OAuth(OAuth),
 }
 
 impl Default for Auth {
@@ -86,4 +89,162 @@ impl AppAuth {
     pub fn generate_bearer_token(&self) -> Result<String> {
         create_jwt(self.app_id, &self.key).context(crate::error::JWTSnafu)
     }
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(from = "OAuthWire")]
+/// The data necessary to authenticate as a github OAtuh app.
+pub struct OAuth {
+    pub access_token: SecretString,
+    pub token_type: String,
+    pub scope: Vec<String>,
+}
+
+#[derive(Deserialize)]
+/// The wire format of the OAuth struct.
+struct OAuthWire {
+    access_token: String,
+    token_type: String,
+    scope: String,
+}
+
+impl From<OAuthWire> for OAuth {
+    fn from(value: OAuthWire) -> Self {
+        OAuth {
+            access_token: SecretString::from(value.access_token),
+            token_type: value.token_type,
+            scope: value.scope.split(",").map(ToString::to_string).collect(),
+        }
+    }
+}
+
+pub async fn authenticate_as_device<I, S>(client_id: SecretString, scope: I) -> Result<DeviceCodes>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let crab = crate::OctocrabBuilder::new()
+        .base_url("https://github.com")?
+        .add_header(ACCEPT, "application/json".to_string())
+        .build()?;
+    let scope = {
+        let mut scopes = scope.into_iter();
+        let first = scopes
+            .next()
+            .map(|s| s.as_ref().to_string())
+            .unwrap_or_default();
+        scopes.fold(first, |i: String, n| i + "," + n.as_ref())
+    };
+    let mut r: DeviceCodes = crab
+        .post(
+            "login/device/code",
+            Some(&DeviceFlow {
+                client_id: client_id.expose_secret(),
+                scope: &scope,
+            }),
+        )
+        .await?;
+    r.crab = crab;
+    r.client_id = Some(client_id);
+    Ok(r)
+}
+
+/// See https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#response-parameters
+#[derive(Deserialize, Clone)]
+pub struct DeviceCodes {
+    /// The device verification code is 40 characters and used to verify the device.
+    pub device_code: String,
+    /// The user verification code is displayed on the device so the user can enter the
+    /// code in a browser. This code is 8 characters with a hyphen in the middle.
+    pub user_code: String,
+    /// The verification URL where users need to enter the user_code: https://github.com/login/device.
+    pub verification_uri: String,
+    /// The number of seconds before the device_code and user_code expire. The default is
+    /// 900 seconds or 15 minutes.
+    pub expires_in: u64,
+    /// The minimum number of seconds that must pass before you can make a new access
+    /// token request (POST https://github.com/login/oauth/access_token) to complete the
+    /// device authorization. For example, if the interval is 5, then you cannot make a
+    /// new request until 5 seconds pass. If you make more than one request over 5
+    /// seconds, then you will hit the rate limit and receive a slow_down error.
+    pub interval: u64,
+
+    // Used to poll for the device codes.
+    #[serde(skip)]
+    crab: crate::Octocrab,
+
+    // Used for polling the device. This should be filled in as soon as possible.
+    #[serde(skip)]
+    client_id: Option<SecretString>,
+}
+
+impl DeviceCodes {
+    /// Poll Github to see if authentication codes are available.
+    ///
+    /// See `https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#response-parameters` for details.
+    pub async fn poll_once(&self) -> Result<Result<OAuth, Continue>> {
+        let poll: TokenResponse = self
+            .crab
+            .post(
+                "login/oauth/access_token",
+                Some(&PollForDevice {
+                    client_id: &self
+                        .client_id
+                        .as_ref()
+                        .expect("should have been equipped shortly after creation")
+                        .expose_secret(),
+                    device_code: &self.device_code,
+                    grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+                }),
+            )
+            .await?;
+        Ok(match poll {
+            TokenResponse::Ok(k) => Ok(k),
+            TokenResponse::Contine { error } => Err(error),
+        })
+    }
+}
+
+/// See https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#input-parameters
+#[derive(Serialize)]
+struct DeviceFlow<'a> {
+    client_id: &'a str,
+    scope: &'a str,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum TokenResponse {
+    // We got the auth information.
+    Ok(OAuth),
+    // We got an error that allows us to continue polling.
+    Contine { error: Continue },
+}
+
+/// Control flow when polling the device flow authorization.
+#[derive(Deserialize, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum Continue {
+    /// When you receive the slow_down error, 5 extra seconds are added to the minimum
+    /// interval or timeframe required between your requests using POST
+    /// https://github.com/login/oauth/access_token. For example, if the starting interval
+    /// required at least 5 seconds between requests and you get a slow_down error response,
+    /// you must now wait a minimum of 10 seconds before making a new request for an OAuth
+    /// access token. The error response includes the new interval that you must use.
+    SlowDown,
+    /// This error occurs when the authorization request is pending and the user hasn't
+    /// entered the user code yet. The app is expected to keep polling the POST
+    /// https://github.com/login/oauth/access_token request without exceeding the
+    /// interval, which requires a minimum number of seconds between each request.
+    AuthorizationPending,
+}
+
+#[derive(Serialize)]
+struct PollForDevice<'a> {
+    /// Required. The client ID you received from GitHub for your OAuth App.
+    client_id: &'a str,
+    /// Required. The device verification code you received from the POST https://github.com/login/device/code request.
+    device_code: &'a str,
+    /// Required. The grant type must be urn:ietf:params:oauth:grant-type:device_code.
+    grant_type: &'static str,
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -170,6 +170,7 @@ impl crate::Octocrab {
 ///
 /// See https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#response-parameters
 #[derive(Deserialize, Clone)]
+#[non_exhaustive]
 pub struct DeviceCodes {
     /// The device verification code is 40 characters and used to verify the device.
     pub device_code: String,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -91,17 +91,17 @@ impl AppAuth {
     }
 }
 
+/// The data necessary to authenticate as a github OAtuh app.
 #[derive(Clone, Deserialize)]
 #[serde(from = "OAuthWire")]
-/// The data necessary to authenticate as a github OAtuh app.
 pub struct OAuth {
     pub access_token: SecretString,
     pub token_type: String,
     pub scope: Vec<String>,
 }
 
-#[derive(Deserialize)]
 /// The wire format of the OAuth struct.
+#[derive(Deserialize)]
 struct OAuthWire {
     access_token: String,
     token_type: String,
@@ -118,6 +118,9 @@ impl From<OAuthWire> for OAuth {
     }
 }
 
+/// Authenticate with Github's device flow. This starts the process to obtain a new `OAuth`.
+///
+/// See https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#device-flow for details.
 pub async fn authenticate_as_device<I, S>(client_id: SecretString, scope: I) -> Result<DeviceCodes>
 where
     I: IntoIterator<Item = S>,
@@ -149,6 +152,8 @@ where
     Ok(r)
 }
 
+/// The device codes as returned from step 1 of Github's device flow.
+///
 /// See https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#response-parameters
 #[derive(Deserialize, Clone)]
 pub struct DeviceCodes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,6 +336,15 @@ impl OctocrabBuilder {
                 AuthState::None
             }
             Auth::App(app_auth) => AuthState::App(app_auth),
+            Auth::OAuth(device) => {
+                hmap.append(
+                    reqwest::header::AUTHORIZATION,
+                    (device.token_type + " " + &device.access_token.expose_secret())
+                        .parse()
+                        .unwrap(),
+                );
+                AuthState::None
+            }
         };
 
         for (key, value) in self.extra_headers.into_iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,13 @@ impl OctocrabBuilder {
     /// Authenticate as a Basic Auth
     /// username and password
     pub fn basic_auth(mut self, username: String, password: String) -> Self {
-        self.auth = Auth::Basic{ username, password };
+        self.auth = Auth::Basic { username, password };
+        self
+    }
+
+    /// Authenticate with an OAuth token.
+    pub fn oauth(mut self, oauth: auth::OAuth) -> Self {
+        self.auth = Auth::OAuth(oauth);
         self
     }
 


### PR DESCRIPTION
Add support for Github's device flow. The document describing the flow is at https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#device-flow.

Fixes #247