### PR TITLE
Added tests for `repos().merges()`

### DIFF
--- a/tests/repos_merges_test.rs
+++ b/tests/repos_merges_test.rs
@@ -1,0 +1,102 @@
+mod mock_error;
+
+use mock_error::setup_error_handler;
+use octocrab::{models::repos::MergeCommit, Octocrab};
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+async fn setup_repos_merges_api(template: ResponseTemplate) -> MockServer {
+    let owner: &str = "org";
+    let repo: &str = "some-repo";
+
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/repos/{owner}/{repo}/merges")))
+        .respond_with(template.clone())
+        .mount(&mock_server)
+        .await;
+
+    setup_error_handler(
+        &mock_server,
+        &format!("POST on /repos/{owner}/{repo}/merges was not received"),
+    )
+    .await;
+    mock_server
+}
+
+fn setup_octocrab(uri: &str) -> Octocrab {
+    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
+}
+
+const OWNER: &str = "org";
+const REPO: &str = "some-repo";
+const BRANCH_HEAD: &str = "head";
+const BRANCH_BASE: &str = "base";
+const COMMIT_MESSAGE: &str = "message here";
+
+#[tokio::test]
+async fn test_merges_returns_204() {
+    let template = ResponseTemplate::new(204);
+    let mock_server = setup_repos_merges_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client
+        .repos(OWNER.to_owned(), REPO.to_owned())
+        .merge(BRANCH_HEAD.to_owned(), BRANCH_BASE.to_owned())
+        .commit_message(COMMIT_MESSAGE.to_owned())
+        .send()
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+
+    let result = result.unwrap();
+
+    assert!(
+        result.is_none(),
+        "expected None() value, got Some(): {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_merges_returns_201() {
+    let repo_merges_json: MergeCommit =
+        serde_json::from_str(include_str!("resources/repos_merges_201.json")).unwrap();
+    let template = ResponseTemplate::new(201).set_body_json(&repo_merges_json);
+    let mock_server = setup_repos_merges_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client
+        .repos(OWNER.to_owned(), REPO.to_owned())
+        .merge(BRANCH_HEAD.to_owned(), BRANCH_BASE.to_owned())
+        .commit_message(COMMIT_MESSAGE.to_owned())
+        .send()
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+
+    let result = result.unwrap();
+
+    assert!(
+        result.is_some(),
+        "expected Some() value, got None: {:#?}",
+        result
+    );
+
+    assert_eq!(
+        result.unwrap().sha,
+        String::from("6dcb09b5b57875f334f61aebed695e2e4193db5e"),
+        "Unable to verify SHA from fixture data."
+    );
+}

--- a/tests/resources/repos_merges_201.json
+++ b/tests/resources/repos_merges_201.json
@@ -1,0 +1,95 @@
+{
+  "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "node_id": "MDY6Q29tbWl0NmRjYjA5YjViNTc4NzVmMzM0ZjYxYWViZWQ2OTVlMmU0MTkzZGI1ZQ==",
+  "html_url": "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "comments_url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e/comments",
+  "commit": {
+    "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+    "author": {
+      "name": "Monalisa Octocat",
+      "email": "mona@github.com",
+      "date": "2011-04-14T16:00:49Z"
+    },
+    "committer": {
+      "name": "Monalisa Octocat",
+      "email": "mona@github.com",
+      "date": "2011-04-14T16:00:49Z"
+    },
+    "message": "Fix all the bugs",
+    "tree": {
+      "url": "https://api.github.com/repos/octocat/Hello-World/tree/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+    },
+    "comment_count": 0,
+    "verification": {
+      "verified": false,
+      "reason": "unsigned",
+      "signature": null,
+      "payload": null
+    }
+  },
+  "author": {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "committer": {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "parents": [
+    {
+      "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+    }
+  ],
+  "stats": {
+    "additions": 104,
+    "deletions": 4,
+    "total": 108
+  },
+  "files": [
+    {
+      "filename": "file1.txt",
+      "additions": 10,
+      "deletions": 2,
+      "changes": 12,
+      "status": "modified",
+      "raw_url": "https://github.com/octocat/Hello-World/raw/7ca483543807a51b6079e54ac4cc392bc29ae284/file1.txt",
+      "blob_url": "https://github.com/octocat/Hello-World/blob/7ca483543807a51b6079e54ac4cc392bc29ae284/file1.txt",
+      "patch": "@@ -29,7 +29,7 @@\n....."
+    }
+  ]
+}


### PR DESCRIPTION
- Added a test for 201 cases
- Added a test for 204 cases
- Fixed the broken 204 case

**BREAKING CHANGE WARNING**: This changes the
return type of the builder from
`Result<models::repos::MergeCommit>` to
`Result<Option<models::repos::MergeCommit>>`.