### PR TITLE
Make `encoding` optional in `Content`

### DIFF
--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -155,7 +155,7 @@ pub struct Content {
     pub name: String,
     pub path: String,
     pub sha: String,
-    pub encoding: String,
+    pub encoding: Option<String>,
     /// File content, Base64 encoded
     pub content: Option<String>,
     pub size: i64,


### PR DESCRIPTION
This seems to never be returned by the API for entries when listing a directory.

The GitHub API docs
https://docs.github.com/en/rest/repos/contents#get-repository-content are a bit unclear on this, the response schema lists "encoding" as required, but omit the type information. The examples are consistent with it only being present if the path requested is a file.