### PR TITLE
examples: Add an example showing gist creation

### DIFF
--- a/examples/create_a_gist.rs
+++ b/examples/create_a_gist.rs
@@ -1,0 +1,24 @@
+use octocrab::Octocrab;
+
+#[tokio::main]
+async fn main() -> octocrab::Result<()> {
+    let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env variable is required");
+
+    let octocrab = Octocrab::builder().personal_token(token).build()?;
+
+    println!("Creating a gist with hello world in rust on your account");
+    let gist = octocrab
+        .gists()
+        .create()
+        .file(
+            "hello_world.rs",
+            "fn main() {\n println!(\"Hello World!\");\n}",
+        )
+        // Optional Parameters
+        .description("Hello World in Rust")
+        .public(false)
+        .send()
+        .await?;
+    println!("Done, created: {url}", url = gist.html_url.to_string());
+    Ok(())
+}


### PR DESCRIPTION
This takes the example from [`CreateGistHandler`'s rustdoc](https://github.com/XAMPPRocky/octocrab/blob/775936c7731b6a8cae4f0a2d4628d1d03e341e24/src/api/gists.rs#L25-L43) and adds it as a runnable example. 

Links to: #27 