### PR TITLE
Make Review::user optional

### DIFF
--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -197,7 +197,7 @@ pub struct Review {
     pub id: ReviewId,
     pub node_id: String,
     pub html_url: Url,
-    pub user: User,
+    pub user: Option<User>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/repos_stargazers_tests.rs
+++ b/tests/repos_stargazers_tests.rs
@@ -2,7 +2,7 @@
 mod mock_error;
 
 use mock_error::setup_error_handler;
-use octocrab::{models::{User, StarGazer}, Octocrab, Page};
+use octocrab::{models::StarGazer, Octocrab, Page};
 use serde::{Deserialize, Serialize};
 use wiremock::{
   matchers::{method, path},


### PR DESCRIPTION
According to the docs, it is optional:

```
      "user": {
        "anyOf": [
          {
            "type": "null"
          },
          {
            "title": "Simple User",
            "description": "A GitHub user.",
            "type": "object",
            "properties": {
...
```

From https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#list-reviews-for-a-pull-request

This should fix crashes of the form:

```
thread '' panicked at 'called `Result::unwrap()` on an `Err` value: Serde {
 source: Error("invalid type: null, expected struct User", line: 0, column: 0), backtrace: Backtrace(
   0: <snafu::backtrace_shim::Backtrace as snafu::GenerateImplicitData>::generate
