### PR TITLE
fix: wrap pull_request_review_id in an Option

### DIFF
--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -233,7 +233,7 @@ pub enum ReviewState {
 #[non_exhaustive]
 pub struct Comment {
     pub url: Url,
-    pub pull_request_review_id: ReviewId,
+    pub pull_request_review_id: Option<ReviewId>,
     pub id: CommentId,
     pub node_id: String,
     pub diff_hunk: String,


### PR DESCRIPTION
In some instances, the GitHub API returns `null` for the `pull_request_review_id` field. Calling `octocrab::pulls::PullRequestHandler::list_comments()` errors with `invalid type: null, expected expected ReviewId as number or string`. This happens, for example, when loading the [comments for PR 1772 in bitcoin/bitcoin](https://api.github.com/repos/bitcoin/bitcoin/pulls/1772/comments) which returns:

```json
[
  {
    "url": "https://api.github.com/repos/bitcoin/bitcoin/pulls/comments/1525240",
    "pull_request_review_id": null,
    "id": 1525240,
    "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE1MjUyNDA=",
...
```


To avoid serialization problems, the field is wrapped in an Option.