### PR TITLE
Add support to get release by id

### DIFF
--- a/src/api/repos/releases.rs
+++ b/src/api/repos/releases.rs
@@ -128,6 +128,28 @@ impl<'octo, 'r> ReleasesHandler<'octo, 'r> {
         self.parent.crab.get(route, None::<&()>).await
     }
 
+    /// Gets a release using its id.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let release = octocrab::instance()
+    ///     .repos("owner", "repo")
+    ///     .releases()
+    ///     .get_by_id(160301961)
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_by_id(&self, release_id: u64) -> crate::Result<models::repos::Release> {
+        let route = format!(
+            "/repos/{owner}/{repo}/releases/{release_id}",
+            owner = self.parent.owner,
+            repo = self.parent.repo,
+            release_id = release_id,
+        );
+
+        self.parent.crab.get(route, None::<&()>).await
+    }
+
     /// Gets the release using its tag.
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {

--- a/src/api/repos/releases.rs
+++ b/src/api/repos/releases.rs
@@ -134,12 +134,12 @@ impl<'octo, 'r> ReleasesHandler<'octo, 'r> {
     /// let release = octocrab::instance()
     ///     .repos("owner", "repo")
     ///     .releases()
-    ///     .get_by_id(160301961)
+    ///     .get(160301961)
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_by_id(&self, release_id: u64) -> crate::Result<models::repos::Release> {
+    pub async fn get(&self, release_id: u64) -> crate::Result<models::repos::Release> {
         let route = format!(
             "/repos/{owner}/{repo}/releases/{release_id}",
             owner = self.parent.owner,


### PR DESCRIPTION
Add support to get a release by its id: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release

Tested by getting the `1.79.0` release from the rust repo: 
```rust
let release = octocrab.repos("rust-lang", "rust")
  .releases()
  .get_by_id(160301961)
  .await?;
```

Closes #663 