### PR TITLE
Fix personal token auth for pagination

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,9 +741,9 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
             .clone()
             .unwrap_or_else(|| Uri::from_str(GITHUB_BASE_URI).unwrap());
 
-        let client = BaseUriLayer::new(uri).layer(client);
+        let client = BaseUriLayer::new(uri.clone()).layer(client);
 
-        let client = AuthHeaderLayer::new(auth_header).layer(client);
+        let client = AuthHeaderLayer::new(auth_header, uri).layer(client);
 
         Ok(Octocrab::new(client, auth_state))
     }


### PR DESCRIPTION
Previously the AuthHeaderLayer added the auth header only when the authority was empty (i.e., base URI for GitHub was supposed to be used). However, the page URIs (e.g., next page) returned by GitHub API contains the absolute URL including the hostname. Because of this, the following code didn't work for resources that needed authentication (e.g., private repos)

```rust
use octocrab::Octocrab;

#[tokio::main]
async fn main() -> octocrab::Result<()> {
    let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env variable is required");

    let octocrab = Octocrab::builder().personal_token(token).build()?;

    let page = octocrab
        .repos("owner", "private-repo")
        .list_commits()
        .send()
        .await?;

    octocrab
        .get_page::<octocrab::models::repos::RepoCommit>(&page.next)
        .await?;

    Ok(())
}
```

This fix adds the base URI to the AuthHeaderLayer so that it can check whether a request is destined for GitHub (either the hostname is empty or it is equal to the base URI).