### PR TITLE
gists: Fix typo in POST /gists endpoint

### DIFF
--- a/src/api/gists.rs
+++ b/src/api/gists.rs
@@ -162,7 +162,7 @@ impl<'octo> CreateGistBuilder<'octo> {
 
     /// Send the `CreateGist` request to Github for execution.
     pub async fn send(self) -> Result<Gist> {
-        self.crab.post("gists", Some(&self.data)).await
+        self.crab.post("/gists", Some(&self.data)).await
     }
 }
 


### PR DESCRIPTION
This also "fixes" the failing gist creation example code.

related to #27 