### PR TITLE
Fix clippy 1.71 warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,4 +22,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: cargo fmt --all -- --check
-    - run: cargo clippy --tests
+    - run: cargo clippy --tests --examples

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -115,18 +115,6 @@ impl<'octo> SearchHandler<'octo> {
     }
 }
 
-#[derive(Clone, Debug)]
-pub enum ContentType {
-    TextMatch,
-    Default,
-}
-
-impl Default for ContentType {
-    fn default() -> Self {
-        Self::Default
-    }
-}
-
 /// A handler for handling search queries to GitHub.
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct QueryHandler<'octo, 'query, T> {
@@ -136,8 +124,6 @@ pub struct QueryHandler<'octo, 'query, T> {
     crab: &'octo Octocrab,
     #[serde(skip)]
     route: &'static str,
-    #[serde(skip)]
-    content_type: ContentType,
     #[serde(rename = "q")]
     query: &'query str,
     per_page: Option<u8>,
@@ -151,7 +137,6 @@ pub struct QueryHandler<'octo, 'query, T> {
 impl<'octo, 'query, T> QueryHandler<'octo, 'query, T> {
     pub(crate) fn new(crab: &'octo Octocrab, route: &'static str, query: &'query str) -> Self {
         Self {
-            content_type: ContentType::Default,
             crab,
             order: None,
             page: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,9 +541,9 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
             #[cfg(all(feature = "rustls", not(feature = "opentls")))]
             let connector = {
                 let builder = HttpsConnectorBuilder::new();
-                #[cfg(all(feature = "rustls-webpki-tokio"))]
+                #[cfg(feature = "rustls-webpki-tokio")]
                 let builder = builder.with_webpki_roots();
-                #[cfg(all(not(feature = "rustls-webpki-tokio")))]
+                #[cfg(not(feature = "rustls-webpki-tokio"))]
                 let builder = builder.with_native_roots(); // enabled the `rustls-native-certs` feature in hyper-rustls
 
                 builder


### PR DESCRIPTION
A few changes:

* Run clippy on `--examples` in CI as well.
* Remove `content_type: ContentType` from the search API. This seems unrelated, according to https://docs.github.com/en/search?query=content_type it isn't used in the search API. There is only a TextMatch in the graphql API https://docs.github.com/en/graphql/reference/objects#textmatch, but this is also unrelated because this is the REST API.
* Fix https://rust-lang.github.io/rust-clippy/master/index.html#/non_minimal_cfg warnings