### PR TITLE
Add 'body_text' and 'body_html' to Review

### DIFF
--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -201,6 +201,10 @@ pub struct Review {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub body_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body_html: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub commit_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<ReviewState>,


### PR DESCRIPTION
Similarly to the `Comment` struct, there should be a field `body_text` and `body_html` in the `Review` struct. They are filled when the header `Accept` is set with `application/vnd.github.text+json`, `application/vnd.github.html+json` or `application/vnd.github.full+json`.

See https://docs.github.com/en/rest/overview/media-types#text.