### PR TITLE
Some improvements to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Help Wanted](https://img.shields.io/github/issues/XAMPPRocky/octocrab/help%20wanted?color=green)](https://github.com/XAMPPRocky/octocrab/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 [![Lines Of Code](https://tokei.rs/b1/github/XAMPPRocky/octocrab?category=code)](https://github.com/XAMPPRocky/octocrab)
 [![Documentation](https://docs.rs/octocrab/badge.svg)](https://docs.rs/octocrab/)
+[![Crates.io](https://img.shields.io/crates/v/octocrab?logo=rust)](https://crates.io/crates/octocrab/)
 
 Octocrab is a third party GitHub API client, allowing you to easily build
 your own GitHub integrations or bots in Rust. `Octocrab` comes with two primary

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ cargo add octocrab
 The semantic API provides strong typing around GitHub's API, a set of
 [`models`] that maps to GitHub's types, and [`auth`] functions that are useful
 for GitHub apps.
-Currently, the following modules are available.
+Currently, the following modules are available as of version `0.17`.
 
 - [`actions`] GitHub Actions.
 - [`apps`] GitHub Apps.
@@ -40,22 +40,22 @@ Currently, the following modules are available.
 - [`search`] GitHub's search API.
 - [`teams`] Teams.
 
-[`models`]: https://docs.rs/octocrab/0.17/octocrab/models/index.html
-[`auth`]: https://docs.rs/octocrab/0.17/octocrab/auth/index.html
-[`apps`]: https://docs.rs/octocrab/0.17/octocrab/apps/index.html
-[`actions`]: https://docs.rs/octocrab/0.17/octocrab/actions/struct.ActionsHandler.html
-[`current`]: https://docs.rs/octocrab/0.17/octocrab/current/struct.CurrentAuthHandler.html
-[`gitignore`]: https://docs.rs/octocrab/0.17/octocrab/gitignore/struct.GitignoreHandler.html
-[`graphql`]: https://docs.rs/octocrab/0.17/octocrab/struct.Octocrab.html#graphql-api
-[`markdown`]: https://docs.rs/octocrab/0.17/octocrab/markdown/struct.MarkdownHandler.html
-[`issues`]: https://docs.rs/octocrab/0.17/octocrab/issues/struct.IssueHandler.html
-[`licenses`]: https://docs.rs/octocrab/0.17/octocrab/licenses/struct.LicenseHandler.html
-[`pulls`]: https://docs.rs/octocrab/0.17/octocrab/pulls/struct.PullRequestHandler.html
-[`orgs`]: https://docs.rs/octocrab/0.17/octocrab/orgs/struct.OrgHandler.html
-[`repos`]: https://docs.rs/octocrab/0.17/octocrab/repos/struct.RepoHandler.html
-[`releases`]: https://docs.rs/octocrab/0.17/octocrab/repos/struct.ReleasesHandler.html
-[`search`]: https://docs.rs/octocrab/0.17/octocrab/search/struct.SearchHandler.html
-[`teams`]: https://docs.rs/octocrab/0.17/octocrab/teams/struct.TeamHandler.html
+[`models`]: https://docs.rs/octocrab/latest/octocrab/models/index.html
+[`auth`]: https://docs.rs/octocrab/latest/octocrab/auth/index.html
+[`apps`]: https://docs.rs/octocrab/latest/octocrab/apps/index.html
+[`actions`]: https://docs.rs/octocrab/latest/octocrab/actions/struct.ActionsHandler.html
+[`current`]: https://docs.rs/octocrab/latest/octocrab/current/struct.CurrentAuthHandler.html
+[`gitignore`]: https://docs.rs/octocrab/latest/octocrab/gitignore/struct.GitignoreHandler.html
+[`graphql`]: https://docs.rs/octocrab/latest/octocrab/struct.Octocrab.html#graphql-api
+[`markdown`]: https://docs.rs/octocrab/latest/octocrab/markdown/struct.MarkdownHandler.html
+[`issues`]: https://docs.rs/octocrab/latest/octocrab/issues/struct.IssueHandler.html
+[`licenses`]: https://docs.rs/octocrab/latest/octocrab/licenses/struct.LicenseHandler.html
+[`pulls`]: https://docs.rs/octocrab/latest/octocrab/pulls/struct.PullRequestHandler.html
+[`orgs`]: https://docs.rs/octocrab/latest/octocrab/orgs/struct.OrgHandler.html
+[`repos`]: https://docs.rs/octocrab/latest/octocrab/repos/struct.RepoHandler.html
+[`releases`]: https://docs.rs/octocrab/latest/octocrab/repos/struct.ReleasesHandler.html
+[`search`]: https://docs.rs/octocrab/latest/octocrab/search/struct.SearchHandler.html
+[`teams`]: https://docs.rs/octocrab/latest/octocrab/teams/struct.TeamHandler.html
 
 #### Getting a Pull Request
 ```rust

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ semantic API, and a lower level HTTP API for extending behaviour.
 
 #### Cargo.toml
 ```toml
-octocrab = "0.16"
+octocrab = "0.17"
 ```
 
 ## Semantic API
@@ -37,27 +37,27 @@ Currently, the following modules are available.
 - [`search`] GitHub's search API.
 - [`teams`] Teams.
 
-[`models`]: https://docs.rs/octocrab/latest/octocrab/models/index.html
-[`auth`]: https://docs.rs/octocrab/latest/octocrab/auth/index.html
-[`apps`]: https://docs.rs/octocrab/latest/octocrab/apps/index.html
-[`actions`]: https://docs.rs/octocrab/latest/octocrab/actions/struct.ActionsHandler.html
-[`current`]: https://docs.rs/octocrab/latest/octocrab/current/struct.CurrentAuthHandler.html
-[`gitignore`]: https://docs.rs/octocrab/latest/octocrab/gitignore/struct.GitignoreHandler.html
-[`graphql`]: https://docs.rs/octocrab/latest/octocrab/struct.Octocrab.html#graphql-api
-[`markdown`]: https://docs.rs/octocrab/latest/octocrab/markdown/struct.MarkdownHandler.html
-[`issues`]: https://docs.rs/octocrab/latest/octocrab/issues/struct.IssueHandler.html
-[`licenses`]: https://docs.rs/octocrab/latest/octocrab/licenses/struct.LicenseHandler.html
-[`pulls`]: https://docs.rs/octocrab/latest/octocrab/pulls/struct.PullRequestHandler.html
-[`orgs`]: https://docs.rs/octocrab/latest/octocrab/orgs/struct.OrgHandler.html
-[`repos`]: https://docs.rs/octocrab/latest/octocrab/repos/struct.RepoHandler.html
-[`releases`]: https://docs.rs/octocrab/0.8.1/octocrab/repos/struct.ReleasesHandler.html
-[`search`]: https://docs.rs/octocrab/latest/octocrab/search/struct.SearchHandler.html
-[`teams`]: https://docs.rs/octocrab/latest/octocrab/teams/struct.TeamHandler.html
+[`models`]: https://docs.rs/octocrab/0.17/octocrab/models/index.html
+[`auth`]: https://docs.rs/octocrab/0.17/octocrab/auth/index.html
+[`apps`]: https://docs.rs/octocrab/0.17/octocrab/apps/index.html
+[`actions`]: https://docs.rs/octocrab/0.17/octocrab/actions/struct.ActionsHandler.html
+[`current`]: https://docs.rs/octocrab/0.17/octocrab/current/struct.CurrentAuthHandler.html
+[`gitignore`]: https://docs.rs/octocrab/0.17/octocrab/gitignore/struct.GitignoreHandler.html
+[`graphql`]: https://docs.rs/octocrab/0.17/octocrab/struct.Octocrab.html#graphql-api
+[`markdown`]: https://docs.rs/octocrab/0.17/octocrab/markdown/struct.MarkdownHandler.html
+[`issues`]: https://docs.rs/octocrab/0.17/octocrab/issues/struct.IssueHandler.html
+[`licenses`]: https://docs.rs/octocrab/0.17/octocrab/licenses/struct.LicenseHandler.html
+[`pulls`]: https://docs.rs/octocrab/0.17/octocrab/pulls/struct.PullRequestHandler.html
+[`orgs`]: https://docs.rs/octocrab/0.17/octocrab/orgs/struct.OrgHandler.html
+[`repos`]: https://docs.rs/octocrab/0.17/octocrab/repos/struct.RepoHandler.html
+[`releases`]: https://docs.rs/octocrab/0.17/octocrab/repos/struct.ReleasesHandler.html
+[`search`]: https://docs.rs/octocrab/0.17/octocrab/search/struct.SearchHandler.html
+[`teams`]: https://docs.rs/octocrab/0.17/octocrab/teams/struct.TeamHandler.html
 
 #### Getting a Pull Request
 ```rust
-// Get pull request #404 from `octocrab/repo`.
-let issue = octocrab::instance().pulls("octocrab", "repo").get(404).await?;
+// Get pull request #5 from `XAMPPRocky/octocrab`.
+let issue = octocrab::instance().pulls("XAMPPRocky", "octocrab").get(5).await?;
 ```
 
 All methods with multiple optional parameters are built as `Builder`

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ your own GitHub integrations or bots in Rust. `Octocrab` comes with two primary
 sets of APIs for communicating with GitHub, a high level strongly typed
 semantic API, and a lower level HTTP API for extending behaviour.
 
-#### Cargo.toml
-```toml
-octocrab = "0.17"
+## Adding Octocrab
+Run this command in your terminal to add the latest version of `Octocrab`.
+
+```bash
+$ cargo add octocrab
 ```
 
 ## Semantic API


### PR DESCRIPTION
Hi!

This PR changes some stuff in the readme:

- Update version `0.16` to the latest, `0.17`
- Make `docs.rs` links point to version 0.17, in case a new version of Octocrab is released that contains breaking changes
- Change the repo used in the "Getting a Pull Request" section to the Octocrab repo, since you use it in the "HTTP API" section