### PR TITLE
Add some actions API methods for working with self-hosted runners

### DIFF
--- a/examples/list_org_self_hosted_runners.rs
+++ b/examples/list_org_self_hosted_runners.rs
@@ -1,0 +1,36 @@
+use octocrab::Octocrab;
+
+#[tokio::main]
+async fn main() -> octocrab::Result<()> {
+    // Note: this token must have the `admin:org` scope. An alternative use case
+    // may be to authenticate as a GitHub App. See github_app_authentication.rs
+    // for that.
+    let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env variable is required");
+
+    let octocrab = Octocrab::builder().personal_token(token).build()?;
+
+    let runners = octocrab
+        .actions()
+        .list_org_self_hosted_runners("my-org")
+        .per_page(100)
+        .send()
+        .await?;
+
+    for runner in runners {
+        println!("ID {}:", runner.id);
+        println!("    Name:\t{}", runner.name);
+        println!("    OS:\t\t{}", runner.os);
+        println!("    Status:\t{}", runner.status);
+        println!("    Busy:\t{}", runner.busy);
+        print!("    Labels:\t[");
+        for (index, label) in runner.labels.iter().enumerate() {
+            print!("\"{}\"", label.name);
+            if index != runner.labels.len() - 1 {
+                print!(", ");
+            }
+        }
+        println!("]");
+    }
+
+    Ok(())
+}

