### PR TITLE
Add conclusion, completed_at and output fields to create check api

### DIFF
--- a/examples/github_app_authentication.rs
+++ b/examples/github_app_authentication.rs
@@ -1,4 +1,3 @@
-use octocrab::models::InstallationRepositories;
 use octocrab::Octocrab;
 
 #[tokio::main]

--- a/src/api/checks.rs
+++ b/src/api/checks.rs
@@ -20,8 +20,6 @@ pub enum CheckRunStatus {
     Completed,
 }
 
-/// Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`,
-/// `skipped`, `stale` or `action_required`.
 #[derive(serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CheckRunConclusion {
@@ -136,8 +134,6 @@ impl<'octo, 'r> CreateCheckRunBuilder<'octo, 'r> {
     }
 
     /// The final conclusion of the check.
-    /// Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`,
-    /// `skipped`, `stale` or `action_required`.
     pub fn conclusion(mut self, conclusion: CheckRunConclusion) -> Self {
         self.conclusion = Some(conclusion);
         self
@@ -240,8 +236,6 @@ impl<'octo, 'r> UpdateCheckRunBuilder<'octo, 'r> {
     }
 
     /// The final conclusion of the check.
-    /// Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`,
-    /// `skipped`, `stale` or `action_required`.
     pub fn conclusion(mut self, conclusion: CheckRunConclusion) -> Self {
         self.conclusion = Some(conclusion);
         self

--- a/src/api/checks.rs
+++ b/src/api/checks.rs
@@ -341,7 +341,7 @@ impl<'octo> ChecksHandler<'octo> {
     ///    .create_check_run("name", "head_sha")
     ///    .details_url("https://example.com")
     ///    .external_id("external_id")
-    ///    .status(octocrab::checks::CheckRunStatus::InProgress)
+    ///    .status(octocrab::params::checks::CheckRunStatus::InProgress)
     ///    .send()
     ///    .await?;
     /// # Ok(())
@@ -363,7 +363,7 @@ impl<'octo> ChecksHandler<'octo> {
     /// .name("name")
     /// .details_url("https://example.com")
     /// .external_url("external_id")
-    /// .status(octocrab::checks::CheckRunStatus::InProgress)
+    /// .status(octocrab::params::checks::CheckRunStatus::InProgress)
     /// .send()
     /// .await?;
     /// # Ok(())

--- a/src/api/checks.rs
+++ b/src/api/checks.rs
@@ -1,5 +1,6 @@
 use crate::models::{CheckRunId, CheckSuiteId};
 use crate::params::repos::Commitish;
+use crate::params::checks::{CheckRunConclusion, CheckRunOutput, CheckRunStatus};
 use crate::{models, Octocrab, Result};
 use chrono::{DateTime, Utc};
 
@@ -10,72 +11,6 @@ pub struct ChecksHandler<'octo> {
     crab: &'octo Octocrab,
     owner: String,
     repo: String,
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CheckRunStatus {
-    Queued,
-    InProgress,
-    Completed,
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CheckRunConclusion {
-    Success,
-    Failure,
-    Neutral,
-    Cancelled,
-    TimedOut,
-    Skipped,
-    Stale,
-    ActionRequired
-}
-
-#[derive(serde::Serialize)]
-pub struct CheckRunOutput {
-    title: String,
-    summary: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    text: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    annotations: Vec<CheckRunOutputAnnotation>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    images: Vec<CheckRunOutputImage>
-}
-
-#[derive(serde::Serialize)]
-pub struct CheckRunOutputAnnotation {
-    path: String,
-    start_line: u32,
-    end_line: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    start_column: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    end_column: Option<u32>,
-    annotation_level: CheckRunOutputAnnotationLevel,
-    message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    title: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    raw_details: Option<String>
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CheckRunOutputAnnotationLevel {
-    Notice,
-    Warning,
-    Failure
-}
-
-#[derive(serde::Serialize)]
-pub struct CheckRunOutputImage {
-    image_url: String,
-    alt: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    caption: Option<String>
 }
 
 #[derive(serde::Serialize)]

--- a/src/api/checks.rs
+++ b/src/api/checks.rs
@@ -1,6 +1,6 @@
 use crate::models::{CheckRunId, CheckSuiteId};
-use crate::params::repos::Commitish;
 use crate::params::checks::{CheckRunConclusion, CheckRunOutput, CheckRunStatus};
+use crate::params::repos::Commitish;
 use crate::{models, Octocrab, Result};
 use chrono::{DateTime, Utc};
 

--- a/src/api/checks.rs
+++ b/src/api/checks.rs
@@ -32,6 +32,12 @@ pub struct CreateCheckRunBuilder<'octo, 'r> {
     external_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<CheckRunStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    conclusion: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    completed_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output: Option<serde_json::Value>,
 }
 
 impl<'octo, 'r> CreateCheckRunBuilder<'octo, 'r> {
@@ -43,6 +49,9 @@ impl<'octo, 'r> CreateCheckRunBuilder<'octo, 'r> {
             details_url: None,
             external_id: None,
             status: None,
+            conclusion: None,
+            completed_at: None,
+            output: None,
         }
     }
 
@@ -63,6 +72,28 @@ impl<'octo, 'r> CreateCheckRunBuilder<'octo, 'r> {
     /// Can be one of `queued`, `in_progress`, or `completed`.
     pub fn status(mut self, status: CheckRunStatus) -> Self {
         self.status = Some(status);
+        self
+    }
+
+    /// The final conclusion of the check.
+    /// Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`,
+    /// `skipped`, `stale` or `action_required`.
+    pub fn conclusion(mut self, conclusion: impl Into<String>) -> Self {
+        self.conclusion = Some(conclusion.into());
+        self
+    }
+
+    /// The time that the check run completed.
+    pub fn completed_at(mut self, completed_at: DateTime<Utc>) -> Self {
+        self.completed_at = Some(completed_at);
+        self
+    }
+
+    /// Check runs can accept a variety of data in the output object,
+    /// including a title and summary and can optionally provide
+    /// descriptive details about the run.
+    pub fn output(mut self, output: serde_json::Value) -> Self {
+        self.output = Some(output);
         self
     }
 

--- a/src/api/checks.rs
+++ b/src/api/checks.rs
@@ -20,6 +20,66 @@ pub enum CheckRunStatus {
     Completed,
 }
 
+/// Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`,
+/// `skipped`, `stale` or `action_required`.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckRunConclusion {
+    Success,
+    Failure,
+    Neutral,
+    Cancelled,
+    TimedOut,
+    Skipped,
+    Stale,
+    ActionRequired
+}
+
+#[derive(serde::Serialize)]
+pub struct CheckRunOutput {
+    title: String,
+    summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    annotations: Vec<CheckRunOutputAnnotation>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    images: Vec<CheckRunOutputImage>
+}
+
+#[derive(serde::Serialize)]
+pub struct CheckRunOutputAnnotation {
+    path: String,
+    start_line: u32,
+    end_line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start_column: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end_column: Option<u32>,
+    annotation_level: CheckRunOutputAnnotationLevel,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    raw_details: Option<String>
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckRunOutputAnnotationLevel {
+    Notice,
+    Warning,
+    Failure
+}
+
+#[derive(serde::Serialize)]
+pub struct CheckRunOutputImage {
+    image_url: String,
+    alt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    caption: Option<String>
+}
+
 #[derive(serde::Serialize)]
 pub struct CreateCheckRunBuilder<'octo, 'r> {
     #[serde(skip)]
@@ -33,11 +93,11 @@ pub struct CreateCheckRunBuilder<'octo, 'r> {
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<CheckRunStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    conclusion: Option<String>,
+    conclusion: Option<CheckRunConclusion>,
     #[serde(skip_serializing_if = "Option::is_none")]
     completed_at: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    output: Option<serde_json::Value>,
+    output: Option<CheckRunOutput>,
 }
 
 impl<'octo, 'r> CreateCheckRunBuilder<'octo, 'r> {
@@ -78,8 +138,8 @@ impl<'octo, 'r> CreateCheckRunBuilder<'octo, 'r> {
     /// The final conclusion of the check.
     /// Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`,
     /// `skipped`, `stale` or `action_required`.
-    pub fn conclusion(mut self, conclusion: impl Into<String>) -> Self {
-        self.conclusion = Some(conclusion.into());
+    pub fn conclusion(mut self, conclusion: CheckRunConclusion) -> Self {
+        self.conclusion = Some(conclusion);
         self
     }
 
@@ -92,7 +152,7 @@ impl<'octo, 'r> CreateCheckRunBuilder<'octo, 'r> {
     /// Check runs can accept a variety of data in the output object,
     /// including a title and summary and can optionally provide
     /// descriptive details about the run.
-    pub fn output(mut self, output: serde_json::Value) -> Self {
+    pub fn output(mut self, output: CheckRunOutput) -> Self {
         self.output = Some(output);
         self
     }
@@ -124,11 +184,11 @@ pub struct UpdateCheckRunBuilder<'octo, 'r> {
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<CheckRunStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    conclusion: Option<String>,
+    conclusion: Option<CheckRunConclusion>,
     #[serde(skip_serializing_if = "Option::is_none")]
     completed_at: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    output: Option<serde_json::Value>,
+    output: Option<CheckRunOutput>,
 }
 
 impl<'octo, 'r> UpdateCheckRunBuilder<'octo, 'r> {
@@ -182,8 +242,8 @@ impl<'octo, 'r> UpdateCheckRunBuilder<'octo, 'r> {
     /// The final conclusion of the check.
     /// Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`,
     /// `skipped`, `stale` or `action_required`.
-    pub fn conclusion(mut self, conclusion: impl Into<String>) -> Self {
-        self.conclusion = Some(conclusion.into());
+    pub fn conclusion(mut self, conclusion: CheckRunConclusion) -> Self {
+        self.conclusion = Some(conclusion);
         self
     }
 
@@ -196,7 +256,7 @@ impl<'octo, 'r> UpdateCheckRunBuilder<'octo, 'r> {
     /// Check runs can accept a variety of data in the output object,
     /// including a title and summary and can optionally provide
     /// descriptive details about the run.
-    pub fn output(mut self, output: serde_json::Value) -> Self {
+    pub fn output(mut self, output: CheckRunOutput) -> Self {
         self.output = Some(output);
         self
     }

--- a/src/params.rs
+++ b/src/params.rs
@@ -105,7 +105,7 @@ pub mod checks {
         TimedOut,
         Skipped,
         Stale,
-        ActionRequired
+        ActionRequired,
     }
 
     #[derive(serde::Serialize)]
@@ -117,7 +117,7 @@ pub mod checks {
         #[serde(skip_serializing_if = "Vec::is_empty")]
         pub annotations: Vec<CheckRunOutputAnnotation>,
         #[serde(skip_serializing_if = "Vec::is_empty")]
-        pub images: Vec<CheckRunOutputImage>
+        pub images: Vec<CheckRunOutputImage>,
     }
 
     #[derive(serde::Serialize)]
@@ -134,7 +134,7 @@ pub mod checks {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub title: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub raw_details: Option<String>
+        pub raw_details: Option<String>,
     }
 
     #[derive(Debug, Clone, Copy, serde::Serialize)]
@@ -142,7 +142,7 @@ pub mod checks {
     pub enum CheckRunOutputAnnotationLevel {
         Notice,
         Warning,
-        Failure
+        Failure,
     }
 
     #[derive(serde::Serialize)]
@@ -150,7 +150,7 @@ pub mod checks {
         pub image_url: String,
         pub alt: String,
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub caption: Option<String>
+        pub caption: Option<String>,
     }
 }
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -110,31 +110,31 @@ pub mod checks {
 
     #[derive(serde::Serialize)]
     pub struct CheckRunOutput {
-        title: String,
-        summary: String,
+        pub title: String,
+        pub summary: String,
         #[serde(skip_serializing_if = "Option::is_none")]
-        text: Option<String>,
+        pub text: Option<String>,
         #[serde(skip_serializing_if = "Vec::is_empty")]
-        annotations: Vec<CheckRunOutputAnnotation>,
+        pub annotations: Vec<CheckRunOutputAnnotation>,
         #[serde(skip_serializing_if = "Vec::is_empty")]
-        images: Vec<CheckRunOutputImage>
+        pub images: Vec<CheckRunOutputImage>
     }
 
     #[derive(serde::Serialize)]
     pub struct CheckRunOutputAnnotation {
-        path: String,
-        start_line: u32,
-        end_line: u32,
+        pub path: String,
+        pub start_line: u32,
+        pub end_line: u32,
         #[serde(skip_serializing_if = "Option::is_none")]
-        start_column: Option<u32>,
+        pub start_column: Option<u32>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        end_column: Option<u32>,
-        annotation_level: CheckRunOutputAnnotationLevel,
-        message: String,
+        pub end_column: Option<u32>,
+        pub annotation_level: CheckRunOutputAnnotationLevel,
+        pub message: String,
         #[serde(skip_serializing_if = "Option::is_none")]
-        title: Option<String>,
+        pub title: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        raw_details: Option<String>
+        pub raw_details: Option<String>
     }
 
     #[derive(Debug, Clone, Copy, serde::Serialize)]
@@ -147,10 +147,10 @@ pub mod checks {
 
     #[derive(serde::Serialize)]
     pub struct CheckRunOutputImage {
-        image_url: String,
-        alt: String,
+        pub image_url: String,
+        pub alt: String,
         #[serde(skip_serializing_if = "Option::is_none")]
-        caption: Option<String>
+        pub caption: Option<String>
     }
 }
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -84,6 +84,76 @@ pub mod apps {
     }
 }
 
+pub mod checks {
+    //! Parameter types for the checks API.
+
+    #[derive(Debug, Clone, Copy, serde::Serialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum CheckRunStatus {
+        Queued,
+        InProgress,
+        Completed,
+    }
+
+    #[derive(Debug, Clone, Copy, serde::Serialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum CheckRunConclusion {
+        Success,
+        Failure,
+        Neutral,
+        Cancelled,
+        TimedOut,
+        Skipped,
+        Stale,
+        ActionRequired
+    }
+
+    #[derive(serde::Serialize)]
+    pub struct CheckRunOutput {
+        title: String,
+        summary: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        text: Option<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        annotations: Vec<CheckRunOutputAnnotation>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        images: Vec<CheckRunOutputImage>
+    }
+
+    #[derive(serde::Serialize)]
+    pub struct CheckRunOutputAnnotation {
+        path: String,
+        start_line: u32,
+        end_line: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        start_column: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        end_column: Option<u32>,
+        annotation_level: CheckRunOutputAnnotationLevel,
+        message: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        raw_details: Option<String>
+    }
+
+    #[derive(Debug, Clone, Copy, serde::Serialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum CheckRunOutputAnnotationLevel {
+        Notice,
+        Warning,
+        Failure
+    }
+
+    #[derive(serde::Serialize)]
+    pub struct CheckRunOutputImage {
+        image_url: String,
+        alt: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        caption: Option<String>
+    }
+}
+
 pub mod issues {
     //! Parameter types for the issues API.
 


### PR DESCRIPTION
The [create checks api](https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run) also allows for immediate reporting of its completion status for quick status reports (for example, verifying that a PR name matches a regex).

This PR adds those fields to the create check api and builder, skipping the need for another request to update the check immediately after creating it.