### PR TITLE
Add Checks API skeleton

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,7 @@
 pub mod actions;
 pub mod activity;
 pub mod apps;
+pub mod checks;
 pub mod commits;
 pub mod current;
 pub mod events;

--- a/src/api/checks.rs
+++ b/src/api/checks.rs
@@ -1,0 +1,81 @@
+use crate::models::CheckSuiteId;
+use crate::{models, Octocrab, Result};
+
+/// Handler for GitHub's Checks API.
+///
+/// Created with [`Octocrab::checks`].
+pub struct ChecksHandler<'octo> {
+    crab: &'octo Octocrab,
+    owner: String,
+    repo: String,
+}
+
+#[derive(serde::Serialize)]
+pub struct ListCheckRunsinCheckSuiteBuilder<'octo, 'r> {
+    #[serde(skip)]
+    handler: &'r ChecksHandler<'octo>,
+    check_suite_id: CheckSuiteId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+}
+
+impl<'octo, 'r> ListCheckRunsinCheckSuiteBuilder<'octo, 'r> {
+    pub(crate) fn new(handler: &'r ChecksHandler<'octo>, check_suite_id: CheckSuiteId) -> Self {
+        Self {
+            handler,
+            check_suite_id,
+            per_page: None,
+            page: None,
+        }
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.page = Some(page.into());
+        self
+    }
+
+    /// Send the actual request.
+    pub async fn send(self) -> Result<models::checks::ListCheckRuns> {
+        let route = format!(
+            "/repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs",
+            owner = self.handler.owner,
+            repo = self.handler.repo,
+            check_suite_id = self.check_suite_id,
+        );
+
+        self.handler.crab.get(route, Some(&self)).await
+    }
+}
+
+impl<'octo> ChecksHandler<'octo> {
+    pub(crate) fn new(crab: &'octo Octocrab, owner: String, repo: String) -> Self {
+        Self { crab, owner, repo }
+    }
+
+    /// Get the rate limit.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let check_runs = octocrab::instance()
+    ///     .checks("owner", "repo")
+    ///     .list_check_runs_in_a_check_suite(123456.into())
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list_check_runs_in_a_check_suite(
+        &self,
+        suite_id: CheckSuiteId,
+    ) -> ListCheckRunsinCheckSuiteBuilder<'_, '_> {
+        ListCheckRunsinCheckSuiteBuilder::new(self, suite_id)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,8 +215,8 @@ use models::{AppId, InstallationId, InstallationToken};
 
 pub use self::{
     api::{
-        actions, activity, apps, commits, current, events, gists, gitignore, issues, licenses,
-        markdown, orgs, pulls, ratelimit, repos, search, teams, workflows,
+        actions, activity, apps, checks, commits, current, events, gists, gitignore, issues,
+        licenses, markdown, orgs, pulls, ratelimit, repos, search, teams, workflows,
     },
     error::{Error, GitHubError},
     from_response::FromResponse,
@@ -978,6 +978,15 @@ impl Octocrab {
     /// GitHub's Gists API.
     pub fn gists(&self) -> gists::GistsHandler {
         gists::GistsHandler::new(self)
+    }
+
+    /// Creates a [`checks::ChecksHandler`] that allows to access the Checks API.
+    pub fn checks(
+        &self,
+        owner: impl Into<String>,
+        repo: impl Into<String>,
+    ) -> checks::ChecksHandler {
+        checks::ChecksHandler::new(self, owner.into(), repo.into())
     }
 
     /// Creates a [`ratelimit::RateLimitHandler`] that returns the API rate limit.

--- a/src/models.rs
+++ b/src/models.rs
@@ -10,6 +10,7 @@ use url::Url;
 
 pub mod activity;
 pub mod apps;
+pub mod checks;
 pub mod commits;
 pub mod events;
 pub mod gists;
@@ -96,6 +97,7 @@ id_type!(
     ArtifactId,
     AssetId,
     CardId,
+    CheckSuiteId,
     CheckRunId,
     CommentId,
     InstallationId,

--- a/src/models/checks.rs
+++ b/src/models/checks.rs
@@ -1,0 +1,16 @@
+use super::*;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CheckRun {
+    pub id: CheckRunId,
+    pub node_id: String,
+    pub details_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ListCheckRuns {
+    total_count: u64,
+    check_runs: Vec<CheckRun>,
+}


### PR DESCRIPTION
This adds an initial draft of the Checks API, which can be extended or reworked in the future