### PR TITLE
Make fields in PullRequestChanges accessible

### DIFF
--- a/src/models/events/payload/pull_request.rs
+++ b/src/models/events/payload/pull_request.rs
@@ -47,8 +47,8 @@ pub enum PullRequestEventAction {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct PullRequestChanges {
-    title: Option<PullRequestEventChangesFrom>,
-    body: Option<PullRequestEventChangesFrom>,
+    pub title: Option<PullRequestEventChangesFrom>,
+    pub body: Option<PullRequestEventChangesFrom>,
 }
 
 /// The previous value of the item (either the body or title) of a pull request which has changed. Only


### PR DESCRIPTION
The fields `title` and `body` in `models::events::payload::pull_request::PullRequestChanges` are inaccessible so crate users cannot use them. This PR fixes that.