--- a/src/api/actions/self_hosted_runners.rs
+++ b/src/api/actions/self_hosted_runners.rs
@@ -1,0 +1,159 @@
+use crate::{actions::ActionsHandler, models::RunnerGroupId};
+use serde::Serialize;
+
+enum RunnerScope {
+    Org(String),
+    Repo { owner: String, repo: String },
+}
+
+/// A builder pattern struct for listing self-hosted runners.
+///
+/// Created by [`ActionsHandler::list_org_self_hosted_runners`] or
+/// [`ActionsHandler::list_repo_self_hosted_runners`].
+///
+/// [`ActionsHandler::list_org_self_hosted_runners`]: ../struct.ActionsHandler.html#method.list_org_self_hosted_runners
+/// [`ActionsHandler::list_repo_self_hosted_runners`]: ../struct.ActionsHandler.html#method.list_repo_self_hosted_runners
+#[derive(Serialize)]
+pub struct ListSelfHostedRunnersBuilder<'octo, 'r> {
+    #[serde(skip)]
+    handler: &'r ActionsHandler<'octo>,
+    #[serde(skip)]
+    scope: RunnerScope,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+}
+
+impl<'octo, 'r> ListSelfHostedRunnersBuilder<'octo, 'r> {
+    pub(crate) fn new_org(handler: &'r ActionsHandler<'octo>, org: String) -> Self {
+        Self {
+            handler,
+            scope: RunnerScope::Org(org),
+            name: None,
+            per_page: None,
+            page: None,
+        }
+    }
+
+    pub(crate) fn new_repo(
+        handler: &'r ActionsHandler<'octo>,
+        owner: String,
+        repo: String,
+    ) -> Self {
+        Self {
+            handler,
+            scope: RunnerScope::Repo { owner, repo },
+            name: None,
+            per_page: None,
+            page: None,
+        }
+    }
+
+    /// Filter the list by runners matching the given name.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.page = Some(page.into());
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(
+        self,
+    ) -> crate::Result<crate::Page<crate::models::actions::SelfHostedRunner>> {
+        let route = match &self.scope {
+            RunnerScope::Org(org) => format!("/orgs/{org}/actions/runners"),
+            RunnerScope::Repo { owner, repo } => format!("/repos/{owner}/{repo}/actions/runners"),
+        };
+
+        self.handler.crab.get(route, Some(&self)).await
+    }
+}
+
+/// A builder pattern struct for creating just-in-time runner configurations.
+///
+/// Created by [`ActionsHandler::create_org_jit_runner_config`] or
+/// [`ActionsHandler::create_repo_jit_runner_config`].
+///
+/// [`ActionsHandler::create_org_jit_runner_config`]: ../struct.ActionsHandler.html#method.create_org_jit_runner_config
+/// [`ActionsHandler::create_repo_jit_runner_config`]: ../struct.ActionsHandler.html#method.create_repo_jit_runner_config
+#[derive(Serialize)]
+pub struct CreateJitRunnerConfigBuilder<'octo, 'r> {
+    #[serde(skip)]
+    handler: &'r ActionsHandler<'octo>,
+    #[serde(skip)]
+    scope: RunnerScope,
+    name: String,
+    runner_group_id: RunnerGroupId,
+    labels: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    work_folder: Option<String>,
+}
+
+impl<'octo, 'r> CreateJitRunnerConfigBuilder<'octo, 'r> {
+    pub(crate) fn new_org(
+        handler: &'r ActionsHandler<'octo>,
+        org: String,
+        name: String,
+        runner_group_id: RunnerGroupId,
+        labels: Vec<String>,
+    ) -> Self {
+        Self {
+            handler,
+            scope: RunnerScope::Org(org),
+            name,
+            runner_group_id,
+            labels,
+            work_folder: None,
+        }
+    }
+
+    pub(crate) fn new_repo(
+        handler: &'r ActionsHandler<'octo>,
+        owner: String,
+        repo: String,
+        name: String,
+        runner_group_id: RunnerGroupId,
+        labels: Vec<String>,
+    ) -> Self {
+        Self {
+            handler,
+            scope: RunnerScope::Repo { owner, repo },
+            name,
+            runner_group_id,
+            labels,
+            work_folder: None,
+        }
+    }
+
+    /// The working directory to be used for job execution, relative to the runner install directory.
+    pub fn work_folder(mut self, work_folder: impl Into<String>) -> Self {
+        self.work_folder = Some(work_folder.into());
+        self
+    }
+
+    /// Sends the actual request.
+    pub async fn send(self) -> crate::Result<crate::models::actions::SelfHostedRunnerJitConfig> {
+        let route = match &self.scope {
+            RunnerScope::Org(org) => format!("/orgs/{org}/actions/runners/generate-jitconfig"),
+            RunnerScope::Repo { owner, repo } => {
+                format!("/repos/{owner}/{repo}/actions/runners/generate-jitconfig")
+            }
+        };
+
+        self.handler.crab.post(route, Some(&self)).await
+    }
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, Utc};
 use serde::{de, Deserialize, Deserializer, Serialize};
 use url::Url;
 
+pub mod actions;
 pub mod activity;
 pub mod apps;
 pub mod checks;
