### PR TITLE
Introduce `state_reason` field in `Issue`

### DIFF
--- a/src/models/issues.rs
+++ b/src/models/issues.rs
@@ -13,6 +13,7 @@ pub struct Issue {
     pub html_url: Url,
     pub number: u64,
     pub state: IssueState,
+    pub state_reason: Option<IssueStateReason>,
     pub title: String,
     pub body: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -58,6 +59,16 @@ pub struct Comment {
     pub created_at: chrono::DateTime<chrono::Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum IssueStateReason {
+    Completed,
+    NotPlanned,
+    Reopened,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This pull request introduces `state_reason` field in `Issue` model.

From https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues Response Schema

```json
    "state_reason": {
      "description": "The reason for the current state",
      "type": [
        "string",
        "null"
      ],
      "enum": [
        "completed",
        "reopened",
        "not_planned",
        null
      ],
      "examples": [
        "not_planned"
      ]
    },
```