### PR TITLE
Fix type Vec<Repositories> to InstallationRepositories on example

### DIFF
--- a/examples/github_app_authentication.rs
+++ b/examples/github_app_authentication.rs
@@ -1,4 +1,4 @@
-use octocrab::models::Repository;
+use octocrab::models::InstallationRepositories;
 use octocrab::Octocrab;
 
 #[tokio::main]
@@ -8,10 +8,11 @@ async fn main() -> octocrab::Result<()> {
     let key = jsonwebtoken::EncodingKey::from_rsa_pem(app_private_key.as_bytes()).unwrap();
 
     let octocrab = Octocrab::builder().app(app_id, key).build()?;
-    let _repos: Vec<Repository> = octocrab
+    let installed_repos: InstallationRepositories = octocrab
         .get("/installation/repositories", None::<&()>)
         .await
         .unwrap();
+    let _repos = installed_repos.repositories;
 
     Ok(())
 }

--- a/examples/github_app_authentication_manual.rs
+++ b/examples/github_app_authentication_manual.rs
@@ -1,4 +1,4 @@
-use octocrab::models::{InstallationToken, Repository};
+use octocrab::models::{InstallationToken, InstallationRepositories};
 use octocrab::params::apps::CreateInstallationAccessToken;
 use octocrab::Octocrab;
 
@@ -36,10 +36,11 @@ async fn main() -> octocrab::Result<()> {
         .build()
         .unwrap();
 
-    let _repos: Vec<Repository> = octocrab
+    let installed_repos: InstallationRepositories = octocrab
         .get("/installation/repositories", None::<&()>)
         .await
         .unwrap();
+    let _repos = installed_repos.repositories;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

example codes aren't working, so let them fixed.

## Detail

`/installation/repositories` returns repositories with total count.
[API Reference](https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#list-repositories-accessible-to-the-app-installation)
(maybe it had returned just repositories? 🤔 )

octocrab has `InstallationRepositories` type, however, these examples has wrong type. ;)
I confirms It works with this fix.