### PR TITLE
[docs] Improve the update_file docs

### DIFF
--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -287,6 +287,17 @@ impl<'octo> RepoHandler<'octo> {
         )
     }
 
+    /// Update an existing file.
+    ///
+    /// - `path`: the path of the updated file.
+    /// - `message`: the message of the commit used to update the file
+    /// - `content`: the updated contents of the file (base64 encoding is done
+    ///   automatically).
+    /// - `sha`: the blob SHA of the file being updated. This can be obtained
+    ///   using the [RepoHandler::get_content] function.
+    ///
+    /// [GitHub API documentation](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents)
+    ///
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
     /// # let blob_sha = "";


### PR DESCRIPTION
This is a documentation-only commit. It updates the docs for the update_file function to explain what the different parameters do and adds a hyperlink to the GitHub API docs.

I was using `octocrab` but it wasn't clear what the `sha` parameter was, and why I'd need to provide a file SHA if I'm already giving the path of the file I want to update. I did some digging to figure out the reason, so I thought I'd update the docs to explain this for future travellers.