### PR TITLE
`Issue.state` has type `IssueState`, not `String`

### DIFF
--- a/src/models/issues.rs
+++ b/src/models/issues.rs
@@ -12,7 +12,7 @@ pub struct Issue {
     pub events_url: Url,
     pub html_url: Url,
     pub number: i64,
-    pub state: String,
+    pub state: IssueState,
     pub title: String,
     pub body: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Strong types are better types.