### PR TITLE
add events for auto_merge_[disabled|enabled]

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -177,6 +177,10 @@ pub enum Event {
     AddedToProject,
     /// The issue or pull request was assigned to a user.
     Assigned,
+    /// Auto merge was disabled for a pull request.
+    AutoMergeDisabled,
+    /// Auto merge was enabled for a pull request.
+    AutoMergeEnabled,
     /// GitHub unsuccessfully attempted to automatically change the base branch of the pull request.
     AutomaticBaseChangeFailed,
     /// GitHub successfully attempted to automatically change the base branch of the pull request.


### PR DESCRIPTION
Found two event types that are missing from the event enum:
- [auto_merge_disabled](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=auto_merge_disabled#pull_request)
- [auto_merge_enabled](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=auto_merge_enabled#pull_request)
