### PR TITLE
fixed timeout methods not being feature gated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ http = "0.2.5"
 http-body = "0.4.5"
 hyper = { version = "0.14.13", features = ["client", "http1", "stream", "tcp"] }
 hyper-rustls = { version = "0.24.0", optional = true }
-hyper-timeout = { version = "0.4.1" }
+hyper-timeout = { version = "0.4.1", optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 once_cell = "1.7.2"
 percent-encoding = "2.2.0"
@@ -46,8 +46,8 @@ serde_json = "1.0.64"
 serde_path_to_error = "0.1.4"
 serde_urlencoded = "0.7.1"
 snafu = { version = "0.7", features = ["backtraces"] }
-tokio = { version = "1.17.0", default-features = false }
-tower = { version = "0.4.13", default-features = false, features = ["util", "buffer", "timeout"] }
+tokio = { version = "1.17.0", default-features = false, optional = true }
+tower = { version = "0.4.13", default-features = false, features = ["util", "buffer"] }
 tower-http = { version = "0.4.0", features = ["map-response-body", "trace"] }
 tracing = { version = "0.1.37", features = ["log"], optional = true }
 url = { version = "2.2.2", features = ["serde"] }
@@ -66,7 +66,7 @@ pretty_assertions = "1.4.0"
 graphql_client = "0.13.0"
 
 [features]
-default = ["follow-redirect", "retry", "rustls", "tracing"]
+default = ["follow-redirect", "retry", "rustls", "timeout", "tracing"]
 
 follow-redirect = ["tower-http/follow-redirect"]
 retry = ["tower/retry", "futures-util"]
@@ -74,3 +74,4 @@ rustls = ["hyper-rustls"]
 rustls-webpki-tokio = ["hyper-rustls/webpki-tokio"]
 opentls = ["hyper-tls"]
 stream = ["futures-core", "futures-util", "hyper/stream"]
+timeout = ["hyper-timeout", "tokio", "tower/timeout"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ http = "0.2.5"
 http-body = "0.4.5"
 hyper = { version = "0.14.13", features = ["client", "http1", "stream", "tcp"] }
 hyper-rustls = { version = "0.24.0", optional = true }
-hyper-timeout = { version = "0.4.1", optional = true }
+hyper-timeout = { version = "0.4.1" }
 hyper-tls = { version = "0.5.0", optional = true }
 once_cell = "1.7.2"
 percent-encoding = "2.2.0"
@@ -46,8 +46,8 @@ serde_json = "1.0.64"
 serde_path_to_error = "0.1.4"
 serde_urlencoded = "0.7.1"
 snafu = { version = "0.7", features = ["backtraces"] }
-tokio = { version = "1.17.0", default-features = false, optional = true }
-tower = { version = "0.4.13", default-features = false, features = ["util", "buffer"] }
+tokio = { version = "1.17.0", default-features = false }
+tower = { version = "0.4.13", default-features = false, features = ["util", "buffer", "timeout"] }
 tower-http = { version = "0.4.0", features = ["map-response-body", "trace"] }
 tracing = { version = "0.1.37", features = ["log"], optional = true }
 url = { version = "2.2.2", features = ["serde"] }
@@ -66,7 +66,7 @@ pretty_assertions = "1.4.0"
 graphql_client = "0.13.0"
 
 [features]
-default = ["follow-redirect", "retry", "rustls", "timeout", "tracing"]
+default = ["follow-redirect", "retry", "rustls", "tracing"]
 
 follow-redirect = ["tower-http/follow-redirect"]
 retry = ["tower/retry", "futures-util"]
@@ -74,4 +74,3 @@ rustls = ["hyper-rustls"]
 rustls-webpki-tokio = ["hyper-rustls/webpki-tokio"]
 opentls = ["hyper-tls"]
 stream = ["futures-core", "futures-util", "hyper/stream"]
-timeout = ["hyper-timeout", "tokio", "tower/timeout"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,6 @@ use hyper_rustls::HttpsConnectorBuilder;
 #[cfg(feature = "retry")]
 use tower::retry::{Retry, RetryLayer};
 
-#[cfg(feature = "timeout")]
 use {
     hyper_timeout::TimeoutConnector,
     tokio::io::{AsyncRead, AsyncWrite},
@@ -486,21 +485,18 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
     }
 
     /// Set the connect timeout.
-    #[cfg(feature = "timeout")]
     pub fn set_connect_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.connect_timeout = timeout;
         self
     }
 
     /// Set the read timeout.
-    #[cfg(feature = "timeout")]
     pub fn set_read_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.read_timeout = timeout;
         self
     }
 
     /// Set the write timeout.
-    #[cfg(feature = "timeout")]
     pub fn set_write_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.write_timeout = timeout;
         self
@@ -571,7 +567,6 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
         retry_layer.layer(connector)
     }
 
-    #[cfg(feature = "timeout")]
     pub fn set_connect_timeout_service<T>(&self, connector: T) -> TimeoutConnector<T>
     where
         T: Service<Uri> + Send,
