### PR TITLE
examples/graphql_issues.rs: Demonstrate variables and paging

### DIFF
--- a/examples/graphql_issues.rs
+++ b/examples/graphql_issues.rs
@@ -4,25 +4,81 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .personal_token(std::env::var("GITHUB_TOKEN").unwrap())
         .build()?;
 
-    let query = r#" {
-        repository(owner:"XAMPPRocky", name:"octocrab") {
-            issues(last: 2, states: OPEN) {
-                nodes {
-                    title
-                    url
+    let mut variables = serde_json::json!({
+        "owner": "XAMPPRocky",
+        "name": "octocrab",
+        "page_size": 5,
+    });
+
+    let pages_to_show = 3;
+    let mut page = 1;
+    loop {
+        if page > pages_to_show {
+            break;
+        }
+
+        let response: octocrab::Result<serde_json::Value> = octocrab
+            .graphql(&serde_json::json!({
+                "query": QUERY,
+                "variables": variables,
+            }))
+            .await;
+
+        match response {
+            Ok(value) => {
+                println!("Page {page}:");
+                print_issues(&value);
+                if !update_page_info(&mut variables, &value) {
+                    break;
                 }
             }
+            Err(error) => {
+                println!("{error:#?}");
+                break;
+            }
         }
-    } "#;
 
-    let response: octocrab::Result<serde_json::Value> = octocrab
-        .graphql(&serde_json::json!({ "query": query }))
-        .await;
-
-    match response {
-        Ok(value) => println!("{value:#?}"),
-        Err(error) => println!("{error:#?}"),
+        page += 1;
     }
 
     Ok(())
 }
+
+fn print_issues(value: &serde_json::Value) {
+    let issues = value["data"]["repository"]["issues"]["nodes"]
+        .as_array()
+        .unwrap();
+
+    for issue in issues {
+        println!(
+            "{} {}",
+            issue["url"].as_str().unwrap(),
+            issue["title"].as_str().unwrap()
+        );
+    }
+}
+
+fn update_page_info(variables: &mut serde_json::Value, value: &serde_json::Value) -> bool {
+    let page_info = value["data"]["repository"]["issues"]["pageInfo"].clone();
+    if page_info["hasPreviousPage"].as_bool().unwrap() {
+        variables["before"] = page_info["startCursor"].clone();
+        true
+    } else {
+        false
+    }
+}
+
+const QUERY: &str = r#" query ($owner: String!, $name: String!, $page_size: Int!, $before: String) {
+    repository(owner: $owner, name: $name) {
+        issues(last: $page_size, before: $before, states: OPEN) {
+            nodes {
+                title
+                url
+            }
+            pageInfo {
+                hasPreviousPage
+                startCursor
+            }
+        }
+    }
+} "#;


### PR DESCRIPTION
This was quite tricky to figure out how to do (for me, anyway), so let's help others by demonstrating how to do it.

Example output:

```console
$ GITHUB_TOKEN=github_pat_123ABC cargo run --example=graphql_issues
Page 1:
https://github.com/XAMPPRocky/octocrab/issues/435 Installation tokens are hard to re-use
https://github.com/XAMPPRocky/octocrab/issues/456 `IssueHandle::delete_label` panics
https://github.com/XAMPPRocky/octocrab/issues/463 [Bug] octocrab::Octocrab::request_installation_auth_token fails with status code 411
https://github.com/XAMPPRocky/octocrab/issues/474 Add Method For Viewing Repository Traffic Stats
https://github.com/XAMPPRocky/octocrab/issues/475 Add API Version configuration to the builder
Page 2:
https://github.com/XAMPPRocky/octocrab/issues/398 Improve Commits API
https://github.com/XAMPPRocky/octocrab/issues/417 Add Projects API
https://github.com/XAMPPRocky/octocrab/issues/421 How to access commit compare endpoint?
https://github.com/XAMPPRocky/octocrab/issues/422 Add `Status`/`Conclusion` enums directly to fields
https://github.com/XAMPPRocky/octocrab/issues/423 Add a `Page::all` method
Page 3:
https://github.com/XAMPPRocky/octocrab/issues/377 Generating Github REST API from Open-API
https://github.com/XAMPPRocky/octocrab/issues/380 Source closed when authenticating with personal token
https://github.com/XAMPPRocky/octocrab/issues/381 The Workflow Run Event Action `in_progress` is Not Supported
https://github.com/XAMPPRocky/octocrab/issues/394 Add method for downloading job logs
https://github.com/XAMPPRocky/octocrab/issues/396 Initializing octocrab takes 300ms on macOS
```