### PR TITLE
Fixed the `projects().delete_project().send() function

### DIFF
--- a/src/api/projects/projects.rs
+++ b/src/api/projects/projects.rs
@@ -93,10 +93,12 @@ impl<'octo, 'r> DeleteProjectBuilder<'octo, 'r> {
         }
     }
 
-    pub async fn send(self) -> crate::Result<crate::models::Project> {
+    pub async fn send(self) -> crate::Result<()> {
         let route = format!("/projects/{project_id}", project_id = self.project_id);
 
-        self.handler.crab.delete(route, None::<&()>).await
+        crate::map_github_error(self.handler.crab._delete(route, None::<&()>).await?)
+            .await
+            .map(drop)
     }
 }
 

--- a/tests/projects_project_delete_test.rs
+++ b/tests/projects_project_delete_test.rs
@@ -35,22 +35,46 @@ fn setup_octocrab(uri: &str) -> Octocrab {
 }
 
 #[tokio::test]
-async fn should_delete_project() {
-    let org_project: Project =
-        serde_json::from_str(include_str!("resources/project.json")).unwrap();
-
-    let page_response = FakeProject(org_project);
-
-    let template = ResponseTemplate::new(200).set_body_json(&page_response);
+async fn should_delete_project_204() {
+    let template = ResponseTemplate::new(204);
     let mock_server = setup_api(template).await;
 
     let client = setup_octocrab(&mock_server.uri());
-    let project = client
-        .projects()
-        .delete_project(PROJECT_ID)
-        .send()
-        .await
-        .unwrap();
+    let result = client.projects().delete_project(PROJECT_ID).send().await;
 
-    assert_eq!(project.creator.login, "octocat");
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn should_delete_project_410() {
+    let template = ResponseTemplate::new(410);
+    let mock_server = setup_api(template).await;
+
+    let client = setup_octocrab(&mock_server.uri());
+    let result = client.projects().delete_project(PROJECT_ID).send().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success somehow: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn should_delete_project_500() {
+    let template = ResponseTemplate::new(500);
+    let mock_server = setup_api(template).await;
+
+    let client = setup_octocrab(&mock_server.uri());
+    let result = client.projects().delete_project(PROJECT_ID).send().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success somehow: {:#?}",
+        result
+    );
 }


### PR DESCRIPTION
- This endpoint, `DELETE /projects/{project_id}` [is documented](https://docs.github.com/en/enterprise-cloud@latest/rest/projects/projects?apiVersion=2022-11-28#delete-a-project) as never returning 200.
- The test was incorrectly verifying a 200 case, and the function broke in a 204
- I fixed the function
- I fixed the test
- I added coverage for 410 and 500 cases, too