### PR TITLE
models/timelines: make dismissal_message optional

### DIFF
--- a/src/models/timelines.rs
+++ b/src/models/timelines.rs
@@ -90,7 +90,7 @@ pub struct TimelineEvent {
 pub struct DismissedReview {
     state: pulls::ReviewState,
     review_id: ReviewId,
-    dismissal_message: String,
+    dismissal_message: Option<String>,
     dismissal_commit_id: Option<String>,
 }
 


### PR DESCRIPTION
Assuming `dismissal_message` is always a string seems to conflict with some GitHub API responses, which leads to `serde` being unable to deserialize the payload.

Signed-off-by: Joao Eduardo Luis \<joao@1e3ms.io>