### PR TITLE
Allow customized retry decisions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ wiremock = "0.5.3"
 
 [features]
 default = ["native-tls"]
-rustls = ["rustls-tls"]  # Leagcy support (<=0.17.0)
+rustls = ["rustls-tls"]  # Legacy support (<=0.17.0)
 
 # Enables native-tls specific functionality not available by default.
 native-tls = ["reqwest/native-tls"]


### PR DESCRIPTION
Adds a retry predicate (with defaults to match existing behavior for 401s). 5xx codes are generally worth retrying without changing anything about the request and this will let any user customize the behavior.