@@ -610,7 +605,6 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
             #[cfg(all(feature = "opentls", not(feature = "rustls")))]
             let connector = HttpsConnector::new();
 
-            #[cfg(feature = "timeout")]
             let connector = self.set_connect_timeout_service(connector);
 
             hyper::Client::builder().build(connector)
@@ -750,11 +744,8 @@ pub struct DefaultOctocrabBuilderConfig {
     auth: Auth,
     previews: Vec<&'static str>,
     extra_headers: Vec<(HeaderName, String)>,
-    #[cfg(feature = "timeout")]
     connect_timeout: Option<Duration>,
-    #[cfg(feature = "timeout")]
     read_timeout: Option<Duration>,
-    #[cfg(feature = "timeout")]
     write_timeout: Option<Duration>,
     base_uri: Option<Uri>,
     #[cfg(feature = "retry")]
@@ -767,11 +758,8 @@ impl Default for DefaultOctocrabBuilderConfig {
             auth: Auth::None,
             previews: Vec::new(),
             extra_headers: Vec::new(),
-            #[cfg(feature = "timeout")]
             connect_timeout: None,
-            #[cfg(feature = "timeout")]
             read_timeout: None,
-            #[cfg(feature = "timeout")]
             write_timeout: None,
             base_uri: None,
             #[cfg(feature = "retry")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,7 @@ use hyper_rustls::HttpsConnectorBuilder;
 #[cfg(feature = "retry")]
 use tower::retry::{Retry, RetryLayer};
 
+#[cfg(feature = "timeout")]
 use {
     hyper_timeout::TimeoutConnector,
     tokio::io::{AsyncRead, AsyncWrite},
@@ -485,18 +486,21 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
     }
 
     /// Set the connect timeout.
+    #[cfg(feature = "timeout")]
     pub fn set_connect_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.connect_timeout = timeout;
         self
     }
 
     /// Set the read timeout.
+    #[cfg(feature = "timeout")]
     pub fn set_read_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.read_timeout = timeout;
         self
     }
 
     /// Set the write timeout.
+    #[cfg(feature = "timeout")]
     pub fn set_write_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.write_timeout = timeout;
         self
@@ -567,6 +571,7 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
         retry_layer.layer(connector)
     }
 
+    #[cfg(feature = "timeout")]
     pub fn set_connect_timeout_service<T>(&self, connector: T) -> TimeoutConnector<T>
     where
         T: Service<Uri> + Send,
@@ -605,6 +610,7 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
             #[cfg(all(feature = "opentls", not(feature = "rustls")))]
             let connector = HttpsConnector::new();
 
+            #[cfg(feature = "timeout")]
             let connector = self.set_connect_timeout_service(connector);
 
             hyper::Client::builder().build(connector)
@@ -744,8 +750,11 @@ pub struct DefaultOctocrabBuilderConfig {
     auth: Auth,
     previews: Vec<&'static str>,
     extra_headers: Vec<(HeaderName, String)>,
+    #[cfg(feature = "timeout")]
     connect_timeout: Option<Duration>,
+    #[cfg(feature = "timeout")]
     read_timeout: Option<Duration>,
+    #[cfg(feature = "timeout")]
     write_timeout: Option<Duration>,
     base_uri: Option<Uri>,
     #[cfg(feature = "retry")]
@@ -758,8 +767,11 @@ impl Default for DefaultOctocrabBuilderConfig {
             auth: Auth::None,
             previews: Vec::new(),
             extra_headers: Vec::new(),
+            #[cfg(feature = "timeout")]
             connect_timeout: None,
+            #[cfg(feature = "timeout")]
             read_timeout: None,
+            #[cfg(feature = "timeout")]
             write_timeout: None,
             base_uri: None,
             #[cfg(feature = "retry")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,18 +486,21 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
     }
 
     /// Set the connect timeout.
+    #[cfg(feature = "timeout")]
     pub fn set_connect_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.connect_timeout = timeout;
         self
     }
 
     /// Set the read timeout.
+    #[cfg(feature = "timeout")]
     pub fn set_read_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.read_timeout = timeout;
         self
     }
 
     /// Set the write timeout.
+    #[cfg(feature = "timeout")]
     pub fn set_write_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.write_timeout = timeout;
         self


### PR DESCRIPTION
> [!NOTE]
> For those affected: Add the `timeout`-feature to get around this bug

In #498 a few methods were introduced which reference fields which are feature-gated.

![image](https://github.com/XAMPPRocky/octocrab/assets/26258709/aa430a73-e756-4a9c-a99b-78d6a02f1a60)

causing 
![image](https://github.com/XAMPPRocky/octocrab/assets/26258709/48044018-d958-4546-94b9-e64ee6c8644f)


This PR applies the same feature gate for these methods (reverted https://github.com/XAMPPRocky/octocrab/pull/498/commits/f1c94c14e250cf7543a8f9bae273613ef5f7ae55)

Cheers and thanks for providing such an usefull crate ^^