### PR TITLE
fix: use put instead of get for set_thread_subscription

### DIFF
--- a/src/api/activity/notifications.rs
+++ b/src/api/activity/notifications.rs
@@ -186,7 +186,7 @@ impl<'octo> NotificationsHandler<'octo> {
         let route = format!("/notifications/threads/{thread}/subscription");
         let body = Inner { ignored };
 
-        self.crab.get(route, Some(&body)).await
+        self.crab.put(route, Some(&body)).await
     }
 
     /// Mutes the whole thread conversation until you comment or get mentioned.


### PR DESCRIPTION
The `set_thread_subscription()` API of the Notification API was supposed to use the PUT method according to the [documentation](https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#set-a-thread-subscription). The implementation was using GET, so I changed it to PUT.

```
curl -L \
  -X PUT \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <YOUR-TOKEN>" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/notifications/threads/THREAD_ID/subscription \
  -d '{"ignored":false}'
```

## Additional Context

When I used PUT, the Not Found error no longer appeared.  
However, the deserialization of the response type [`ThreadSubscription`](https://docs.rs/octocrab/latest/octocrab/models/activity/struct.ThreadSubscription.html)  failed.  
The cause was that the `reason` field was an empty string.  (not null)

As a result, I was able to successfully change the thread subscription with the following code:

```rust
    pub(crate) async fn unsubscribe_thread(&self, id: ThreadId) -> octocrab::Result<()> {
        #[derive(serde::Serialize)]
        struct Inner {
            ignored: bool,
        }
        #[derive(serde::Deserialize)]
        struct Response {}

        let thread = id;
        let ignored = true;

        let route = format!("/notifications/threads/{thread}/subscription");
        let body = Inner { ignored };

        self.crab
            .put::<Response, _, _>(route, Some(&body))
            .await?;
        Ok(())
    }
```