### PR TITLE
Make user information optional

### DIFF
--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -305,7 +305,7 @@ pub struct Release {
     pub prerelease: bool,
     pub created_at: Option<DateTime<Utc>>,
     pub published_at: Option<DateTime<Utc>>,
-    pub author: crate::models::Author,
+    pub author: Option<crate::models::Author>,
     pub assets: Vec<Asset>,
 }
 


### PR DESCRIPTION
Fixes https://github.com/XAMPPRocky/octocrab/issues/197

Despite it being documented as required in the Github API, the `author` field is sometimes absent when listing releases (perhaps in rare cases where a user's profile is deleted or similar).

This can be demonstrated by listing releases for the segmentio/chamber repo: https://api.github.com/repos/segmentio/chamber/releases
<img width="1083" alt="Screenshot 2024-01-08 at 2 17 24 pm" src="https://github.com/XAMPPRocky/octocrab/assets/3197007/625fe08a-1322-472a-b23e-e4c45b63e509">

Making this field optional allows octocrab users to handle this partial data gracefully rather than making all of the release data inaccessible.

This is obviously a breaking change, so I'd think that it should go into an 0.33.0 release rather than into a patch.