### PR TITLE
Fix installation token cache issue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1614,12 +1614,10 @@ mod tests {
     }
 
     #[test]
-    fn get_valid_token_within_buffer() {
+    fn no_token_when_expired() {
         let cache = CachedToken(RwLock::new(None));
-        let expiration = Utc::now() + Duration::seconds(10);
+        let expiration = Utc::now() + Duration::seconds(9);
         cache.set("secret".to_string(), Some(expiration));
-
-        sleep(Duration::seconds(5).to_std().unwrap()); // sleep for 5 seconds
 
         assert!(
             cache
@@ -1640,20 +1638,6 @@ mod tests {
                 .get_valid_token_with_buffer(Duration::seconds(10))
                 .is_some(),
             "Token should still be valid outside of buffer."
-        );
-    }
-
-    #[test]
-    fn no_token_when_expired() {
-        let cache = CachedToken(RwLock::new(None));
-        let expiration = Utc::now() + Duration::seconds(9);
-        cache.set("secret".to_string(), Some(expiration));
-
-        assert!(
-            cache
-                .get_valid_token_with_buffer(Duration::seconds(10))
-                .is_none(),
-            "Token should not be valid when inside buffer."
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -785,10 +785,6 @@ impl CachedToken {
         *self.0.write().unwrap() = None;
     }
 
-    fn token(&self) -> Option<SecretString> {
-        self.0.read().unwrap().as_ref().map(|t| t.secret.clone())
-    }
-
     /// Returns a valid token if it exists and is not expired or if there is no expiration date.
     fn valid_token_with_buffer(&self, buffer: chrono::Duration) -> Option<SecretString> {
         let inner = self.0.read().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,6 @@ use std::marker::PhantomData;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use tracing::debug;
 
 use http::{header::HeaderName, StatusCode};
 #[cfg(all(not(feature = "opentls"), not(feature = "rustls")))]
@@ -1409,7 +1408,7 @@ impl Octocrab {
             })
             .transpose()?;
 
-        debug!("Token expires at: {:?}", expiration);
+        tracing::debug!("Token expires at: {:?}", expiration);
 
         token.set(token_object.token.clone(), expiration);
 
@@ -1589,7 +1588,6 @@ mod tests {
 
     use super::*;
     use chrono::Duration;
-    use std::thread::sleep;
 
     #[test]
     fn set_and_get_token() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,7 @@ use std::marker::PhantomData;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
+use tracing::debug;
 
 use http::{header::HeaderName, StatusCode};
 #[cfg(all(not(feature = "opentls"), not(feature = "rustls")))]
@@ -1395,6 +1396,8 @@ impl Octocrab {
                 })
             })
             .transpose()?;
+
+        debug!("Token expires at: {:?}", expiration);
 
         token.set(token_object.token.clone(), expiration);
 


### PR DESCRIPTION
My application holds an Installation for an extended period of time (longer than 1 hour). This causes a "Bad credentials" error from Github. This PR introduces a fix that changes the installation token cache to only return a token if it's not expired, forcing Octocrab client to refresh the token appropriately. 