### PR TITLE
Use CommitAuthor for Commit.author

### DIFF
--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -123,9 +123,9 @@ pub struct Commit {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comments_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub author: Option<Author>,
+    pub author: Option<CommitAuthor>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub committer: Option<Author>,
+    pub committer: Option<CommitAuthor>,
 }
 
 /// The author of a commit, identified by its name and email, as well as (optionally) a time


### PR DESCRIPTION
## Problem:
The GitHub response from creating a file/commit is failing due to a serialization error with the Commit struct, despite the request being successful.
The error is saying that the path of commit.author.login is missing.

## Context
In the GitHub documentation, they include the response schema for the "Create or update file contents" endpoint [Repositories/Contents/Create or update file contents](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents) , where, `author` is a git user with a `name: string`, an `email: string`, and a `date:string`. This is the same for the `committer` field in the response schema.

Full response schema:
<details>

```json
{
  "title": "File Commit",
  "description": "File Commit",
  "type": "object",
  "required": [
    "content",
    "commit"
  ],
  "properties": {
    "content": {
      "type": [
        "object",
        "null"
      ],
      "properties": {
        "name": {
          "type": "string"
        },
        "path": {
          "type": "string"
        },
        "sha": {
          "type": "string"
        },
        "size": {
          "type": "integer"
        },
        "url": {
          "type": "string"
        },
        "html_url": {
          "type": "string"
        },
        "git_url": {
          "type": "string"
        },
        "download_url": {
          "type": "string"
        },
        "type": {
          "type": "string"
        },
        "_links": {
          "type": "object",
          "properties": {
            "self": {
              "type": "string"
            },
            "git": {
              "type": "string"
            },
            "html": {
              "type": "string"
            }
          }
        }
      }
    },
    "commit": {
      "type": "object",
      "properties": {
        "sha": {
          "type": "string"
        },
        "node_id": {
          "type": "string"
        },
        "url": {
          "type": "string"
        },
        "html_url": {
          "type": "string"
        },
        "author": {
          "type": "object",
          "properties": {
            "date": {
              "type": "string"
            },
            "name": {
              "type": "string"
            },
            "email": {
              "type": "string"
            }
          }
        },
        "committer": {
          "type": "object",
          "properties": {
            "date": {
              "type": "string"
            },
            "name": {
              "type": "string"
            },
            "email": {
              "type": "string"
            }
          }
        },
        "message": {
          "type": "string"
        },
        "tree": {
          "type": "object",
          "properties": {
            "url": {
              "type": "string"
            },
            "sha": {
              "type": "string"
            }
          }
        },
        "parents": {
          "type": "array",
          "items": {
            "type": "object",
            "properties": {
              "url": {
                "type": "string"
              },
              "html_url": {
                "type": "string"
              },
              "sha": {
                "type": "string"
              }
            }
          }
        },
        "verification": {
          "type": "object",
          "properties": {
            "verified": {
              "type": "boolean"
            },
            "reason": {
              "type": "string"
            },
            "signature": {
              "type": [
                "string",
                "null"
              ]
            },
            "payload": {
              "type": [
                "string",
                "null"
              ]
            }
          }
        }
      }
    }
  }
}
```
</details>

## Fix
Use the `CommitAuthor` Author rather than the `Author` Author, for the `Commit` struct.