### PR TITLE
Deserialize installation_* webhook events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octocrab"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["XAMPPRocky <xampprocky@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -1,6 +1,6 @@
 pub mod payload;
 
-use crate::models::events::payload::EventInstallationPayload;
+use crate::models::events::payload::EventInstallation;
 
 use self::payload::{
     CommitCommentEventPayload, CreateEventPayload, DeleteEventPayload, EventPayload,
@@ -15,6 +15,10 @@ use serde::{de::Error, Deserialize, Serialize};
 use url::Url;
 
 /// A GitHub event.
+///
+/// If you want to deserialize a webhook payload received in a Github Application, you
+/// must directly deserialize the body into a [`WrappedEventPayload`](WrappedEventPayload).
+/// For webhooks, the event type is stored in the `X-GitHub-Event` header.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[non_exhaustive]
 pub struct Event {
@@ -139,7 +143,7 @@ impl<'de> Deserialize<'de> for Event {
         }
         #[derive(Deserialize)]
         struct IntermediatePayload {
-            installation: Option<EventInstallationPayload>,
+            installation: Option<EventInstallation>,
             organization: Option<crate::models::orgs::Organization>,
             repository: Option<crate::models::Repository>,
             sender: Option<crate::models::Author>,
@@ -230,8 +234,13 @@ mod test {
         let event: Event = serde_json::from_str(json).unwrap();
         assert_eq!(event.r#type, EventType::WorkflowRunEvent);
         assert_eq!(
-            event.payload.unwrap().installation.unwrap().id,
-            crate::models::InstallationId(18995746)
+            event.payload.unwrap().installation.unwrap(),
+            crate::models::events::payload::EventInstallation::Minimal(Box::new(
+                crate::models::events::payload::EventInstallationId {
+                    id: 18995746.into(),
+                    node_id: "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMTg5OTU3NDY=".to_string()
+                }
+            ))
         )
     }
 

--- a/src/models/events/payload/installation.rs
+++ b/src/models/events/payload/installation.rs
@@ -1,0 +1,39 @@
+//! This event occurs when there is activity relating to a GitHub App
+//! installation. All GitHub Apps receive this event by default. You cannot
+//! manually subscribe to this event.
+
+use serde::{Deserialize, Serialize};
+
+use super::InstallationEventRepository;
+use crate::models::Author;
+
+/// The payload in a webhook installation event type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InstallationEventPayload {
+    /// The action this event represents.
+    pub action: InstallationEventAction,
+    /// An enterprise on GitHub
+    pub enterprise: Option<serde_json::Value>,
+    /// An array of repositories that the installation can access
+    pub repositories: Vec<InstallationEventRepository>,
+    /// The initiator of the request, mainly for the [`created`](InstallationAction::Created) action
+    pub requester: Option<Author>,
+}
+
+/// The action on an installation this event corresponds to.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum InstallationEventAction {
+    /// Someone installed a GitHub App on a user or organization account.
+    Created,
+    /// Someone uninstalled a GitHub App on a user or organization account.
+    Deleted,
+    /// Someone granted new permissions to a GitHub App.
+    NewPermissionsAccepted,
+    /// Someone blocked access by a GitHub App to their user or organization account.
+    Suspend,
+    /// A GitHub App that was blocked from accessing a user or organization account was given access the account again.
+    Unsuspend,
+}

--- a/src/models/events/payload/installation_repositories.rs
+++ b/src/models/events/payload/installation_repositories.rs
@@ -1,0 +1,45 @@
+//! This event occurs when there is activity relating to which repositories a
+//! GitHub App installation can access. All GitHub Apps receive this event by
+//! default. You cannot manually subscribe to this event.
+
+use serde::{Deserialize, Serialize};
+
+use super::InstallationEventRepository;
+use crate::models::Author;
+
+/// The payload in a webhook installation_repositories event type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InstallationRepositoriesEventPayload {
+    /// The action this event represents.
+    pub action: InstallationRepositoriesEventAction,
+    /// An enterprise on GitHub
+    pub enterprise: Option<serde_json::Value>,
+    /// An array of repositories, which were added to the installation
+    pub repositories_added: Vec<InstallationEventRepository>,
+    /// An array of repositories, which were removed from the installation
+    pub repositories_removed: Vec<InstallationEventRepository>,
+    /// Describe whether all repositories have been selected or there's a selection involved
+    pub repository_selection: InstallationRepositoriesEventSelection,
+    /// The initiator of the request, mainly for the [`created`](InstallationAction::Created) action
+    pub requester: Option<Author>,
+}
+
+/// The action on an installation this event corresponds to.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum InstallationRepositoriesEventAction {
+    /// A GitHub App installation was granted access to one or more repositories.
+    Added,
+    /// Access to one or more repositories was revoked for a GitHub App installation.
+    Removed,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum InstallationRepositoriesEventSelection {
+    All,
+    Selected,
+}

--- a/src/models/events/payload/installation_target.rs
+++ b/src/models/events/payload/installation_target.rs
@@ -1,0 +1,36 @@
+//! This event occurs when there is activity relating to the user or
+//! organization account that a GitHub App is installed on.
+
+use serde::{Deserialize, Serialize};
+
+use crate::models::orgs::Organization;
+
+/// The payload in a webhook installation_target event type.
+///
+/// Somebody renamed the user or organization account that a GitHub App is installed on.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InstallationTargetEventPayload {
+    pub account: Organization,
+    pub changes: InstallationTargetChanges,
+    pub target_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InstallationTargetChanges {
+    pub login: InstallationTargetLoginChanges,
+    pub slug: InstallationTargetSlugChanges,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InstallationTargetLoginChanges {
+    pub from: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InstallationTargetSlugChanges {
+    pub from: String,
+}

--- a/tests/resources/installation_event.json
+++ b/tests/resources/installation_event.json
@@ -1,0 +1,100 @@
+{
+  "action": "created",
+  "installation": {
+    "id": 7777777,
+    "account": {
+      "login": "gagbo",
+      "id": 88888,
+      "node_id": "PLACEHOLDER_NODE_ID",
+      "avatar_url": "https://avatars.githubusercontent.com/u/88888?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/gagbo",
+      "html_url": "https://github.com/gagbo",
+      "followers_url": "https://api.github.com/users/gagbo/followers",
+      "following_url": "https://api.github.com/users/gagbo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/gagbo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/gagbo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/gagbo/subscriptions",
+      "organizations_url": "https://api.github.com/users/gagbo/orgs",
+      "repos_url": "https://api.github.com/users/gagbo/repos",
+      "events_url": "https://api.github.com/users/gagbo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/gagbo/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "repository_selection": "all",
+    "access_tokens_url": "https://api.github.com/app/installations/39593520/access_tokens",
+    "repositories_url": "https://api.github.com/installation/repositories",
+    "html_url": "https://github.com/settings/installations/39593520",
+    "app_id": 360617,
+    "app_slug": "gagbo-test-app",
+    "target_id": 88888,
+    "target_type": "User",
+    "permissions": {
+      "issues": "write",
+      "actions": "write",
+      "metadata": "read",
+      "pull_requests": "write"
+    },
+    "events": [
+      "issues",
+      "issue_comment",
+      "pull_request",
+      "pull_request_review",
+      "pull_request_review_comment",
+      "pull_request_review_thread",
+      "repository"
+    ],
+    "created_at": "2023-07-13T11:35:31.000+02:00",
+    "updated_at": "2023-07-13T11:35:32.000+02:00",
+    "single_file_name": null,
+    "has_multiple_single_files": false,
+    "single_file_paths": [],
+    "suspended_by": null,
+    "suspended_at": null
+  },
+  "repositories": [
+    {
+      "id": 29128586,
+      "node_id": "MDEwOlJlcG9zaXRvcnkyOTEyODU4Ng==",
+      "name": "ViscoElRebound",
+      "full_name": "gagbo/ViscoElRebound",
+      "private": false
+    },
+    {
+      "id": 109778911,
+      "node_id": "MDEwOlJlcG9zaXRvcnkxMDk3Nzg5MTE=",
+      "name": "OSSU",
+      "full_name": "gagbo/OSSU",
+      "private": true
+    },
+    {
+      "id": 665086759,
+      "node_id": "R_kgDOJ6RrJw",
+      "name": "octocrab",
+      "full_name": "gagbo/octocrab",
+      "private": false
+    }
+  ],
+  "requester": null,
+  "sender": {
+    "login": "gagbo",
+    "id": 88888,
+    "node_id": "PLACEHOLDER_NODE_ID",
+    "avatar_url": "https://avatars.githubusercontent.com/u/88888?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/gagbo",
+    "html_url": "https://github.com/gagbo",
+    "followers_url": "https://api.github.com/users/gagbo/followers",
+    "following_url": "https://api.github.com/users/gagbo/following{/other_user}",
+    "gists_url": "https://api.github.com/users/gagbo/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/gagbo/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/gagbo/subscriptions",
+    "organizations_url": "https://api.github.com/users/gagbo/orgs",
+    "repos_url": "https://api.github.com/users/gagbo/repos",
+    "events_url": "https://api.github.com/users/gagbo/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/gagbo/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}


### PR DESCRIPTION
Fixes #415

This Pull Request adds support for deserializing GitHub-sent webhook events related to GitHub Apps installations.
This is another breaking change because I could not figure out a cleaner way to deal with the `WrappedEventPayload::installation` field duality:
- When receiving an `installation` event, the `installation` field contains a full copy of `crate::models::Installation`, but
- when receiving any other type of event, the `installation` field only contains an `id` and a `node_id` (Note: `node_id` is _not_ present in the first case.)

If there's a better solution than breaking the API again, I'll be happy to apply that.

It might also be nice to try to have a proper `WebhookEvent` type I guess? But I don't know where it would fit. The main things I would like to have for
supporting webhooks is a failible constructor that takes a string as parameter. Since webhook have their "Event::type" stored in a HTTP header (`X-GitHub-Event`), I
think it would be nice to have a `WebhookEvent::try_from(r#type: String, payload: &[u8]) -> Result<Self>` that would automatically try to parse the payload to the
correct enum variant if `type` is known, and falls back to the `Unknown(serde_json::Value)` variant if `type` isn't known/handled by Octocrab.

I can provide payloads from my test app if that helps, it just takes time to anonymize them so I'll only do it on demand.

Cheers,

Gerry
