### PR TITLE
chane list_stargazers to use the Github relevant API option with starred_at

### DIFF
--- a/src/api/repos/stargazers.rs
+++ b/src/api/repos/stargazers.rs
@@ -32,12 +32,16 @@ impl<'octo, 'r> ListStarGazersBuilder<'octo, 'r> {
   }
 
   /// Sends the actual request.
-  pub async fn send(self) -> crate::Result<crate::Page<crate::models::User>> {
+  pub async fn send(self) -> crate::Result<crate::Page<crate::models::StarGazer>> {
     let url = format!(
       "repos/{owner}/{repo}/stargazers",
       owner = self.handler.owner,
       repo = self.handler.repo
     );
-    self.handler.crab.get(url, Some(&self)).await
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(ACCEPT, "application/vnd.github.v3.star+json".parse().unwrap());
+
+    self.handler.crab.get_with_headers(url, Some(&self), Some(headers)).await
   }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -322,6 +322,13 @@ pub struct User {
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
+pub struct StarGazer {
+    pub starred_at: Option<DateTime<Utc>>,
+    pub user: User,
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Label {
     pub id: LabelId,
     pub node_id: String,


### PR DESCRIPTION
Resolved #268

list_stargazer now returns a new model StarGazer which includes starred_at
added get_with_headers and _get_with_headers to allow injecting headers (original get and _get call the new methods)
