### PR TITLE
Fix `github_app_authentication.rs` example

### DIFF
--- a/examples/github_app_authentication.rs
+++ b/examples/github_app_authentication.rs
@@ -8,11 +8,7 @@ async fn main() -> octocrab::Result<()> {
     let key = jsonwebtoken::EncodingKey::from_rsa_pem(app_private_key.as_bytes()).unwrap();
 
     let octocrab = Octocrab::builder().app(app_id, key).build()?;
-    let installed_repos: InstallationRepositories = octocrab
-        .get("/installation/repositories", None::<&()>)
-        .await
-        .unwrap();
-    let _repos = installed_repos.repositories;
+    let _installations = octocrab.apps().installations().send().await.unwrap();
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #215

The API call `.get("/installation/repositories", ...)`  has to be authenticated through an installation ID, so better to use `.apps().installations()` API call in this example