### PR TITLE
Add examples/graphql_issues.rs

### DIFF
--- a/examples/graphql_issues.rs
+++ b/examples/graphql_issues.rs
@@ -1,0 +1,28 @@
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let octocrab = octocrab::Octocrab::builder()
+        .personal_token(std::env::var("GITHUB_TOKEN").unwrap())
+        .build()?;
+
+    let query = r#" {
+        repository(owner:"XAMPPRocky", name:"octocrab") {
+            issues(last: 2, states: OPEN) {
+                nodes {
+                    title
+                    url
+                }
+            }
+        }
+    } "#;
+
+    let response: octocrab::Result<serde_json::Value> = octocrab
+        .graphql(&serde_json::json!({ "query": query }))
+        .await;
+
+    match response {
+        Ok(value) => println!("{value:#?}"),
+        Err(error) => println!("{error:#?}"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
I could not find any examples of a real graphql query, so here comes one. It would have helped me so hopefully it will also help others.

Example output:

```console
$ GITHUB_TOKEN=github_pat_1234ABC cargo run --example=graphql_issues
Object {
    "data": Object {
        "repository": Object {
            "issues": Object {
                "nodes": Array [
                    Object {
                        "title": String("Add Method For Viewing Repository Traffic Stats  "),
                        "url": String("https://github.com/XAMPPRocky/octocrab/issues/474"),
                    },
                    Object {
                        "title": String("Add API Version configuration to the builder"),
                        "url": String("https://github.com/XAMPPRocky/octocrab/issues/475"),
                    },
                ],
            },
        },
    },
}
$ GITHUB_TOKEN=invalid cargo run --example=graphql_issues
GitHub {
    source: GitHubError {
        documentation_url: Some(
            "https://docs.github.com/graphql",
        ),
        errors: None,
        message: "Bad credentials",
    },
    backtrace: Backtrace(
           0:     0x5641fcb6af8a - backtrace::backtrace::libunwind::trace::h5d71e1a92685bd90
                                       at /home/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.68/src/backtrace/libunwind.rs:93:5
                                   backtrace::backtrace::trace_unsynchronized::h18e9f171dc178e01
                                       at /home/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.68/src/backtrace/mod.rs:66:5
           ...
        ,
    ),
```