### PR TITLE
feat: add check run pull requests and list parameters

### DIFF
--- a/src/models/checks.rs
+++ b/src/models/checks.rs
@@ -1,6 +1,7 @@
 use crate::models::workflows::HeadCommit;
 
 use super::*;
+use crate::models::pulls::PullRequest;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -26,6 +27,7 @@ pub struct CheckRun {
     pub started_at: Option<chrono::DateTime<chrono::Utc>>,
     pub completed_at: Option<chrono::DateTime<chrono::Utc>>,
     pub name: String,
+    pub pull_requests: Vec<PullRequest>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This PR add a few request parameters for the list check run from check suite request (see: https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-in-a-check-suite) 

It also adds the `pull_requests` field to `CheckRun`. 

This is useful when handling check suite event that are not yet attached to a pull request. 

Let me know if anything needs to be changed. 