@@ -123,6 +124,9 @@ id_type!(
     RepositoryId,
     ReviewId,
     RunId,
+    RunnerId,
+    RunnerGroupId,
+    RunnerLabelId,
     StatusId,
     TeamId,
     TimelineEventId,

--- a/src/models/actions.rs
+++ b/src/models/actions.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SelfHostedRunner {
+    pub id: RunnerId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_group_id: Option<RunnerGroupId>,
+    pub name: String,
+    pub os: String,
+    pub status: String,
+    pub busy: bool,
+    pub labels: Vec<SelfHostedRunnerLabel>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SelfHostedRunnerLabel {
+    pub id: RunnerLabelId,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub label_type: SelfHostedRunnerLabelType,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SelfHostedRunnerLabelType {
+    ReadOnly,
+    Custom,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SelfHostedRunnerJitConfig {
+    pub runner: SelfHostedRunner,
+    pub encoded_jit_config: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SelfHostedRunnerToken {
+    pub token: String,
+    pub expires_at: DateTime<Utc>,
+}

--- a/src/page.rs
+++ b/src/page.rs
@@ -201,6 +201,7 @@ impl<T: serde::de::DeserializeOwned> crate::FromResponse for Page<T> {
                 "artifacts",
                 "repositories",
                 "installations",
+                "runners",
             ]
             .into_iter()
             .find(|v| json.get(v).is_some())

--- a/tests/actions_self_hosted_runners.rs
+++ b/tests/actions_self_hosted_runners.rs
@@ -1,0 +1,499 @@
+// Tests for calls to the actions self-hosted runners API:
+// - /repos/{owner}/{repo}/actions/runners
+// - /orgs/{org}/actions/runners
+mod mock_error;
+
+use http::StatusCode;
+use mock_error::setup_error_handler;
+use octocrab::{
+    models::{
+        actions::{SelfHostedRunner, SelfHostedRunnerJitConfig, SelfHostedRunnerToken},
+        RunnerGroupId,
+    },
+    Octocrab, Page,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use wiremock::{
+    matchers::{body_json, method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+const OWNER: &str = "owner";
+const REPO: &str = "repo";
+const ORG: &str = "org";
+
+enum Scope {
+    Repo,
+    Org,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct FakePage {
+    total_count: u64,
+    runners: Vec<SelfHostedRunner>,
+}
+
+struct TestContext {
+    _server: MockServer,
+    client: Octocrab,
+}
+
+#[derive(Clone, Serialize)]
+struct JitConfigBody {
+    name: String,
+    runner_group_id: RunnerGroupId,
+    labels: Vec<String>,
+}
+
+impl JitConfigBody {
+    fn expected_response(&self) -> SelfHostedRunnerJitConfig {
+        let json = json!({
+            "runner": {
+                "id": 23,
+                "runner_group_id": self.runner_group_id,
+                "name": self.name.clone(),
+                "os": "unknown",
+                "status": "offline",
+                "busy": false,
+                "labels": self.labels.iter().enumerate().map(|(index, label)| json!({
+                    "id": index,
+                    "name": label,
+                    "type": "custom"
+                })).collect::<Vec<_>>()
+            },
+            "encoded_jit_config": "abc123"
+        });
+
+        serde_json::from_value(json).unwrap()
+    }
+}
+
+impl JitConfigBody {}
+
+async fn setup_api(
+    scope: Scope,
+    method_name: &str,
+    sub_uri: &str,
+    request: Option<impl Serialize>,
+    response: ResponseTemplate,
+) -> MockServer {
+    let mock_server = MockServer::start().await;
+    let mut uri = match scope {
+        Scope::Repo => format!("/repos/{OWNER}/{REPO}"),
+        Scope::Org => format!("/orgs/{ORG}"),
+    };
+    uri.push_str(sub_uri);
+
+    let mut builder = Mock::given(method(method_name)).and(path(&uri));
+    if let Some(request) = request {
+        builder = builder.and(body_json(request));
+    }
+    builder.respond_with(response).mount(&mock_server).await;
+
+    setup_error_handler(&mock_server, &format!("GET on {uri} was not received")).await;
+    mock_server
+}
+
+async fn test_context(
+    scope: Scope,
+    method_name: &str,
+    actions_uri: &str,
+    response_code: StatusCode,
+    resp_body: Option<impl Serialize>,
+) -> TestContext {
+    let template = match resp_body {
+        Some(resp_body) => ResponseTemplate::new(response_code).set_body_json(resp_body),
+        None => ResponseTemplate::new(response_code),
+    };
+    let server = setup_api(scope, method_name, actions_uri, None::<()>, template).await;
+    let client = Octocrab::builder()
+        .base_uri(&server.uri())
+        .unwrap()
+        .build()
+        .unwrap();
+
+    TestContext {
+        _server: server,
+        client,
+    }
+}
+
+async fn test_context_with_request_body(
+    scope: Scope,
+    method_name: &str,
+    actions_uri: &str,
+    response_code: StatusCode,
+    request_body: impl Serialize,
+    resp_body: Option<impl Serialize>,
+) -> TestContext {
+    let template = ResponseTemplate::new(response_code).set_body_json(resp_body);
+    let server = setup_api(
+        scope,
+        method_name,
+        actions_uri,
+        Some(request_body),
+        template,
+    )
+    .await;
+    let client = Octocrab::builder()
+        .base_uri(&server.uri())
+        .unwrap()
+        .build()
+        .unwrap();
+
+    TestContext {
+        _server: server,
+        client,
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Tests
+///////////////////////////////////////////////////////////////////////////////
+
+#[tokio::test]
+async fn should_return_page_with_org_self_hosted_runners() {
+    let expected_runners: FakePage =
+        serde_json::from_str(include_str!("resources/self_hosted_runners.json")).unwrap();
+    let test_context = test_context(
+        Scope::Org,
+        "GET",
+        "/actions/runners",
+        StatusCode::OK,
+        Some(expected_runners.clone()),
+    )
+    .await;
+    let result = test_context
+        .client
+        .actions()
+        .list_org_self_hosted_runners(ORG)
+        .send()
+        .await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let Page {
+        total_count, items, ..
+    } = result.unwrap();
+    assert_eq!(total_count.unwrap(), expected_runners.total_count);
+    assert_eq!(items, expected_runners.runners);
+}
+
+#[tokio::test]
+async fn should_return_page_with_repo_self_hosted_runners() {
+    let expected_runners: FakePage =
+        serde_json::from_str(include_str!("resources/self_hosted_runners.json")).unwrap();
+    let test_context = test_context(
+        Scope::Repo,
+        "GET",
+        "/actions/runners",
+        StatusCode::OK,
+        Some(expected_runners.clone()),
+    )
+    .await;
+    let result = test_context
+        .client
+        .actions()
+        .list_repo_self_hosted_runners(OWNER, REPO)
+        .send()
+        .await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let Page {
+        total_count, items, ..
+    } = result.unwrap();
+    assert_eq!(total_count.unwrap(), expected_runners.total_count);
+    assert_eq!(items, expected_runners.runners);
+}
+
+#[tokio::test]
+async fn should_return_org_jit_config() {
+    let jit_config_req = JitConfigBody {
+        name: "jit_config".into(),
+        runner_group_id: 20.into(),
+        labels: vec!["label-1".into(), "label-2".into()],
+    };
+    let expected_response = jit_config_req.expected_response();
+
+    let test_context = test_context_with_request_body(
+        Scope::Org,
+        "POST",
+        &format!("/actions/runners/generate-jitconfig"),
+        StatusCode::CREATED,
+        jit_config_req.clone(),
+        Some(expected_response.clone()),
+    )
+    .await;
+
+    let result = test_context
+        .client
+        .actions()
+        .create_org_jit_runner_config(
+            ORG,
+            jit_config_req.name,
+            jit_config_req.runner_group_id,
+            jit_config_req.labels,
+        )
+        .send()
+        .await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let config = result.unwrap();
+    assert_eq!(config, expected_response);
+}
+
+#[tokio::test]
+async fn should_return_repo_jit_config() {
+    let jit_config_req = JitConfigBody {
+        name: "jit_config".into(),
+        runner_group_id: 20.into(),
+        labels: vec!["label-1".into(), "label-2".into()],
+    };
+    let expected_response = jit_config_req.expected_response();
+
+    let test_context = test_context_with_request_body(
+        Scope::Repo,
+        "POST",
+        &format!("/actions/runners/generate-jitconfig"),
+        StatusCode::CREATED,
+        jit_config_req.clone(),
+        Some(expected_response.clone()),
+    )
+    .await;
+
+    let result = test_context
+        .client
+        .actions()
+        .create_repo_jit_runner_config(
+            OWNER,
+            REPO,
+            jit_config_req.name,
+            jit_config_req.runner_group_id,
+            jit_config_req.labels,
+        )
+        .send()
+        .await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let config = result.unwrap();
+    assert_eq!(config, expected_response);
+}
+
+#[tokio::test]
+async fn should_return_org_registration_token() {
+    let expected_token: SelfHostedRunnerToken =
+        serde_json::from_str(include_str!("resources/self_hosted_runner_token.json")).unwrap();
+    let test_context = test_context(
+        Scope::Org,
+        "POST",
+        &format!("/actions/runners/registration-token"),
+        StatusCode::CREATED,
+        Some(expected_token.clone()),
+    )
+    .await;
+    let result = test_context
+        .client
+        .actions()
+        .create_org_runner_registration_token(ORG)
+        .await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let token = result.unwrap();
+    assert_eq!(token, expected_token);
+}
+
+#[tokio::test]
+async fn should_return_repo_registration_token() {
+    let expected_token: SelfHostedRunnerToken =
+        serde_json::from_str(include_str!("resources/self_hosted_runner_token.json")).unwrap();
+    let test_context = test_context(
+        Scope::Repo,
+        "POST",
+        &format!("/actions/runners/registration-token"),
+        StatusCode::CREATED,
+        Some(expected_token.clone()),
+    )
+    .await;
+    let result = test_context
+        .client
+        .actions()
+        .create_repo_runner_registration_token(OWNER, REPO)
+        .await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let token = result.unwrap();
+    assert_eq!(token, expected_token);
+}
+
+#[tokio::test]
+async fn should_return_org_remove_token() {
+    let expected_token: SelfHostedRunnerToken =
+        serde_json::from_str(include_str!("resources/self_hosted_runner_token.json")).unwrap();
+    let test_context = test_context(
+        Scope::Org,
+        "POST",
+        &format!("/actions/runners/remove-token"),
+        StatusCode::CREATED,
+        Some(expected_token.clone()),
+    )
+    .await;
+    let result = test_context
+        .client
+        .actions()
+        .create_org_runner_remove_token(ORG)
+        .await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let token = result.unwrap();
+    assert_eq!(token, expected_token);
+}
+
+#[tokio::test]
+async fn should_return_repo_remove_token() {
+    let expected_token: SelfHostedRunnerToken =
+        serde_json::from_str(include_str!("resources/self_hosted_runner_token.json")).unwrap();
+    let test_context = test_context(
+        Scope::Repo,
+        "POST",
+        &format!("/actions/runners/remove-token"),
+        StatusCode::CREATED,
+        Some(expected_token.clone()),
+    )
+    .await;
+    let result = test_context
+        .client
+        .actions()
+        .create_repo_runner_remove_token(OWNER, REPO)
+        .await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let token = result.unwrap();
+    assert_eq!(token, expected_token);
+}
+#[tokio::test]
+async fn should_return_single_org_self_hosted_runner() {
+    const RUNNER_ID: u64 = 30;
+
+    let expected_runner: SelfHostedRunner =
+        serde_json::from_str(include_str!("resources/self_hosted_runner.json")).unwrap();
+    let test_context = test_context(
+        Scope::Org,
+        "GET",
+        &format!("/actions/runners/{RUNNER_ID}"),
+        StatusCode::OK,
+        Some(expected_runner.clone()),
+    )
+    .await;
+    let result = test_context
+        .client
+        .actions()
+        .get_org_runner(ORG, RUNNER_ID.into())
+        .await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let runner = result.unwrap();
+    assert_eq!(runner, expected_runner);
+}
+
+#[tokio::test]
+async fn should_return_single_repo_self_hosted_runner() {
+    const RUNNER_ID: u64 = 30;
+
+    let expected_runner: SelfHostedRunner =
+        serde_json::from_str(include_str!("resources/self_hosted_runner.json")).unwrap();
+    let test_context = test_context(
+        Scope::Repo,
+        "GET",
+        &format!("/actions/runners/{RUNNER_ID}"),
+        StatusCode::OK,
+        Some(expected_runner.clone()),
+    )
+    .await;
+    let result = test_context
+        .client
+        .actions()
+        .get_repo_runner(OWNER, REPO, RUNNER_ID.into())
+        .await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let runner = result.unwrap();
+    assert_eq!(runner, expected_runner);
+}
+
+#[tokio::test]
+async fn should_return_no_content_deleting_org_runner() {
+    const RUNNER_ID: u64 = 30;
+
+    let test_context = test_context(
+        Scope::Org,
+        "DELETE",
+        &format!("/actions/runners/{RUNNER_ID}"),
+        StatusCode::NO_CONTENT,
+        None::<()>,
+    )
+    .await;
+    let result = test_context
+        .client
+        .actions()
+        .delete_org_runner(ORG, RUNNER_ID.into())
+        .await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn should_return_no_content_deleting_repo_runner() {
+    const RUNNER_ID: u64 = 30;
+
+    let test_context = test_context(
+        Scope::Repo,
+        "DELETE",
+        &format!("/actions/runners/{RUNNER_ID}"),
+        StatusCode::NO_CONTENT,
+        None::<()>,
+    )
+    .await;
+    let result = test_context
+        .client
+        .actions()
+        .delete_repo_runner(OWNER, REPO, RUNNER_ID.into())
+        .await;
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+}

--- a/tests/resources/self_hosted_runner.json
+++ b/tests/resources/self_hosted_runner.json
@@ -1,0 +1,24 @@
+{
+  "id": 23,
+  "name": "linux_runner",
+  "os": "linux",
+  "status": "online",
+  "busy": true,
+  "labels": [
+    {
+      "id": 5,
+      "name": "self-hosted",
+      "type": "read-only"
+    },
+    {
+      "id": 7,
+      "name": "X64",
+      "type": "read-only"
+    },
+    {
+      "id": 11,
+      "name": "Linux",
+      "type": "read-only"
+    }
+  ]
+}

--- a/tests/resources/self_hosted_runner_token.json
+++ b/tests/resources/self_hosted_runner_token.json
@@ -1,0 +1,4 @@
+{
+  "token": "LLBF3JGZDX3P5PMEXLND6TS6FCWO6",
+  "expires_at": "2020-01-22T12:13:35.123-08:00"
+}

--- a/tests/resources/self_hosted_runners.json
+++ b/tests/resources/self_hosted_runners.json
@@ -1,0 +1,58 @@
+{
+  "total_count": 2,
+  "runners": [
+    {
+      "id": 23,
+      "name": "linux_runner",
+      "os": "linux",
+      "status": "online",
+      "busy": true,
+      "labels": [
+        {
+          "id": 5,
+          "name": "self-hosted",
+          "type": "read-only"
+        },
+        {
+          "id": 7,
+          "name": "X64",
+          "type": "read-only"
+        },
+        {
+          "id": 11,
+          "name": "Linux",
+          "type": "read-only"
+        }
+      ]
+    },
+    {
+      "id": 24,
+      "name": "mac_runner",
+      "os": "macos",
+      "status": "offline",
+      "busy": false,
+      "labels": [
+        {
+          "id": 5,
+          "name": "self-hosted",
+          "type": "read-only"
+        },
+        {
+          "id": 7,
+          "name": "X64",
+          "type": "read-only"
+        },
+        {
+          "id": 20,
+          "name": "macOS",
+          "type": "read-only"
+        },
+        {
+          "id": 21,
+          "name": "no-gpu",
+          "type": "custom"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds some methods to the ActionsHandler to work with GitHub's self-hosted runners API, for managing self-hosted GitHub Actions runners associated with repos or organizations. I didn't have time to cover the full API, so I implemented the methods I need and what I think are likely to be the most popular methods in this area of the API.

Relevant API reference is [here](https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28).

I have tried to follow the styles and conventions that I see in the project, but please let me know if I missed anything. Thanks!