### PR TITLE
CD Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+jobs:
+  publish-cargo:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Adds a release workflow to cut a new release automatically on pushes to main or with a manual release. @XAMPPRocky will need to set the repo secret `CARGO_REGISTRY_TOKEN` for this to work. Hopefully this will help to increase development velocity on the project and reduce the time/effort of cutting manual releases.