### PR TITLE
Fixing the test that `wiremock@v0.6.0` breaks.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ tokio = { version = "1.17.0", default-features = false, features = [
     "time",
 ] }
 tokio-test = "0.4.2"
-wiremock = "0.5.3"
+wiremock = "0.6.0"
 crypto_box = { version = "0.8.2", features = ["seal"] }
 base64 = "0.21.2"
 pretty_assertions = "1.4.0"

--- a/tests/follow_redirect.rs
+++ b/tests/follow_redirect.rs
@@ -25,10 +25,8 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
         .respond_with(
             ResponseTemplate::new(301).append_header(
                 "location",
-                HeaderValue::from_bytes(
-                    format!("/repos/{new_owner}/{repo}/stargazers").into_bytes(),
-                )
-                .unwrap(),
+                HeaderValue::from_bytes(format!("/repos/{new_owner}/{repo}/stargazers").as_bytes())
+                    .unwrap(),
             ),
         )
         .mount(&mock_server)


### PR DESCRIPTION
- Updated wiremock to 0.6.0
- Fixed the one test broken by the update

I did this one in response to seeing tests fail here: https://github.com/XAMPPRocky/octocrab/pull/575