### PR TITLE
Extended issue comment with the author_association

### DIFF
--- a/src/models/issues.rs
+++ b/src/models/issues.rs
@@ -55,6 +55,7 @@ pub struct Comment {
     pub body_text: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body_html: Option<String>,
+    pub author_association: AuthorAssociation,
     pub user: Author,
     pub created_at: chrono::DateTime<chrono::Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Github issue comments support author_association labels. 
I have added them as the field was missing before.