### PR TITLE
Fixed some `.gists()` functions, and wrote tests.

### DIFF
--- a/src/api/checks.rs
+++ b/src/api/checks.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Utc};
-use hyper::body::Body;
 
 use crate::models::checks::{AutoTriggerCheck, CheckSuite, CheckSuitePreferences};
 use crate::models::{AppId, CheckRunId, CheckSuiteId};

--- a/src/api/gists.rs
+++ b/src/api/gists.rs
@@ -193,10 +193,16 @@ impl<'octo> GistsHandler<'octo> {
     /// ```
     pub async fn delete(&self, gist_id: impl AsRef<str>) -> Result<()> {
         let gist_id = gist_id.as_ref();
-        self.crab
+        let response = self
+            .crab
             ._delete(format!("/gists/{gist_id}"), None::<&()>)
-            .await
-            .map(|_| ())
+            .await?;
+
+        if response.status() != StatusCode::NOT_MODIFIED && !response.status().is_success() {
+            return Err(crate::map_github_error(response).await.unwrap_err());
+        }
+
+        Ok(())
     }
 
     /// Get a single gist revision.

--- a/tests/gists_test.rs
+++ b/tests/gists_test.rs
@@ -1,0 +1,225 @@
+mod mock_error;
+
+use mock_error::setup_error_handler;
+use octocrab::Octocrab;
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+async fn setup_get_api(template: ResponseTemplate) -> MockServer {
+    let gist_id: &str = "12c55a94bd03166ff33ed0596263b4c6";
+
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/gists/{gist_id}/star")))
+        .respond_with(template.clone())
+        .mount(&mock_server)
+        .await;
+
+    setup_error_handler(
+        &mock_server,
+        &format!("GET on /gists/{gist_id}/star was not received"),
+    )
+    .await;
+    mock_server
+}
+
+async fn setup_delete_api(template: ResponseTemplate) -> MockServer {
+    let gist_id: &str = "12c55a94bd03166ff33ed0596263b4c6";
+
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path(format!("/gists/{gist_id}/star")))
+        .respond_with(template.clone())
+        .mount(&mock_server)
+        .await;
+
+    setup_error_handler(
+        &mock_server,
+        &format!("DELETE on /gists/{gist_id}/star was not received"),
+    )
+    .await;
+    mock_server
+}
+
+async fn setup_put_api(template: ResponseTemplate) -> MockServer {
+    let gist_id: &str = "12c55a94bd03166ff33ed0596263b4c6";
+
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path(format!("/gists/{gist_id}/star")))
+        .respond_with(template.clone())
+        .mount(&mock_server)
+        .await;
+
+    setup_error_handler(
+        &mock_server,
+        &format!("PUT on /gists/{gist_id}/star was not received"),
+    )
+    .await;
+    mock_server
+}
+
+fn setup_octocrab(uri: &str) -> Octocrab {
+    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
+}
+
+const GIST_ID: &str = "12c55a94bd03166ff33ed0596263b4c6";
+
+#[tokio::test]
+async fn test_get_gists_star_204() {
+    let template = ResponseTemplate::new(204);
+    let mock_server = setup_get_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client.gists().is_starred(GIST_ID.to_owned()).await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let result = result.unwrap();
+    assert!(result, "expected the result to be true: {}", result);
+}
+
+#[tokio::test]
+async fn test_get_gists_star_404() {
+    let template = ResponseTemplate::new(404);
+    let mock_server = setup_get_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client.gists().is_starred(GIST_ID.to_owned()).await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let result = result.unwrap();
+    assert!(!result, "expected the result to be false: {}", result);
+}
+
+#[tokio::test]
+async fn test_get_gists_star_500() {
+    let template = ResponseTemplate::new(500);
+    let mock_server = setup_get_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client.gists().is_starred(GIST_ID.to_owned()).await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_put_gists_star_204() {
+    let template = ResponseTemplate::new(204);
+    let mock_server = setup_put_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client.gists().star(GIST_ID.to_owned()).await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_put_gists_star_404() {
+    let template = ResponseTemplate::new(404);
+    let mock_server = setup_put_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client.gists().star(GIST_ID.to_owned()).await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_put_gists_star_500() {
+    let template = ResponseTemplate::new(500);
+    let mock_server = setup_put_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client.gists().star(GIST_ID.to_owned()).await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_delete_gists_star_204() {
+    let template = ResponseTemplate::new(204);
+    let mock_server = setup_delete_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client.gists().unstar(GIST_ID.to_owned()).await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_delete_gists_star_304() {
+    let template = ResponseTemplate::new(304);
+    let mock_server = setup_delete_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client.gists().unstar(GIST_ID.to_owned()).await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_delete_gists_star_404() {
+    let template = ResponseTemplate::new(404);
+    let mock_server = setup_delete_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client.gists().unstar(GIST_ID.to_owned()).await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_delete_gists_star_500() {
+    let template = ResponseTemplate::new(500);
+    let mock_server = setup_delete_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client.gists().unstar(GIST_ID.to_owned()).await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}


### PR DESCRIPTION
- All three gist star-related functions suppressed errors, which has been fixed
- `.gists().is_starred()`
  - 204 case covered
  - 404 case covered
  - 500 case covered
  - Now handles errors properly
- `.gists().star()`
  - 204 case covered
  - 404 case covered
  - 500 case covered
  - Now handles errors properly
- `.gists().unstar()`
  - 204 case covered
  - 304 case covered
  - 404 case covered
  - 500 case covered
  - Now handles errors properly
- `.gists().delete()`
  - 204 case covered
  - 304 case covered
  - 404 case covered
  - 500 case covered
  - Now handles errors properly
- Removed an unused import from `src/api/checks.rs`