### PR TITLE
add get_readme for RepoHandler

### DIFF
--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -22,6 +22,7 @@ mod tags;
 mod teams;
 
 use crate::error::HttpSnafu;
+use crate::repos::file::GetReadmeBuilder;
 use crate::{models, params, Octocrab, Result};
 pub use branches::ListBranchesBuilder;
 pub use collaborators::ListCollaboratorsBuilder;
@@ -36,7 +37,6 @@ pub use stargazers::ListStarGazersBuilder;
 pub use status::{CreateStatusBuilder, ListStatusesBuilder};
 pub use tags::ListTagsBuilder;
 pub use teams::ListTeamsBuilder;
-use crate::repos::file::GetReadmeBuilder;
 
 /// Handler for GitHub's repository API.
 ///

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -36,6 +36,7 @@ pub use stargazers::ListStarGazersBuilder;
 pub use status::{CreateStatusBuilder, ListStatusesBuilder};
 pub use tags::ListTagsBuilder;
 pub use teams::ListTeamsBuilder;
+use crate::repos::file::GetReadmeBuilder;
 
 /// Handler for GitHub's repository API.
 ///
@@ -221,6 +222,24 @@ impl<'octo> RepoHandler<'octo> {
     /// ```
     pub fn get_content(&self) -> GetContentBuilder<'_, '_> {
         GetContentBuilder::new(self)
+    }
+
+    /// Get repository readme.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    ///
+    /// octocrab::instance()
+    ///     .repos("owner", "repo")
+    ///     .get_readme()
+    ///     .path("path/to/file")
+    ///     .r#ref("main")
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_readme(&self) -> GetReadmeBuilder<'_, '_> {
+        GetReadmeBuilder::new(self)
     }
 
     /// Creates a new file in the repository.

--- a/src/api/repos/file.rs
+++ b/src/api/repos/file.rs
@@ -45,7 +45,6 @@ impl<'octo, 'r> GetContentBuilder<'octo, 'r> {
     }
 }
 
-
 #[derive(serde::Serialize)]
 pub struct GetReadmeBuilder<'octo, 'r> {
     #[serde(skip)]
@@ -91,7 +90,6 @@ impl<'octo, 'r> GetReadmeBuilder<'octo, 'r> {
         self.handler.crab.get(route, Some(&self)).await
     }
 }
-
 
 #[derive(serde::Serialize)]
 pub struct UpdateFileBuilder<'octo, 'r> {

--- a/src/api/repos/file.rs
+++ b/src/api/repos/file.rs
@@ -45,6 +45,54 @@ impl<'octo, 'r> GetContentBuilder<'octo, 'r> {
     }
 }
 
+
+#[derive(serde::Serialize)]
+pub struct GetReadmeBuilder<'octo, 'r> {
+    #[serde(skip)]
+    handler: &'r RepoHandler<'octo>,
+    #[serde(skip)]
+    path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    r#ref: Option<String>,
+}
+
+impl<'octo, 'r> GetReadmeBuilder<'octo, 'r> {
+    pub(crate) fn new(handler: &'r RepoHandler<'octo>) -> Self {
+        Self {
+            handler,
+            path: None,
+            r#ref: None,
+        }
+    }
+
+    /// The content path.
+    /// Default: none (the repository's root directory)
+    pub fn path(mut self, path: impl Into<String>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// The name of the commit/branch/tag.
+    /// Default: the repository’s default branch (usually `master)
+    pub fn r#ref(mut self, r#ref: impl Into<String>) -> Self {
+        self.r#ref = Some(r#ref.into());
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(self) -> Result<models::repos::Content> {
+        let path = self.path.clone().unwrap_or(String::from(""));
+        let route = format!(
+            "/repos/{owner}/{repo}/readme/{path}",
+            owner = self.handler.owner,
+            repo = self.handler.repo,
+            path = path,
+        );
+        self.handler.crab.get(route, Some(&self)).await
+    }
+}
+
+
 #[derive(serde::Serialize)]
 pub struct UpdateFileBuilder<'octo, 'r> {
     #[serde(skip)]


### PR DESCRIPTION
This implements API:
- https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-a-repository-readme
- https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-a-repository-readme-for-a-directory