### PR TITLE
fix: the API returns one reviewer not reviewers

### DIFF
--- a/src/models/timelines.rs
+++ b/src/models/timelines.rs
@@ -78,7 +78,7 @@ pub struct TimelineEvent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pull_request_url: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub requested_reviewers: Option<Vec<Author>>,
+    pub requested_reviewer: Option<Author>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub review_requester: Option<Author>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
For the ["review_requested"][0] and ["review_request_removed"][1] events the GitHub API returns only a single requested_reviewer and not multiple requested_reviewers. This was incorrectly introduced in 250d9efb956361767f485752a68ba09c4ba5cbf4.

[0]: https://docs.github.com/en/webhooks-and-events/events/issue-event-types#properties-for-review_requested
[1]: https://docs.github.com/en/webhooks-and-events/events/issue-event-types#review_request_removed