### PR TITLE
request_reviews fixups

### DIFF
--- a/src/api/pulls.rs
+++ b/src/api/pulls.rs
@@ -242,9 +242,8 @@ impl<'octo> PullRequestHandler<'octo> {
     /// Request a review from users or teams.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
-    /// use octocrab::params;
     /// let review = octocrab::instance().pulls("owner", "repo")
-    ///    .request_reviews(101, vec!["user1".to_string(), "user2".to_string()], vec!["team1".to_string(), "team2".to_string()])
+    ///    .request_reviews(101, ["user1".to_string(), "user2".to_string()], ["team1".to_string(), "team2".to_string()])
     ///  .await?;
     /// # Ok(())
     /// # }
@@ -252,8 +251,8 @@ impl<'octo> PullRequestHandler<'octo> {
     pub async fn request_reviews(
         &self,
         pr: u64,
-        reviewers: Vec<String>,
-        team_reviewers: Vec<String>,
+        reviewers: impl Into<Vec<String>>,
+        team_reviewers: impl Into<Vec<String>>,
     ) -> crate::Result<crate::models::pulls::Review> {
         let url = format!(
             "repos/{owner}/{repo}/pulls/{pr}/requested_reviewers",
@@ -263,8 +262,8 @@ impl<'octo> PullRequestHandler<'octo> {
         );
 
         let mut map = serde_json::Map::new();
-        map.insert("reviewers".to_string(), reviewers.into());
-        map.insert("team_reviewers".to_string(), team_reviewers.into());
+        map.insert("reviewers".to_string(), reviewers.into().into());
+        map.insert("team_reviewers".to_string(), team_reviewers.into().into());
 
         self.crab.post(url, Some(&map)).await
     }

--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -289,7 +289,7 @@ impl<'de> Deserialize<'de> for ReviewState {
                     "CHANGES_REQUESTED" | "changes_requested" => ReviewState::ChangesRequested,
                     "COMMENTED" | "commented" => ReviewState::Commented,
                     "DISMISSED" | "dismissed" => ReviewState::Dismissed,
-                    unknown => return Err(E::custom(format!("unknown variant `{}`, expected one of `approved`, `pending`, `changes_requested`, `commented`", unknown))),
+                    unknown => return Err(E::custom(format!("unknown variant `{}`, expected one of `open`, `approved`, `pending`, `changes_requested`, `commented`, `dismissed`", unknown))),
                 })
             }
         }


### PR DESCRIPTION
Address my review comments from https://github.com/XAMPPRocky/octocrab/pull/277#pullrequestreview-1195552584


I also tried to get it to accept a vec/slice/array of `&str`, but didn't see an easy way to achieve this.