### PR TITLE
Alter graphql method to pass arbitrarily complex payloads (variables and graphql-client support)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,13 +670,11 @@ impl Octocrab {
     /// ```
     pub async fn graphql<R: crate::FromResponse>(
         &self,
-        body: &(impl serde::Serialize + ?Sized),
+        payload: &(impl serde::Serialize + ?Sized),
     ) -> crate::Result<R> {
         self.post(
             "graphql",
-            Some(&serde_json::json!({
-                "query": body,
-            })),
+            Some(&serde_json::json!(payload)),
         )
         .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1022,11 +1022,8 @@ impl Octocrab {
         &self,
         payload: &(impl serde::Serialize + ?Sized),
     ) -> crate::Result<R> {
-        self.post(
-            "/graphql",
-            Some(&serde_json::json!(payload)),
-        )
-        .await
+        self.post("/graphql", Some(&serde_json::json!(payload)))
+            .await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -680,6 +680,31 @@ impl Octocrab {
         )
         .await
     }
+
+    /// Sends a graphql query to GitHub along with any required variables, and deserialises the response
+    /// from JSON.
+    /// ```no_run
+    ///# async fn run() -> octocrab::Result<()> {
+    /// let response: serde_json::Value = octocrab::instance()
+    ///     .graphql_with_variables("query ($count: Int!) { viewer { repositories(last: $count) { nodes { name } } } }", "{ "count": 10 }")
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub async fn graphql_with_variables<R: crate::FromResponse>(
+        &self,
+        body: &(impl serde::Serialize + ?Sized),
+        variables: &(impl serde::Serialize + ?Sized),
+    ) -> crate::Result<R> {
+        self.post(
+            "graphql",
+            Some(&serde_json::json!({
+                "query": body,
+                "variables": variables,
+            })),
+        )
+        .await
+    }
 }
 
 /// # HTTP Methods

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1013,7 +1013,7 @@ impl Octocrab {
     /// ```no_run
     ///# async fn run() -> octocrab::Result<()> {
     /// let response: serde_json::Value = octocrab::instance()
-    ///     .graphql("query { viewer { login }}")
+    ///     .graphql("{ 'query': '{ viewer { login }}' }")
     ///     .await?;
     ///# Ok(())
     ///# }
@@ -1023,33 +1023,8 @@ impl Octocrab {
         payload: &(impl serde::Serialize + ?Sized),
     ) -> crate::Result<R> {
         self.post(
-            "graphql",
-            Some(&serde_json::json!(payload)),
-        )
-        .await
-    }
-
-    /// Sends a graphql query to GitHub along with any required variables, and deserialises the response
-    /// from JSON.
-    /// ```no_run
-    ///# async fn run() -> octocrab::Result<()> {
-    /// let response: serde_json::Value = octocrab::instance()
-    ///     .graphql_with_variables("query ($count: Int!) { viewer { repositories(last: $count) { nodes { name } } } }", "{ "count": 10 }")
-    ///     .await?;
-    ///# Ok(())
-    ///# }
-    /// ```
-    pub async fn graphql_with_variables<R: crate::FromResponse>(
-        &self,
-        body: &(impl serde::Serialize + ?Sized),
-        variables: &(impl serde::Serialize + ?Sized),
-    ) -> crate::Result<R> {
-        self.post(
             "/graphql",
-            Some(&serde_json::json!({
-                "query": body,
-                "variables": variables,
-            })),
+            Some(&serde_json::json!(payload)),
         )
         .await
     }


### PR DESCRIPTION
Closes #177.

I've branched off of v0.19 and got this working, but 0.20 versions seem to panic (posted at the bottom).
Attempting to not make any breaking changes: I've added a second method to the graphql block that explicitly passes variables ([577783c](https://github.com/XAMPPRocky/octocrab/pull/332/commits/577783cc36e05e664e0a8b744ce16eb08cdf33b1)).

This still doesn't allow us to actually use the likes of [graphql-client](https://github.com/graphql-rust/graphql-client), since we're generating the `body` and `variables` explicitly. To enable this, we'd need to make a breaking change such that `graphql` looked more like this ([15ab99b](https://github.com/XAMPPRocky/octocrab/pull/332/commits/15ab99b941b5e780ec69089df3205f5aa859cf8b)):

```rust
pub async fn graphql<R: crate::FromResponse>(
         &self,
         payload: &(impl serde::Serialize + ?Sized),
) -> crate::Result<R> {     
        self.post(              
             "graphql",          
             Some(&serde_json::json!(payload)),
         )                                                   
         .await                                              
}
```

so that we could serialize [QueryBody](https://github.com/graphql-rust/graphql-client/blob/987a72d8de23acd07c98b599cf479b3674316e0e/graphql_client/src/lib.rs#L90-L99) properly. 

As it stands there's some work to do on this PR for it to be ready, but I think it'd be best to agree on the design direction before adding anything else.

---

Failure on 0.20-x:
```
Error: Service Error: error trying to connect: dns error: failed to lookup address information: Name or service not known

Found at  0 <snafu::backtrace_shim::Backtrace as snafu::GenerateImplicitData>::generate::hdba4c6d4c95a516e
   /home/tim/.cargo/registry/src/github.com-1ecc6299db9ec823/snafu-0.7.4/src/backtrace_shim.rs:15
   snafu::GenerateImplicitData::generate_with_source::hf58e5ce0dc248bd5
   /home/tim/.cargo/registry/src/github.com-1ecc6299db9ec823/snafu-0.7.4/src/lib.rs:1152
 1 <octocrab::error::ServiceSnafu as snafu::IntoError<octocrab::error::Error>>::into_error::h574c155efcb54da7
   /home/tim/.cargo/git/checkouts/octocrab-e41e95788484cc6b/b369007/src/error.rs:23
 2 <core::result::Result<T,E> as snafu::ResultExt<T,E>>::context::h5855c4f1c86b1443
   /home/tim/.cargo/registry/src/github.com-1ecc6299db9ec823/snafu-0.7.4/src/lib.rs:697
 3 octocrab::Octocrab::send::{{closure}}::hb88ac53a30777769
   /home/tim/.cargo/git/checkouts/octocrab-e41e95788484cc6b/b369007/src/lib.rs:1327
 4 octocrab::Octocrab::execute::{{closure}}::h80789cf7ae87153f
   /home/tim/.cargo/git/checkouts/octocrab-e41e95788484cc6b/b369007/src/lib.rs:1401
 5 octocrab::Octocrab::_post::{{closure}}::h34875f653be9849d
   /home/tim/.cargo/git/checkouts/octocrab-e41e95788484cc6b/b369007/src/lib.rs:1087
 6 octocrab::Octocrab::post::{{closure}}::h85c2333f4b5d0944
   /home/tim/.cargo/git/checkouts/octocrab-e41e95788484cc6b/b369007/src/lib.rs:1071
 7 octocrab::Octocrab::graphql_with_variables::{{closure}}::ha2b3981052ee3830
   /home/tim/.cargo/git/checkouts/octocrab-e41e95788484cc6b/b369007/src/lib.rs:1046
 8 githubapi::main::{{closure}}::hb11b5b9abf744129
   /mnt/turtle/scratch/githubapi/src/main.rs:53
 9 tokio::runtime::park::CachedParkThread::block_on::{{closure}}::hd33fdc053e9a0f40
   /home/tim/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/park.rs:283
10 tokio::runtime::coop::with_budget::hcd6feb83d577a4cb
   /home/tim/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/coop.rs:107
   tokio::runtime::coop::budget::h499f252586de8224
   /home/tim/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/coop.rs:73
   tokio::runtime::park::CachedParkThread::block_on::hd473620779372287
   /home/tim/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/park.rs:283
11 tokio::runtime::context::BlockingRegionGuard::block_on::h42e07193681fa260
   /home/tim/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/context.rs:315
12 tokio::runtime::scheduler::multi_thread::MultiThread::block_on::h97b44ee63dc13b0b
   /home/tim/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/scheduler/multi_thread/mod.rs:66
13 tokio::runtime::runtime::Runtime::block_on::h6f2e1c7999958463
   /home/tim/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/runtime.rs:304
14 githubapi::main::h92b07a76beaaccfe
   /mnt/turtle/scratch/githubapi/src/main.rs:68
15 core::ops::function::FnOnce::call_once::h9f711cddfbbe738d
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/core/src/ops/function.rs:250
16 std::sys_common::backtrace::__rust_begin_short_backtrace::h91dc861adfd36163
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/std/src/sys_common/backtrace.rs:121
17 std::rt::lang_start::{{closure}}::habb4b8267316e968
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/std/src/rt.rs:166
18 core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::h2dd1a24ae3e0569f
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/core/src/ops/function.rs:287
   std::panicking::try::do_call::h71e38d3ed05d0919
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/std/src/panicking.rs:483
   std::panicking::try::h9dd8fea17c119511
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/std/src/panicking.rs:447
   std::panic::catch_unwind::h073a10d358958706
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/std/src/panic.rs:140
   std::rt::lang_start_internal::{{closure}}::h0cf5d9b5652f6b98
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/std/src/rt.rs:148
   std::panicking::try::do_call::hc59ab1d339fa21e7
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/std/src/panicking.rs:483
   std::panicking::try::h40dd3124b394a6da
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/std/src/panicking.rs:447
   std::panic::catch_unwind::hff10c6c48e0fc17d
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/std/src/panic.rs:140
   std::rt::lang_start_internal::h7868f0ffe3ad1ec2
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/std/src/rt.rs:148
19 std::rt::lang_start::hba536777dd880493
   /rustc/8460ca823e8367a30dda430efda790588b8c84d3/library/std/src/rt.rs:165
20 main
22 __libc_start_main
23 _start


Caused by:
    0: error trying to connect: dns error: failed to lookup address information: Name or service not known
    1: dns error: failed to lookup address information: Name or service not known
    2: failed to lookup address information: Name or service not known
```