### PR TITLE
Make Issue.number type u64

### DIFF
--- a/examples/unlock.rs
+++ b/examples/unlock.rs
@@ -1,0 +1,9 @@
+#[tokio::main]
+async fn main() -> octocrab::Result<()> {
+    let api = octocrab::instance();
+    let issues_api = api.issues("rust-lang", "rust");
+    let one_issue = issues_api.list().per_page(1).send().await?.take_items();
+    issues_api.unlock(one_issue.first().unwrap().number).await?;
+
+    Ok(())
+}

--- a/src/models/issues.rs
+++ b/src/models/issues.rs
@@ -11,7 +11,7 @@ pub struct Issue {
     pub comments_url: Url,
     pub events_url: Url,
     pub html_url: Url,
-    pub number: i64,
+    pub number: u64,
     pub state: String,
     pub title: String,
     pub body: Option<String>,


### PR DESCRIPTION
This is needed because the `IssueHandler` assumes `u64` in all methods, see for example https://docs.rs/octocrab/latest/octocrab/issues/struct.IssueHandler.html#method.update

This should avoid having to type `number.try_into().unwrap()` when using the member variable.
