### PR TITLE
crash when using pagination on `installation/repositories`

### DIFF
--- a/src/page.rs
+++ b/src/page.rs
@@ -182,10 +182,20 @@ impl<T: serde::de::DeserializeOwned> crate::FromResponse for Page<T> {
                 last,
             })
         } else {
-            let attr = vec!["items", "workflows", "workflow_runs", "jobs", "artifacts", "repositories"]
-                .into_iter()
-                .find(|v| json.get(v).is_some())
-                .unwrap();
+            let attr = vec![
+                "items",
+                "workflows",
+                "workflow_runs",
+                "jobs",
+                "artifacts",
+                "repositories",
+            ]
+            .into_iter()
+            .find(|v| json.get(v).is_some())
+            .ok_or(Box::from(
+                "error decoding pagination result, top-level attribute unknown",
+            ))
+            .context(crate::error::OtherSnafu)?;
 
             Ok(Self {
                 items: serde_json::from_value(json.get(attr).cloned().unwrap())

--- a/src/page.rs
+++ b/src/page.rs
@@ -182,7 +182,7 @@ impl<T: serde::de::DeserializeOwned> crate::FromResponse for Page<T> {
                 last,
             })
         } else {
-            let attr = vec!["items", "workflows", "workflow_runs", "jobs", "artifacts"]
+            let attr = vec!["items", "workflows", "workflow_runs", "jobs", "artifacts", "repositories"]
                 .into_iter()
                 .find(|v| json.get(v).is_some())
                 .unwrap();


### PR DESCRIPTION
When doing

```rust
            let first_repo_page: Page<Repository> = octocrab
                .get("/installation/repositories", None::<&()>)
                .await?;

            let repo_pages = octocrab.all_pages(first_repo_page).await?;
```

octocrab crashes here: https://github.com/XAMPPRocky/octocrab/blob/99872f252184b3a509b05a4e118a5245b51cce79/src/page.rs#L185-L188


Shortterm solution is to add the repositories attribute to the expected attributes list. In any case, the whole list feels shaky, this will likely break again... unwrap feels dangerous here.