### PR TITLE
Add repository list language support

### DIFF
--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -489,6 +489,29 @@ impl<'octo> RepoHandler<'octo> {
         ListStarGazersBuilder::new(self)
     }
 
+    /// Lists languages for the specified repository.
+    /// The value shown for each language is the number of bytes of code written in that language.
+    ///
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    ///
+    /// // Get the languages used in the repository
+    /// let languages = octocrab::instance()
+    ///     .repos("owner", "repo")
+    ///     .list_languages()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list_languages(&self) -> Result<models::repos::Languages> {
+        let route = format!(
+            "/repos/{owner}/{repo}/languages",
+            owner = self.owner,
+            repo = self.repo,
+        );
+        self.crab.get(route, None::<&()>).await
+    }
+
     /// Creates a `ReleasesHandler` for the specified repository.
     pub fn releases(&self) -> releases::ReleasesHandler<'_, '_> {
         releases::ReleasesHandler::new(self)

--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -377,3 +377,6 @@ pub struct MergeCommit {
     pub html_url: String,
     pub comments_url: String,
 }
+
+/// A HashMap of languages and the number of bytes of code written in that language.
+pub type Languages = std::collections::HashMap<String, i64>;


### PR DESCRIPTION
I have added support for getting the languages of a repository. [The API returns a Hashmap of the languages and the byte count of that language](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-languages).

Let me know if there is anything else that I need to do to get this merged.

Love this project by the way :heart_eyes: 