### PR TITLE
add `WebhookEventType::Schedule` variant

### DIFF
--- a/src/models/webhook_events.rs
+++ b/src/models/webhook_events.rs
@@ -609,6 +609,12 @@ pub enum WebhookEventType {
     /// **Note:** This event is deprecated. see the
     /// [`DependabotAlert`](WebhookEventType::DependabotAlert) event instead.
     RepositoryVulnerabilityAlert,
+    /// The schedule event allows you to trigger a workflow at a scheduled time.
+    ///
+    /// You can schedule a workflow to run at specific UTC times using POSIX cron syntax. Scheduled
+    /// workflows run on the latest commit on the default or base branch. The shortest interval you
+    /// can run scheduled workflows is once every 5 minutes.
+    Schedule,
     /// This event occurs when there is activity relating to a secret scanning alert. For more
     /// information about secret scanning, see "About secret scanning."
     ///
@@ -898,6 +904,9 @@ impl WebhookEventType {
                     serde_json::from_value(data)?,
                 )))
             }
+            WebhookEventType::Schedule => Ok(WebhookEventPayload::Schedule(Box::new(
+                serde_json::from_value(data)?,
+            ))),
             WebhookEventType::SecretScanningAlert => Ok(WebhookEventPayload::SecretScanningAlert(
                 Box::new(serde_json::from_value(data)?),
             )),

--- a/src/models/webhook_events/payload.rs
+++ b/src/models/webhook_events/payload.rs
@@ -51,6 +51,7 @@ mod repository_advisory;
 mod repository_dispatch;
 mod repository_import;
 mod repository_vulnerability_alert;
+mod schedule;
 mod secret_scanning_alert;
 mod secret_scanning_alert_location;
 mod security_advisory;
@@ -77,9 +78,10 @@ pub use self::{
     pull_request::*, pull_request_review::*, pull_request_review_comment::*,
     pull_request_review_thread::*, push::*, registry_package::*, release::*, repository::*,
     repository_advisory::*, repository_dispatch::*, repository_import::*,
-    repository_vulnerability_alert::*, secret_scanning_alert::*, secret_scanning_alert_location::*,
-    security_advisory::*, security_and_analysis::*, sponsorship::*, star::*, status::*, team::*,
-    team_add::*, watch::*, workflow_dispatch::*, workflow_job::*, workflow_run::*,
+    repository_vulnerability_alert::*, schedule::*, secret_scanning_alert::*,
+    secret_scanning_alert_location::*, security_advisory::*, security_and_analysis::*,
+    sponsorship::*, star::*, status::*, team::*, team_add::*, watch::*, workflow_dispatch::*,
+    workflow_job::*, workflow_run::*,
 };
 
 use serde::{Deserialize, Serialize};
@@ -141,6 +143,7 @@ pub enum WebhookEventPayload {
     RepositoryDispatch(Box<RepositoryDispatchWebhookEventPayload>),
     RepositoryImport(Box<RepositoryImportWebhookEventPayload>),
     RepositoryVulnerabilityAlert(Box<RepositoryVulnerabilityAlertWebhookEventPayload>),
+    Schedule(Box<ScheduleWebhookEventPayload>),
     SecretScanningAlert(Box<SecretScanningAlertWebhookEventPayload>),
     SecretScanningAlertLocation(Box<SecretScanningAlertLocationWebhookEventPayload>),
     SecurityAdvisory(Box<SecurityAdvisoryWebhookEventPayload>),

--- a/src/models/webhook_events/payload/schedule.rs
+++ b/src/models/webhook_events/payload/schedule.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ScheduleWebhookEventPayload {
+    pub schedule: String,
+    pub workflow: String,
+}


### PR DESCRIPTION
I added this because I'm using the `WebhookEventType` to strongly type the event data available during a GitHub Workflow run. However, it's not strictly a webhook event, as it can't be received as a webhook.

You can read about this event on the "[Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)" page, but it's (for obvious reasons) omitted from the "[Webhook events and payloads](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads)" page.

Most (all except this one?) events listed on the first page, link to the relevant webhook events on the second page, so I don't think there's a need to have a completely separate type, but if you feel differently, I'd be happy to make a change.