### PR TITLE
Add installation_id in Webhook events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ tokio-test = "0.4.2"
 wiremock = "0.5.3"
 crypto_box = { version = "0.8.2", features = ["seal"] }
 base64 = "0.21.2"
+pretty_assertions = "1.4.0"
 
 [features]
 default = ["rustls", "timeout", "tracing", "retry"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octocrab"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["XAMPPRocky <xampprocky@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -157,6 +157,7 @@ impl<'de> Deserialize<'de> for Event {
 #[cfg(test)]
 mod test {
     use super::{Event, EventPayload, EventType};
+    use pretty_assertions::assert_eq;
     use url::Url;
 
     #[test]

--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -140,6 +140,9 @@ impl<'de> Deserialize<'de> for Event {
         #[derive(Deserialize)]
         struct IntermediatePayload {
             installation: Option<EventInstallationPayload>,
+            organization: Option<crate::models::orgs::Organization>,
+            repository: Option<crate::models::Repository>,
+            sender: Option<crate::models::Author>,
             #[serde(flatten)]
             specific: Option<serde_json::Value>,
         }
@@ -153,6 +156,9 @@ impl<'de> Deserialize<'de> for Event {
             .map_err(|e| Error::custom(e.to_string()))?;
             Ok(Some(WrappedEventPayload {
                 installation: data.installation,
+                organization: data.organization,
+                repository: data.repository,
+                sender: data.sender,
                 specific,
             }))
         })?;

--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -1,10 +1,12 @@
 pub mod payload;
 
+use crate::models::events::payload::EventInstallationPayload;
+
 use self::payload::{
     CommitCommentEventPayload, CreateEventPayload, DeleteEventPayload, EventPayload,
     ForkEventPayload, GollumEventPayload, IssueCommentEventPayload, IssuesEventPayload,
     PullRequestEventPayload, PullRequestReviewCommentEventPayload, PullRequestReviewEventPayload,
-    PushEventPayload, WorkflowRunEventPayload,
+    PushEventPayload, WorkflowRunEventPayload, WrappedEventPayload,
 };
 use super::{ActorId, OrgId, RepositoryId};
 use chrono::{DateTime, Utc};
@@ -22,7 +24,7 @@ pub struct Event {
     pub repo: Repository,
     pub public: bool,
     pub created_at: DateTime<Utc>,
-    pub payload: Option<EventPayload>,
+    pub payload: Option<WrappedEventPayload>,
     pub org: Option<Org>,
 }
 
@@ -133,12 +135,26 @@ impl<'de> Deserialize<'de> for Event {
             public: bool,
             created_at: DateTime<Utc>,
             org: Option<Org>,
-            payload: Option<serde_json::Value>,
+            payload: Option<IntermediatePayload>,
+        }
+        #[derive(Deserialize)]
+        struct IntermediatePayload {
+            installation: Option<EventInstallationPayload>,
+            #[serde(flatten)]
+            specific: Option<serde_json::Value>,
         }
         let intermediate = Intermediate::deserialize(deserializer)?;
         let event_type = deserialize_event_type(intermediate.typ.as_ref());
         let payload = intermediate.payload.map_or(Ok(None), |data| {
-            deserialize_payload(&event_type, data).map_err(|e| Error::custom(e.to_string()))
+            let specific = deserialize_payload(
+                &event_type,
+                data.specific.unwrap_or(serde_json::Value::Null),
+            )
+            .map_err(|e| Error::custom(e.to_string()))?;
+            Ok(Some(WrappedEventPayload {
+                installation: data.installation,
+                specific,
+            }))
         })?;
         let event = Event {
             id: intermediate.id,
@@ -207,6 +223,10 @@ mod test {
         let json = include_str!("../../tests/resources/workflow_run_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
         assert_eq!(event.r#type, EventType::WorkflowRunEvent);
+        assert_eq!(
+            event.payload.unwrap().installation.unwrap().id,
+            crate::models::InstallationId(18995746)
+        )
     }
 
     #[test]
@@ -269,7 +289,7 @@ mod test {
         let event: Event = serde_json::from_str(json).unwrap();
         assert!(event.payload.is_some());
         let payload = event.payload.unwrap();
-        match payload {
+        match payload.specific.unwrap() {
             EventPayload::UnknownEvent(json) => {
                 assert!(json.is_object());
                 let map = json.as_object().unwrap();

--- a/src/models/events/payload.rs
+++ b/src/models/events/payload.rs
@@ -30,6 +30,8 @@ pub use workflow_run::*;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use crate::models::{orgs::Organization, Author, Repository};
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EventInstallationPayload {
     pub id: InstallationId,
@@ -38,6 +40,9 @@ pub struct EventInstallationPayload {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WrappedEventPayload {
     pub installation: Option<EventInstallationPayload>,
+    pub organization: Option<Organization>,
+    pub repository: Option<Repository>,
+    pub sender: Option<Author>,
     #[serde(flatten)]
     pub specific: Option<EventPayload>,
 }

--- a/src/models/events/payload.rs
+++ b/src/models/events/payload.rs
@@ -12,7 +12,7 @@ mod pull_request_review_comment;
 mod push;
 mod workflow_run;
 
-use crate::models::repos::CommitAuthor;
+use crate::models::{repos::CommitAuthor, InstallationId};
 pub use commit_comment::*;
 pub use create::*;
 pub use delete::*;
@@ -29,6 +29,18 @@ pub use workflow_run::*;
 
 use serde::{Deserialize, Serialize};
 use url::Url;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EventInstallationPayload {
+    pub id: InstallationId,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WrappedEventPayload {
+    pub installation: Option<EventInstallationPayload>,
+    #[serde(flatten)]
+    pub specific: Option<EventPayload>,
+}
 
 /// The payload in an event type.
 ///

--- a/src/models/events/payload/commit_comment.rs
+++ b/src/models/events/payload/commit_comment.rs
@@ -17,7 +17,9 @@ mod test {
     fn should_deserialize_with_correct_payload() {
         let json = include_str!("../../../../tests/resources/commit_comment_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        if let Some(EventPayload::CommitCommentEvent(payload)) = event.payload {
+        if let Some(EventPayload::CommitCommentEvent(ref payload)) =
+            event.payload.as_ref().unwrap().specific
+        {
             assert_eq!(payload.comment.id.0, 46377107);
         } else {
             panic!("unexpected event payload encountered: {:#?}", event.payload);

--- a/src/models/events/payload/create.rs
+++ b/src/models/events/payload/create.rs
@@ -21,7 +21,7 @@ mod test {
         let json = include_str!("../../../../tests/resources/create_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
         assert!(event.payload.is_some());
-        let payload = event.payload.unwrap();
+        let payload = event.payload.unwrap().specific.unwrap();
         match payload {
             EventPayload::CreateEvent(payload) => {
                 assert_eq!(payload.r#ref, Some("url-normalisation".to_string()));
@@ -43,7 +43,7 @@ mod test {
             include_str!("../../../../tests/resources/create_event_with_null_description.json");
         let event: Event = serde_json::from_str(json).unwrap();
         assert!(event.payload.is_some());
-        let payload = event.payload.unwrap();
+        let payload = event.payload.unwrap().specific.unwrap();
         match payload {
             EventPayload::CreateEvent(payload) => assert_eq!(payload.description, None),
             _ => panic!("unexpected event deserialized"),

--- a/src/models/events/payload/delete.rs
+++ b/src/models/events/payload/delete.rs
@@ -18,7 +18,9 @@ mod test {
     fn should_deserialize_with_correct_payload() {
         let json = include_str!("../../../../tests/resources/delete_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        if let Some(EventPayload::DeleteEvent(payload)) = event.payload {
+        if let Some(EventPayload::DeleteEvent(ref payload)) =
+            event.payload.as_ref().unwrap().specific
+        {
             assert_eq!(payload.r#ref, "test2");
             assert_eq!(payload.ref_type, "branch");
         } else {

--- a/src/models/events/payload/fork.rs
+++ b/src/models/events/payload/fork.rs
@@ -17,7 +17,8 @@ mod test {
     fn should_deserialize_with_correct_payload() {
         let json = include_str!("../../../../tests/resources/fork_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        if let Some(EventPayload::ForkEvent(payload)) = event.payload {
+        if let Some(EventPayload::ForkEvent(ref payload)) = event.payload.as_ref().unwrap().specific
+        {
             assert_eq!(payload.forkee.id.0, 334843423);
         } else {
             panic!("unexpected event payload encountered: {:#?}", event.payload);

--- a/src/models/events/payload/gollum.rs
+++ b/src/models/events/payload/gollum.rs
@@ -55,7 +55,9 @@ mod test {
     fn should_deserialize_with_correct_payload() {
         let json = include_str!("../../../../tests/resources/gollum_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        if let Some(EventPayload::GollumEvent(payload)) = event.payload {
+        if let Some(EventPayload::GollumEvent(ref payload)) =
+            event.payload.as_ref().unwrap().specific
+        {
             assert_eq!(payload.pages[0].page_name, "Home");
             assert_eq!(payload.pages[0].title, "Home");
             assert_eq!(payload.pages[0].action, GollumEventPageAction::Created);

--- a/src/models/events/payload/issue_comment.rs
+++ b/src/models/events/payload/issue_comment.rs
@@ -83,7 +83,9 @@ mod test {
     fn should_deserialize_with_correct_payload() {
         let json = include_str!("../../../../tests/resources/issue_comment_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        if let Some(EventPayload::IssueCommentEvent(payload)) = event.payload {
+        if let Some(EventPayload::IssueCommentEvent(ref payload)) =
+            event.payload.as_ref().unwrap().specific
+        {
             assert_eq!(payload.action, IssueCommentEventAction::Created);
             assert_eq!(payload.issue.id.0, 785981862);
             assert_eq!(payload.comment.id.0, 760203693);

--- a/src/models/events/payload/issues.rs
+++ b/src/models/events/payload/issues.rs
@@ -120,7 +120,9 @@ mod test {
     fn should_deserialize_with_correct_payload() {
         let json = include_str!("../../../../tests/resources/issues_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        if let Some(EventPayload::IssuesEvent(payload)) = event.payload {
+        if let Some(EventPayload::IssuesEvent(ref payload)) =
+            event.payload.as_ref().unwrap().specific
+        {
             assert_eq!(payload.action, IssuesEventAction::Opened);
             assert_eq!(payload.issue.id.0, 786747990);
         } else {

--- a/src/models/events/payload/member.rs
+++ b/src/models/events/payload/member.rs
@@ -83,7 +83,9 @@ mod test {
     fn should_deserialize_with_correct_payload() {
         let json = include_str!("../../../../tests/resources/member_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        if let Some(EventPayload::MemberEvent(payload)) = event.payload {
+        if let Some(EventPayload::MemberEvent(ref payload)) =
+            event.payload.as_ref().unwrap().specific
+        {
             assert_eq!(payload.action, MemberEventAction::Added);
             assert_eq!(payload.member.id.0, 58522265);
         } else {

--- a/src/models/events/payload/pull_request.rs
+++ b/src/models/events/payload/pull_request.rs
@@ -148,7 +148,9 @@ mod test {
     fn should_deserialize_with_correct_payload() {
         let json = include_str!("../../../../tests/resources/pull_request_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        if let Some(EventPayload::PullRequestEvent(payload)) = event.payload {
+        if let Some(EventPayload::PullRequestEvent(ref payload)) =
+            event.payload.as_ref().unwrap().specific
+        {
             assert_eq!(payload.action, PullRequestEventAction::Opened);
             assert_eq!(payload.number, 8);
             assert_eq!(payload.pull_request.id.0, 558121796);

--- a/src/models/events/payload/pull_request_review.rs
+++ b/src/models/events/payload/pull_request_review.rs
@@ -75,7 +75,9 @@ mod test {
     fn should_deserialize_with_correct_payload() {
         let json = include_str!("../../../../tests/resources/pull_request_review_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        if let Some(EventPayload::PullRequestReviewEvent(payload)) = event.payload {
+        if let Some(EventPayload::PullRequestReviewEvent(ref payload)) =
+            event.payload.as_ref().unwrap().specific
+        {
             assert_eq!(payload.pull_request.id.0, 1237933052);
         } else {
             panic!("unexpected event payload encountered: {:#?}", event.payload);

--- a/src/models/events/payload/pull_request_review_comment.rs
+++ b/src/models/events/payload/pull_request_review_comment.rs
@@ -84,7 +84,9 @@ mod test {
         let json =
             include_str!("../../../../tests/resources/pull_request_review_comment_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        if let Some(EventPayload::PullRequestReviewCommentEvent(payload)) = event.payload {
+        if let Some(EventPayload::PullRequestReviewCommentEvent(ref payload)) =
+            event.payload.as_ref().unwrap().specific
+        {
             assert_eq!(payload.action, PullRequestReviewCommentEventAction::Created);
             assert_eq!(payload.pull_request.id.0, 558121796);
             assert_eq!(payload.comment.id.0, 560976245);

--- a/src/models/events/payload/push.rs
+++ b/src/models/events/payload/push.rs
@@ -29,7 +29,7 @@ mod test {
         let json = include_str!("../../../../tests/resources/push_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
         assert!(event.payload.is_some());
-        let payload = event.payload.unwrap();
+        let payload = event.payload.unwrap().specific.unwrap();
         match payload {
             EventPayload::PushEvent(payload) => {
                 assert_eq!(payload.push_id.0, 6080608029);

--- a/src/models/events/payload/workflow_run.rs
+++ b/src/models/events/payload/workflow_run.rs
@@ -12,9 +12,6 @@ pub struct WorkflowRunEventPayload {
     pub action: WorkflowRunEventAction,
     pub workflow_run: Run,
     pub workflow: WorkFlow,
-    pub organization: Option<Organization>,
-    pub repository: Repository,
-    pub sender: Author,
 }
 
 /// The action on a pull request this event corresponds to.
@@ -52,7 +49,7 @@ mod test {
             event.payload.as_ref().unwrap().specific
         {
             assert_eq!(payload.workflow_run.run_number, 1185);
-            assert_eq!(payload.organization, None);
+            assert_eq!(event.payload.as_ref().unwrap().organization, None);
         } else {
             panic!("unexpected event payload encountered: {:#?}", event.payload);
         }

--- a/src/models/events/payload/workflow_run.rs
+++ b/src/models/events/payload/workflow_run.rs
@@ -34,7 +34,9 @@ mod test {
     fn should_deserialize_with_correct_payload() {
         let json = include_str!("../../../../tests/resources/workflow_run_event.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        if let Some(EventPayload::WorkflowRunEvent(payload)) = event.payload {
+        if let Some(EventPayload::WorkflowRunEvent(ref payload)) =
+            event.payload.as_ref().unwrap().specific
+        {
             assert_eq!(payload.workflow_run.run_number, 1185);
         } else {
             panic!("unexpected event payload encountered: {:#?}", event.payload);
@@ -46,7 +48,9 @@ mod test {
         let json =
             include_str!("../../../../tests/resources/workflow_run_event_no_organization.json");
         let event: Event = serde_json::from_str(json).unwrap();
-        if let Some(EventPayload::WorkflowRunEvent(payload)) = event.payload {
+        if let Some(EventPayload::WorkflowRunEvent(ref payload)) =
+            event.payload.as_ref().unwrap().specific
+        {
             assert_eq!(payload.workflow_run.run_number, 1185);
             assert_eq!(payload.organization, None);
         } else {


### PR DESCRIPTION
This PR does 2 things:

- Add `pretty_assertions` as a dev dependency to have better output from the "there and back again" serde tests
- Add support for reading `installation_id` from webhook payloads.

This last change is a breaking change (hence the `0.26` bump), because it wraps the `EventPayload` enum to have
easy access to common Event fields whichever variant is actually deserialized.

Tests have been changed accordingly to follow the new API, which could definitely be changed. All the name of the types/fields are also "quick names" that I chose to get going, I'm open to suggestions for better names

Fixes #407

- [ ] Extract sender, organization, and repository from https://github.com/XAMPPRocky/octocrab/blob/f2ce7986fc12c7084ff84bf3e022aa53b8dfa39f/src/models/events/payload/workflow_run.rs#L15 to the common fields of payload (as per [the doc](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-object-common-properties))