### PR TITLE
Properly mark feature-gated functionality in docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ keywords = ["github", "github-api"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,7 @@
 //! };
 //! ```
 #![cfg_attr(test, recursion_limit = "512")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod api;
 mod error;
@@ -338,6 +339,7 @@ pub async fn map_github_error(
 /// # }
 /// ```
 #[cfg(feature = "default-client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "default-client")))]
 pub fn initialise(crab: Octocrab) -> Arc<Octocrab> {
     STATIC_INSTANCE.swap(Arc::from(crab))
 }
@@ -351,6 +353,7 @@ pub fn initialise(crab: Octocrab) -> Arc<Octocrab> {
 /// }
 /// ```
 #[cfg(feature = "default-client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "default-client")))]
 pub fn instance() -> Arc<Octocrab> {
     STATIC_INSTANCE.load().clone()
 }
@@ -500,6 +503,7 @@ impl<Svc, Config, LayerState> OctocrabBuilder<Svc, Config, NoAuth, LayerState> {
 impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady> {
     /// Set the retry configuration
     #[cfg(feature = "retry")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "retry")))]
     pub fn add_retry_config(mut self, retry_config: RetryConfig) -> Self {
         self.config.retry_config = retry_config;
         self
@@ -507,6 +511,7 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
 
     /// Set the connect timeout.
     #[cfg(feature = "timeout")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "timeout")))]
     pub fn set_connect_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.connect_timeout = timeout;
         self
@@ -514,6 +519,7 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
 
     /// Set the read timeout.
     #[cfg(feature = "timeout")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "timeout")))]
     pub fn set_read_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.read_timeout = timeout;
         self
@@ -521,6 +527,7 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
 
     /// Set the write timeout.
     #[cfg(feature = "timeout")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "timeout")))]
     pub fn set_write_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.write_timeout = timeout;
         self
@@ -582,6 +589,7 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
     }
 
     #[cfg(feature = "retry")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "retry")))]
     pub fn set_connector_retry_service<S>(
         &self,
         connector: hyper_util::client::legacy::Client<S, String>,
@@ -592,6 +600,7 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
     }
 
     #[cfg(feature = "timeout")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "timeout")))]
     pub fn set_connect_timeout_service<T>(&self, connector: T) -> TimeoutConnector<T>
     where
         T: Service<Uri> + Send,
@@ -609,6 +618,7 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
 
     /// Build a [`Client`] instance with the current [`Service`] stack.
     #[cfg(feature = "default-client")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "defaut-client")))]
     pub fn build(self) -> Result<Octocrab> {
         let client: hyper_util::client::legacy::Client<_, String> = {
             #[cfg(all(not(feature = "opentls"), not(feature = "rustls")))]
@@ -937,6 +947,7 @@ impl fmt::Debug for Octocrab {
 /// - `auth`: `None`
 /// - `client`: http client with the `octocrab` user agent.
 #[cfg(feature = "default-client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "default-client")))]
 impl Default for Octocrab {
     fn default() -> Self {
         OctocrabBuilder::default().build().unwrap()

--- a/src/service/middleware/mod.rs
+++ b/src/service/middleware/mod.rs
@@ -2,4 +2,5 @@ pub mod auth_header;
 pub mod base_uri;
 pub mod extra_headers;
 #[cfg(feature = "retry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "retry")))]
 pub mod retry;


### PR DESCRIPTION
This PR follows [these instructions](https://users.rust-lang.org/t/how-to-document-optional-features-in-api-docs/64577/3) to ensure that feature-gated functionality in `octocrab` is correctly marked as such in the rendered documentation.  This includes adding some missing `#[cfg_attr(docsrs, doc(cfg(feature = "...")))]` lines and also ensuring that all features are enabled when building the docs (as, currently, `Page::into_stream()` isn't listed on docs.rs at all!).