### PR TITLE
Add list_teams() and list_collaborators() to repos()

### DIFF
--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -6,6 +6,7 @@ use http::Uri;
 use snafu::ResultExt;
 
 mod branches;
+mod collaborators;
 mod commits;
 pub mod events;
 mod file;
@@ -17,10 +18,12 @@ pub mod releases;
 mod stargazers;
 mod status;
 mod tags;
+mod teams;
 
 use crate::error::HttpSnafu;
 use crate::{models, params, Octocrab, Result};
 pub use branches::ListBranchesBuilder;
+pub use collaborators::ListCollaboratorsBuilder;
 pub use commits::ListCommitsBuilder;
 pub use file::{DeleteFileBuilder, GetContentBuilder, UpdateFileBuilder};
 pub use generate::GenerateRepositoryBuilder;
@@ -30,6 +33,7 @@ pub use releases::ReleasesHandler;
 pub use stargazers::ListStarGazersBuilder;
 pub use status::{CreateStatusBuilder, ListStatusesBuilder};
 pub use tags::ListTagsBuilder;
+pub use teams::ListTeamsBuilder;
 
 /// Handler for GitHub's repository API.
 ///
@@ -377,6 +381,28 @@ impl<'octo> RepoHandler<'octo> {
     /// ```
     pub fn list_commits(&self) -> ListCommitsBuilder<'_, '_> {
         ListCommitsBuilder::new(self)
+    }
+
+    /// List teams from a repository.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let teams = octocrab::instance().repos("owner", "repo").list_teams().send().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list_teams(&self) -> ListTeamsBuilder<'_, '_> {
+        ListTeamsBuilder::new(self)
+    }
+
+    /// List collaborators from a repository.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let teams = octocrab::instance().repos("owner", "repo").list_teams().send().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list_collaborators(&self) -> ListCollaboratorsBuilder<'_, '_> {
+        ListCollaboratorsBuilder::new(self)
     }
 
     /// List star_gazers from a repository.

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -397,7 +397,7 @@ impl<'octo> RepoHandler<'octo> {
     /// List collaborators from a repository.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
-    /// let teams = octocrab::instance().repos("owner", "repo").list_teams().send().await?;
+    /// let collaborators = octocrab::instance().repos("owner", "repo").list_collaborators().send().await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/api/repos/collaborators.rs
+++ b/src/api/repos/collaborators.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+#[derive(serde::Serialize)]
+pub struct ListCollaboratorsBuilder<'octo, 'r> {
+    #[serde(skip)]
+    handler: &'r RepoHandler<'octo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+}
+
+impl<'octo, 'r> ListCollaboratorsBuilder<'octo, 'r> {
+    pub fn new(handler: &'r RepoHandler<'octo>) -> Self {
+        Self {
+            handler,
+            per_page: None,
+            page: None,
+        }
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.page = Some(page.into());
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(self) -> crate::Result<crate::Page<crate::models::Collaborator>> {
+        let route = format!(
+            "/repos/{owner}/{repo}/collaborators",
+            owner = self.handler.owner,
+            repo = self.handler.repo
+        );
+        self.handler.crab.get(route, Some(&self)).await
+    }
+}

--- a/src/api/repos/teams.rs
+++ b/src/api/repos/teams.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+#[derive(serde::Serialize)]
+pub struct ListTeamsBuilder<'octo, 'r> {
+    #[serde(skip)]
+    handler: &'r RepoHandler<'octo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+}
+
+impl<'octo, 'r> ListTeamsBuilder<'octo, 'r> {
+    pub fn new(handler: &'r RepoHandler<'octo>) -> Self {
+        Self {
+            handler,
+            per_page: None,
+            page: None,
+        }
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.page = Some(page.into());
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(self) -> crate::Result<crate::Page<crate::models::teams::Team>> {
+        let route = format!(
+            "/repos/{owner}/{repo}/teams",
+            owner = self.handler.owner,
+            repo = self.handler.repo
+        );
+        self.handler.crab.get(route, Some(&self)).await
+    }
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -411,7 +411,6 @@ pub struct Collaborator {
     pub permissions: Permissions,
 }
 
-
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct StarGazer {

--- a/src/models.rs
+++ b/src/models.rs
@@ -403,6 +403,15 @@ pub struct Author {
     pub site_admin: bool,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Collaborator {
+    #[serde(flatten)]
+    pub author: Author,
+    pub permissions: Permissions,
+}
+
+
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct StarGazer {


### PR DESCRIPTION
This adds the following functions (copied from existing implementation patterns):

```rust
/// List teams from a repository.
pub fn list_teams(&self) -> ListTeamsBuilder<'_, '_> {
    ListTeamsBuilder::new(self)
}
```

and 

```rust
/// List collaborators from a repository.
pub fn list_collaborators(&self) -> ListCollaboratorsBuilder<'_, '_> {
    ListCollaboratorsBuilder::new(self)
}
```

which would be called, for example, respectively:

```rust
let teams = octocrab::instance().repos("owner", "repo").list_teams().send().await?;
```

and

```rust
let collaborators = octocrab::instance().repos("owner", "repo").list_collaborators().send().await?;
```