### PR TITLE
Ensure that absolute URLs are used, fix #149

### DIFF
--- a/src/api/actions.rs
+++ b/src/api/actions.rs
@@ -168,7 +168,8 @@ impl<'octo> ActionsHandler<'octo> {
             repository_id = repository_id,
         );
 
-        crate::map_github_error(self.crab._put(&route, None::<&()>).await?)
+        let url = self.crab.absolute_url(route)?;
+        crate::map_github_error(self.crab._put(url, None::<&()>).await?)
             .await
             .map(drop)
     }
@@ -200,7 +201,8 @@ impl<'octo> ActionsHandler<'octo> {
             repository_id = repository_id,
         );
 
-        crate::map_github_error(self.crab._delete(&route, None::<&()>).await?)
+        let url = self.crab.absolute_url(route)?;
+        crate::map_github_error(self.crab._delete(url, None::<&()>).await?)
             .await
             .map(drop)
     }
@@ -230,7 +232,8 @@ impl<'octo> ActionsHandler<'octo> {
             run_id = run_id,
         );
 
-        crate::map_github_error(self.crab._post(&route, None::<&()>).await?)
+        let url = self.crab.absolute_url(route)?;
+        crate::map_github_error(self.crab._post(url, None::<&()>).await?)
             .await
             .map(drop)
     }
@@ -344,7 +347,8 @@ impl<'octo> ActionsHandler<'octo> {
             run_id = run_id,
         );
 
-        crate::map_github_error(self.crab._delete(&route, None::<&()>).await?)
+        let url = self.crab.absolute_url(route)?;
+        crate::map_github_error(self.crab._delete(url, None::<&()>).await?)
             .await
             .map(drop)
     }

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -117,7 +117,8 @@ impl<'octo> TeamHandler<'octo> {
             org = self.owner,
             team = team_slug.into(),
         );
-        crate::map_github_error(self.crab._delete(&url, None::<&()>).await?)
+        let url = self.crab.absolute_url(url)?;
+        crate::map_github_error(self.crab._delete(url, None::<&()>).await?)
             .await
             .map(drop)
     }


### PR DESCRIPTION
First off, thank you for building octocrab. 😃 

I'm using it for the backend parts of autofix.ci and it's a pleasure to work with overall. I did run into #149 on the way, which is easily fixed by making sure that no relative URLs are fed to `crab._(get|post|...)`. This PR fixes all occurences that I could find. :)