### PR TITLE
Handle redirects for download_tarball

### DIFF
--- a/src/api/actions.rs
+++ b/src/api/actions.rs
@@ -264,13 +264,7 @@ impl<'octo> ActionsHandler<'octo> {
         &self,
         response: http::Response<hyper::Body>,
     ) -> crate::Result<bytes::Bytes> {
-        let data_response = if let Some(redirect) = response.headers().get(http::header::LOCATION) {
-            let location = redirect.to_str().expect("Location URL not valid str");
-
-            self.crab._get(location).await?
-        } else {
-            response
-        };
+        let data_response = self.crab.follow_location_to_data(response).await?;
 
         let body = data_response.into_body();
 

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -546,7 +546,7 @@ impl<'octo> RepoHandler<'octo> {
             .path_and_query(route)
             .build()
             .context(HttpSnafu)?;
-        self.crab._get(uri).await
+        self.crab.follow_location_to_data(self.crab._get(uri).await?).await
     }
 
     /// Check if a user is a repository collaborator

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -546,7 +546,9 @@ impl<'octo> RepoHandler<'octo> {
             .path_and_query(route)
             .build()
             .context(HttpSnafu)?;
-        self.crab.follow_location_to_data(self.crab._get(uri).await?).await
+        self.crab
+            .follow_location_to_data(self.crab._get(uri).await?)
+            .await
     }
 
     /// Check if a user is a repository collaborator

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1395,6 +1395,19 @@ impl Octocrab {
         }
         Ok(response)
     }
+
+    pub async fn follow_location_to_data(
+        &self,
+        response: http::Response<hyper::Body>,
+    ) -> crate::Result<http::Response<hyper::Body>> {
+        if let Some(redirect) = response.headers().get(http::header::LOCATION) {
+            let location = redirect.to_str().expect("Location URL not valid str");
+
+            self._get(location).await
+        } else {
+            Ok(response)
+        }
+    }
 }
 
 /// # Utility Methods


### PR DESCRIPTION
I've observed that the GH API endpoint for download_tarball will return a 302. I suspect this was regressed when reqwest was removed because reqwest automatically follows redirects by default. There may be other API endpoints that are currently broken because of the underlying issue ...