### PR TITLE
Fix listing contents containing submodules

### DIFF
--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -160,8 +160,8 @@ pub struct Content {
     pub content: Option<String>,
     pub size: i64,
     pub url: String,
-    pub html_url: String,
-    pub git_url: String,
+    pub html_url: Option<String>,
+    pub git_url: Option<String>,
     pub download_url: Option<String>,
     pub r#type: String,
     #[serde(rename = "_links")]
@@ -231,8 +231,8 @@ impl crate::FromResponse for ContentItems {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ContentLinks {
-    pub git: Url,
-    pub html: Url,
+    pub git: Option<Url>,
+    pub html: Option<Url>,
     #[serde(rename = "self")]
     pub _self: Url,
 }


### PR DESCRIPTION
Types of `Content` and `ContentLinks` struct don't agree with the API docs

The `Content` `html_url` and `git_url` fields are `String`s, and the `ContentLinks` `html` and `git` fields are `Url` but the documentation for these says:

```
{
  "title": "Content Tree",
  "description": "Content Tree",
  "type": "object",
  "properties": {
    ...
    "git_url": {
      "type": [
        "string",
        "null"
      ],
      "format": "uri"
    },
    "html_url": {
      "type": [
        "string",
        "null"
      ],
      "format": "uri"
    },
    "download_url": {
      "type": [
        "string",
        "null"
      ],
      "format": "uri"
    },
    "entries": {
      "type": "array",
      "items": {
        "type": "object",
        "properties": {
          ...
          "git_url": {
            "type": [
              "string",
              "null"
            ],
            "format": "uri"
          },
          "html_url": {
            "type": [
              "string",
              "null"
            ],
            "format": "uri"
          },
          ...
          "_links": {
            "type": "object",
            "properties": {
              "git": {
                "type": [
                  "string",
                  "null"
                ],
                "format": "uri"
              },
              "html": {
                "type": [
                  "string",
                  "null"
                ],
                "format": "uri"
              },
              ...
          }
        },
        ...
      }
    },
    "_links": {
      "type": "object",
      "properties": {
        "git": {
          "type": [
            "string",
            "null"
          ],
          "format": "uri"
        },
        "html": {
          "type": [
            "string",
            "null"
          ],
          "format": "uri"
        },
        ...
      },
      ...
    }
  },
  ...
}
```

Apparently the only case that these are omitted is for submodules: https://docs.github.com/en/rest/repos/contents#if-the-content-is-a-submodule.

----

I could also see an argument that the should all be `Option<Url>` but then `url` should probably be `Url` as well. 