### PR TITLE
add some of the missing fields to PullRequest

### DIFF
--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -83,6 +83,18 @@ pub struct PullRequest {
     pub draft: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo: Option<Box<Repository>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additions: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deletions: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub changed_files: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commits: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_comments: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comments: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This adds some of the fields that are missing from the PullRequest model but are present in the GitHub API response. However, I haven't checked if all fields from the API are present in the model now.

The docs can be found here https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request