### PR TITLE
Make the new `encoding` field optional as it's absent in responses to `PUT` requests

### DIFF
--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -155,7 +155,7 @@ pub struct Content {
     pub name: String,
     pub path: String,
     pub sha: String,
-    pub encoding: String,
+    pub encoding: Option<String>,
     /// File content, Base64 encoded
     pub content: Option<String>,
     pub size: i64,


### PR DESCRIPTION
The change made in https://github.com/XAMPPRocky/octocrab/pull/245 seems to have broken [octocrab::repos::RepoHandler::update_file()](https://docs.rs/octocrab/latest/octocrab/repos/struct.RepoHandler.html#method.update_file) which sends a `PUT` request. The response for that request [won't contain the `encoding` field](https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents).

This PR makes the relevant field `optional`.

Perhaps the resulting `Content` type should be split into two (with a shared common denominator), one corresponding to the `GET` responses, and one corresponding to the `PUT` responses. If that's desired, please let me know, I can do that. 🙂 However, it would be a breaking change, so I figured a simple fix like this is better.