### PR TITLE
Fix authentication endpoints

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -155,7 +155,7 @@ impl crate::Octocrab {
         };
         let codes: DeviceCodes = self
             .post(
-                "login/device/code",
+                "/login/device/code",
                 Some(&DeviceFlow {
                     client_id: client_id.expose_secret(),
                     scope: &scope,
@@ -201,7 +201,7 @@ impl DeviceCodes {
     ) -> Result<Either<OAuth, Continue>> {
         let poll: TokenResponse = crab
             .post(
-                "login/oauth/access_token",
+                "/login/oauth/access_token",
                 Some(&PollForDevice {
                     client_id: client_id.expose_secret(),
                     device_code: &self.device_code,


### PR DESCRIPTION
After upgrading from a previous `octocrab` version, I've run into an URI parsing regression on these code paths.

I'm not entirely sure if this patch is exhaustive of this pattern/misuse being present in octocrab, but it fixes my issue.

If you'd like me to find a more systematic approach to this, I'm happy to patch that in too.