### PR TITLE
Enable rustls(and use as default client)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ futures-core = { version = "0.3.15", optional = true }
 futures-util = { version = "0.3.15", optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 percent-encoding = "2.2.0"
-rustls-pemfile = { version = "1.0.0", optional = true }
 [dev-dependencies]
 tokio = { version = "1.17.0", default-features = false, features = [
     "macros",
@@ -62,9 +61,10 @@ tokio-test = "0.4.2"
 wiremock = "0.5.3"
 
 [features]
-default = ["tls", "timeout", "tracing", "retry"]
+default = ["rustls", "timeout", "tracing", "retry"]
 
 retry = ["tower/retry", "futures-util"]
-tls = ["hyper-tls"]
+rustls = ["hyper-rustls"]
+opentls = ["hyper-tls"]
 timeout = ["hyper-timeout", "tokio", "tower/timeout"]
 stream = ["futures-core", "futures-util", "hyper/stream"]

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -1,6 +1,6 @@
 use http::header::USER_AGENT;
 use http::Uri;
-use hyper_tls::HttpsConnector;
+use hyper_rustls::HttpsConnectorBuilder;
 
 use octocrab::service::middleware::base_uri::BaseUriLayer;
 use octocrab::service::middleware::extra_headers::ExtraHeadersLayer;
@@ -9,7 +9,13 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> octocrab::Result<()> {
-    let client = hyper::Client::builder().build(HttpsConnector::new());
+    let connector = HttpsConnectorBuilder::new()
+        .with_native_roots() // enabled the `rustls-native-certs` feature in hyper-rustls
+        .https_only()
+        .enable_http1()
+        .build();
+
+    let client = hyper::Client::builder().build(connector);
     let octocrab = OctocrabBuilder::new_empty()
         .with_service(client)
         .with_layer(&BaseUriLayer::new(Uri::from_static(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use http::{header::HeaderName, StatusCode};
-#[cfg(all(not(feature = "tls")))]
+#[cfg(all(not(feature = "opentls"), not(feature = "rustls")))]
 use hyper::client::HttpConnector;
 use hyper::{body, Body, Request, Response};
 
@@ -183,8 +183,11 @@ use tower::{buffer::Buffer, util::BoxService, BoxError, Layer, Service, ServiceE
 use bytes::Bytes;
 use http::header::USER_AGENT;
 use http::request::Builder;
-#[cfg(feature = "tls")]
+#[cfg(feature = "opentls")]
 use hyper_tls::HttpsConnector;
+
+#[cfg(feature = "rustls")]
+use hyper_rustls::HttpsConnectorBuilder;
 
 #[cfg(feature = "retry")]
 use tower::retry::{Retry, RetryLayer};
@@ -524,9 +527,17 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
     /// Build a [`Client`] instance with the current [`Service`] stack.
     pub fn build(self) -> Result<Octocrab> {
         let client: hyper::Client<_, String> = {
-            #[cfg(all(not(feature = "tls")))]
+            #[cfg(all(not(feature = "opentls"), not(feature = "rustls")))]
             let mut connector = HttpConnector::new();
-            #[cfg(feature = "tls")]
+
+            #[cfg(all(feature = "rustls", not(feature = "opentls")))]
+            let connector = HttpsConnectorBuilder::new()
+                .with_native_roots() // enabled the `rustls-native-certs` feature in hyper-rustls
+                .https_only()
+                .enable_http1()
+                .build();
+
+            #[cfg(all(feature = "opentls", not(feature = "rustls")))]
             let connector = HttpsConnector::new();
 
             #[cfg(feature = "timeout")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,7 +533,7 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
             #[cfg(all(feature = "rustls", not(feature = "opentls")))]
             let connector = HttpsConnectorBuilder::new()
                 .with_native_roots() // enabled the `rustls-native-certs` feature in hyper-rustls
-                .https_only()
+                .https_or_http() //  Disable .https_only() during tests until: https://github.com/LukeMathWalker/wiremock-rs/issues/58 is resolved. Alternatively we can use conditional compilation to only enable this feature in tests, but it becomes rather ugly with integration tests.
                 .enable_http1()
                 .build();
 


### PR DESCRIPTION
Enable rustls as per #346

Since rustls is enabled, I have also renamed `tls` feature to `opentls`.

I have implemented the client using `https_or_http`, instead of `https_only`, since the mock server we use for tests doesn't currently support https endpoints. I could alternatively implement two separate clients using conditional compilation for tests, though it becomes rather ugly, especially having to introduce a separate feature just to compile this in integration tests(since `test` flag doesn't propagate to library code) 