### PR TITLE
Add Get Commit API

### DIFF
--- a/examples/get_commit.rs
+++ b/examples/get_commit.rs
@@ -6,7 +6,10 @@ async fn main() -> octocrab::Result<()> {
 
     let octocrab = Octocrab::builder().personal_token(token).build()?;
 
-    let commit = octocrab.commits("XAMPPRocky", "octocrab").get("15c0e31").await?;
+    let commit = octocrab
+        .commits("XAMPPRocky", "octocrab")
+        .get("15c0e31")
+        .await?;
 
     for file in commit.files.unwrap() {
         println!(

--- a/examples/get_commit.rs
+++ b/examples/get_commit.rs
@@ -1,0 +1,21 @@
+use octocrab::Octocrab;
+
+#[tokio::main]
+async fn main() -> octocrab::Result<()> {
+    let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env variable is required");
+
+    let octocrab = Octocrab::builder().personal_token(token).build()?;
+
+    let commit = octocrab.commits("XAMPPRocky", "octocrab").get("15c0e31").await?;
+
+    for file in commit.files.unwrap() {
+        println!(
+            "File: {file}, Additions: {additions}, Deletions: {deletions}",
+            file = file.filename,
+            additions = file.additions,
+            deletions = file.deletions,
+        );
+    }
+
+    Ok(())
+}

--- a/src/api/commits.rs
+++ b/src/api/commits.rs
@@ -2,7 +2,7 @@
 mod create_comment;
 
 pub use self::create_comment::CreateCommentBuilder;
-use crate::{models, Octocrab};
+use crate::{models, Octocrab, Result};
 
 pub struct CommitHandler<'octo> {
     crab: &'octo Octocrab,
@@ -25,5 +25,18 @@ impl<'octo> CommitHandler<'octo> {
         body: impl Into<String>,
     ) -> create_comment::CreateCommentBuilder<'_, '_> {
         create_comment::CreateCommentBuilder::new(self, sha.into(), body.into())
+    }
+
+    pub async fn get(
+        &self,
+        reference: impl Into<String>,
+    ) -> Result<models::repos::RepoCommit> {
+        let route = format!(
+            "/repos/{owner}/{repo}/commits/{reference}",
+            owner = self.owner,
+            repo = self.repo,
+            reference = reference.into(),
+        );
+        self.crab.get(route, None::<&()>).await
     }
 }

--- a/src/api/commits.rs
+++ b/src/api/commits.rs
@@ -27,10 +27,7 @@ impl<'octo> CommitHandler<'octo> {
         create_comment::CreateCommentBuilder::new(self, sha.into(), body.into())
     }
 
-    pub async fn get(
-        &self,
-        reference: impl Into<String>,
-    ) -> Result<models::repos::RepoCommit> {
+    pub async fn get(&self, reference: impl Into<String>) -> Result<models::repos::RepoCommit> {
         let route = format!(
             "/repos/{owner}/{repo}/commits/{reference}",
             owner = self.owner,


### PR DESCRIPTION
Add `get` method to `CommitHandler`. This appears to more reliably return `Some` for optional response fields such as `files` and `stats`. See https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit