### PR TITLE
Handle redirects in ReleasesHandler::stream_asset().

### DIFF
--- a/src/api/repos/releases.rs
+++ b/src/api/repos/releases.rs
@@ -193,6 +193,7 @@ impl<'octo, 'r> ReleasesHandler<'octo, 'r> {
             .header(http::header::ACCEPT, "application/octet-stream");
         let request = self.parent.crab.build_request(builder, None::<&()>)?;
         let response = self.parent.crab.execute(request).await?;
+        let response = self.parent.crab.follow_location_to_data(response).await?;
         Ok(response
             .into_body()
             .map_err(|source| crate::error::Error::Hyper {


### PR DESCRIPTION
From
https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#get-a-release-asset

```
API clients should handle both a 200 or 302 response.
```