### PR TITLE
Added a test for `repos().is_collaborator()`. The 204 case is good!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Other
+- Added a test case for `repos().is_collaborator()` to cover both 204 and 404 cases.
+
 ## [0.33.1](https://github.com/XAMPPRocky/octocrab/compare/v0.33.0...v0.33.1) - 2024-01-15
 
 ### Fixed

--- a/tests/issues_labels_delete_test.rs
+++ b/tests/issues_labels_delete_test.rs
@@ -2,7 +2,6 @@ mod mock_error;
 
 use mock_error::setup_error_handler;
 use octocrab::{models, Octocrab};
-// use serde::{Deserialize, Serialize};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,

--- a/tests/repos_is_collaborator_test.rs
+++ b/tests/repos_is_collaborator_test.rs
@@ -1,0 +1,79 @@
+mod mock_error;
+
+use mock_error::setup_error_handler;
+use octocrab::Octocrab;
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+async fn setup_repo_collaborator_api(template: ResponseTemplate) -> MockServer {
+    let owner: &str = "org";
+    let repo: &str = "some-repo";
+    let username: &str = "someusername";
+
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/{owner}/{repo}/collaborators/{username}"
+        )))
+        .respond_with(template.clone())
+        .mount(&mock_server)
+        .await;
+
+    setup_error_handler(
+        &mock_server,
+        &format!("GET on /repos/{owner}/{repo}/collaborators/{username} was not received"),
+    )
+    .await;
+    mock_server
+}
+
+fn setup_octocrab(uri: &str) -> Octocrab {
+    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
+}
+
+const OWNER: &str = "org";
+const REPO: &str = "some-repo";
+const USERNAME: &str = "someusername";
+
+#[tokio::test]
+async fn is_collaborators_returns_true() {
+    let template = ResponseTemplate::new(204);
+    let mock_server = setup_repo_collaborator_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client
+        .repos(OWNER.to_owned(), REPO.to_owned())
+        .is_collaborator(USERNAME.to_owned())
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let result = result.unwrap();
+    assert!(result, "expected the result to be true: {}", result);
+}
+
+#[tokio::test]
+async fn is_collaborators_returns_false() {
+    let template = ResponseTemplate::new(404);
+    let mock_server = setup_repo_collaborator_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client
+        .repos(OWNER.to_owned(), REPO.to_owned())
+        .is_collaborator(USERNAME.to_owned())
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let result = result.unwrap();
+    assert!(!result, "expected the result to be false: {}", result);
+}


### PR DESCRIPTION
Added a test for `repos().is_collaborator()` which proves the 204 case is good.

https://github.com/manchicken/octocrab/issues/156