### PR TITLE
Add 'request_reviews' function

### DIFF
--- a/src/api/pulls.rs
+++ b/src/api/pulls.rs
@@ -239,6 +239,36 @@ impl<'octo> PullRequestHandler<'octo> {
         self.http_get(url, None::<&()>).await
     }
 
+    /// Request a review from users or teams.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// use octocrab::params;
+    /// let review = octocrab::instance().pulls("owner", "repo")
+    ///    .request_reviews(101, vec!["user1".to_string(), "user2".to_string()], vec!["team1".to_string(), "team2".to_string()])
+    ///  .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn request_reviews(
+        &self,
+        pr: u64,
+        reviewers: Vec<String>,
+        team_reviewers: Vec<String>,
+    ) -> crate::Result<crate::models::pulls::Review> {
+        let url = format!(
+            "repos/{owner}/{repo}/pulls/{pr}/requested_reviewers",
+            owner = self.owner,
+            repo = self.repo,
+            pr = pr
+        );
+
+        let mut map = serde_json::Map::new();
+        map.insert("reviewers".to_string(), reviewers.into());
+        map.insert("team_reviewers".to_string(), team_reviewers.into());
+
+        self.crab.post(url, Some(&map)).await
+    }
+
     /// List all `FileDiff`s associated with the pull request.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {

--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -221,6 +221,7 @@ pub struct Review {
 #[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
 #[non_exhaustive]
 pub enum ReviewState {
+    Open,
     Approved,
     Pending,
     ChangesRequested,
@@ -282,6 +283,7 @@ impl<'de> Deserialize<'de> for ReviewState {
                 E: serde::de::Error,
             {
                 Ok(match value {
+                    "OPEN" | "open" => ReviewState::Open,
                     "APPROVED" | "approved" => ReviewState::Approved,
                     "PENDING" | "pending" => ReviewState::Pending,
                     "CHANGES_REQUESTED" | "changes_requested" => ReviewState::ChangesRequested,


### PR DESCRIPTION
Adds a command to request reviews from reviewers. See https://docs.github.com/en/rest/pulls/review-requests#request-reviewers-for-a-pull-request.

I had to add 'Open' to the `ReviewState` enum, otherwise, there would be a deserialization error after a review request.