### PR TITLE
fix(builder): Change add_retry_config signature to match other Builder methods 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,8 +498,9 @@ impl<Svc, Config, LayerState> OctocrabBuilder<Svc, Config, NoAuth, LayerState> {
 }
 
 impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady> {
+    /// Set the retry configuration
     #[cfg(feature = "retry")]
-    pub fn add_retry_config(&mut self, retry_config: RetryConfig) -> &mut Self {
+    pub fn add_retry_config(mut self, retry_config: RetryConfig) -> Self {
         self.config.retry_config = retry_config;
         self
     }


### PR DESCRIPTION
Makes `add_retry_config()` adhere to standard set by other methods in the builder. 
This has been tested locally and appears to work exactly as expected given attached usage example.

Usage example: 
![image](https://github.com/XAMPPRocky/octocrab/assets/136495421/5be8d9a1-b24e-402e-9da4-abc65e2db071)

Closes #642 