### PR TITLE
Add status code to GithubError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
 use http::uri::InvalidUri;
 
-use http::StatusCode;
 use snafu::{Backtrace, Snafu};
 
 use std::fmt;
@@ -104,7 +103,7 @@ pub struct GitHubError {
     pub documentation_url: Option<String>,
     pub errors: Option<Vec<serde_json::Value>>,
     pub message: String,
-    pub status_code: StatusCode,
+    pub status_code: http::StatusCode,
 }
 
 impl fmt::Display for GitHubError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use http::uri::InvalidUri;
 
+use http::StatusCode;
 use snafu::{Backtrace, Snafu};
 
 use std::fmt;
@@ -97,12 +98,13 @@ pub enum Error {
 }
 
 /// An error returned from GitHub's API.
-#[derive(serde::Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct GitHubError {
     pub documentation_url: Option<String>,
     pub errors: Option<Vec<serde_json::Value>>,
     pub message: String,
+    pub status_code: StatusCode,
 }
 
 impl fmt::Display for GitHubError {

--- a/tests/commit_associated_check_runs_tests.rs
+++ b/tests/commit_associated_check_runs_tests.rs
@@ -95,7 +95,8 @@ async fn should_fail_when_not_found() {
 
     match result.unwrap_err() {
         Error::GitHub { source, .. } => {
-            assert_eq!("Its gone", source.message)
+            assert_eq!(http::StatusCode::NOT_FOUND, source.status_code);
+            assert_eq!("Its gone", source.message);
         }
         other => panic!("Unexpected error: {:?}", other),
     }


### PR DESCRIPTION
Fixes #598

I could leave the `derive(serde::Deserialize)` in for GithubError, but what could it be deserialized from? A payload where someone manually stuck `status_code` into?