### PR TITLE
Unify diff entry models

### DIFF
--- a/src/api/pulls.rs
+++ b/src/api/pulls.rs
@@ -334,7 +334,10 @@ impl<'octo> PullRequestHandler<'octo> {
     /// let files = octocrab::instance().pulls("owner", "repo").list_files(101).await?;
     /// # Ok(())
     /// # }
-    pub async fn list_files(&self, pr: u64) -> crate::Result<Page<crate::models::repos::DiffEntry>> {
+    pub async fn list_files(
+        &self,
+        pr: u64,
+    ) -> crate::Result<Page<crate::models::repos::DiffEntry>> {
         let route = format!(
             "/repos/{owner}/{repo}/pulls/{pr}/files",
             owner = self.owner,

--- a/src/api/pulls.rs
+++ b/src/api/pulls.rs
@@ -328,13 +328,13 @@ impl<'octo> PullRequestHandler<'octo> {
         self.crab.delete(route, Some(&map)).await
     }
 
-    /// List all `FileDiff`s associated with the pull request.
+    /// List all `DiffEntry`s associated with the pull request.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
     /// let files = octocrab::instance().pulls("owner", "repo").list_files(101).await?;
     /// # Ok(())
     /// # }
-    pub async fn list_files(&self, pr: u64) -> crate::Result<Page<crate::models::pulls::FileDiff>> {
+    pub async fn list_files(&self, pr: u64) -> crate::Result<Page<crate::models::repos::DiffEntry>> {
         let route = format!(
             "/repos/{owner}/{repo}/pulls/{pr}/files",
             owner = self.owner,

--- a/src/models/commits.rs
+++ b/src/models/commits.rs
@@ -47,7 +47,7 @@ pub struct CommitComparison {
     pub behind_by: i64,
     pub commits: Vec<Commit>,
     pub diff_url: String,
-    pub files: Option<Vec<CommitFile>>,
+    pub files: Option<Vec<repos::DiffEntry>>,
     pub html_url: String,
     /// Commit
     pub merge_base_commit: Commit,
@@ -91,37 +91,12 @@ pub struct Verification {
     pub verified: bool,
 }
 
-/// Diff Entry
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum FileStatus {
-    Added,
-    Changed,
-    Copied,
-    Modified,
-    Removed,
-    Renamed,
-    Unchanged,
-}
+#[deprecated(note = "use repos::DiffEntryStatus instead")]
+pub type FileStatus = repos::DiffEntryStatus;
 
 /// Commit
-/// Diff Entry
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CommitFile {
-    pub additions: i64,
-    // unlike the schema online, this can be null
-    pub blob_url: Option<String>,
-    pub changes: i64,
-    pub contents_url: String,
-    pub deletions: i64,
-    pub filename: String,
-    pub patch: Option<String>,
-    pub previous_filename: Option<String>,
-    // unlike the schema online, this can be null
-    pub raw_url: Option<String>,
-    pub sha: String,
-    pub status: FileStatus,
-}
+#[deprecated(note = "use repos::DiffEntry instead")]
+pub type CommitFile = repos::DiffEntry;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommitParent {
@@ -144,7 +119,7 @@ pub struct Commit {
     pub comments_url: String,
     pub commit: CommitElement,
     pub committer: Option<Author>,
-    pub files: Option<Vec<CommitFile>>,
+    pub files: Option<Vec<repos::DiffEntry>>,
     pub html_url: String,
     pub node_id: String,
     pub parents: Vec<CommitParent>,

--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -383,34 +383,11 @@ pub enum MergeableState {
     Unstable,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub struct FileDiff {
-    pub sha: String,
-    pub filename: String,
-    pub status: FileDiffStatus,
-    pub additions: u64,
-    pub deletions: u64,
-    pub changes: u64,
-    pub blob_url: Url,
-    pub raw_url: Url,
-    pub contents_url: Url,
-    pub patch: Option<String>,
-    pub previous_filename: Option<String>,
-}
+#[deprecated(note = "use repos::DiffEntry instead")]
+pub type FileDiff = repos::DiffEntry;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum FileDiffStatus {
-    Added,
-    Removed,
-    Modified,
-    Renamed,
-    Copied,
-    Changed,
-    Unchanged,
-}
+#[deprecated(note = "use repos::DiffEntryStatus instead")]
+pub type FileDiffStatus = repos::DiffEntryStatus;
 
 #[cfg(test)]
 mod test {

--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -81,8 +81,11 @@ pub struct DiffEntry {
     pub additions: u64,
     pub deletions: u64,
     pub changes: u64,
-    pub blob_url: Url,
-    pub raw_url: Url,
+    // unlike the schema online, this can be null
+    pub blob_url: Option<String>,
+    // unlike the schema online, this can be null
+    pub raw_url: Option<String>,
+    // never null
     pub contents_url: Url,
 
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Fixes #623

IDK which one would the best “source of truth”.

Maybe `commits` would make most sense? `commits` and `repos` share a lot of structs, I think. But `commits::GitCommitObject` already uses a bunch of things from `repos`