### PR TITLE
feat: allow sending non String payload with execute

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -1,0 +1,116 @@
+use http_body_util::BodyExt;
+
+use bytes::Bytes;
+use http_body::Frame;
+use snafu::{Backtrace, GenerateImplicitData};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+type BoxBody = http_body_util::combinators::BoxBody<Bytes, crate::Error>;
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+fn boxed<B>(body: B) -> BoxBody
+where
+    B: http_body::Body<Data = Bytes> + Send + Sync + 'static,
+    B::Error: Into<BoxError>,
+{
+    try_downcast(body).unwrap_or_else(|body| {
+        body.map_err(|e| crate::Error::Other {
+            source: e.into(),
+            backtrace: Backtrace::generate(),
+        })
+        .boxed()
+    })
+}
+
+fn try_downcast<T, K>(k: K) -> Result<T, K>
+where
+    T: 'static,
+    K: Send + 'static,
+{
+    let mut k = Some(k);
+    if let Some(k) = <dyn std::any::Any>::downcast_mut::<Option<T>>(&mut k) {
+        Ok(k.take().unwrap())
+    } else {
+        Err(k.unwrap())
+    }
+}
+
+// Define octocrab Body
+#[derive(Debug)]
+pub struct OctoBody(BoxBody);
+
+impl OctoBody {
+    /// Create a new `Body` that wraps another [`http_body::Body`].
+    pub fn new<B>(body: B) -> Self
+    where
+        B: http_body::Body<Data = Bytes> + Send + Sync + 'static,
+        B::Error: Into<BoxError>,
+    {
+        try_downcast(body).unwrap_or_else(|body| Self(boxed(body)))
+    }
+    /// Create an empty body.
+    pub fn empty() -> Self {
+        Self::new(http_body_util::Empty::new())
+    }
+}
+
+impl Default for OctoBody {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+// Implement standard Bodiesque casting
+impl From<()> for OctoBody {
+    fn from(_: ()) -> Self {
+        Self::empty()
+    }
+}
+
+impl From<String> for OctoBody {
+    fn from(buf: String) -> Self {
+        Self::new(http_body_util::Full::from(buf))
+    }
+}
+
+impl From<Vec<u8>> for OctoBody {
+    fn from(buf: Vec<u8>) -> Self {
+        Self::new(http_body_util::Full::from(buf))
+    }
+}
+
+impl From<Bytes> for OctoBody {
+    fn from(buf: Bytes) -> Self {
+        Self::new(http_body_util::Full::from(buf))
+    }
+}
+
+impl From<&'static str> for OctoBody {
+    fn from(buf: &'static str) -> Self {
+        Self::new(http_body_util::Full::from(buf))
+    }
+}
+
+impl http_body::Body for OctoBody {
+    type Data = Bytes;
+    type Error = crate::Error;
+
+    #[inline]
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        Pin::new(&mut self.0).poll_frame(cx)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.0.size_hint()
+    }
+
+    #[inline]
+    fn is_end_stream(&self) -> bool {
+        self.0.is_end_stream()
+    }
+}

--- a/src/body.rs
+++ b/src/body.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use http_body::Frame;
 use snafu::{Backtrace, GenerateImplicitData};
 use std::pin::Pin;
+use std::sync::{Arc, RwLock};
 use std::task::{Context, Poll};
 
 type BoxBody = http_body_util::combinators::BoxBody<Bytes, crate::Error>;
@@ -38,7 +39,7 @@ where
 
 // Define octocrab Body
 #[derive(Debug)]
-pub struct OctoBody(BoxBody);
+pub struct OctoBody(Arc<RwLock<BoxBody>>);
 
 impl OctoBody {
     /// Create a new `Body` that wraps another [`http_body::Body`].
@@ -47,7 +48,7 @@ impl OctoBody {
         B: http_body::Body<Data = Bytes> + Send + Sync + 'static,
         B::Error: Into<BoxError>,
     {
-        try_downcast(body).unwrap_or_else(|body| Self(boxed(body)))
+        try_downcast(body).unwrap_or_else(|body| Self(Arc::new(RwLock::new(boxed(body)))))
     }
     /// Create an empty body.
     pub fn empty() -> Self {
@@ -98,19 +99,29 @@ impl http_body::Body for OctoBody {
 
     #[inline]
     fn poll_frame(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        Pin::new(&mut self.0).poll_frame(cx)
+        let inner = Pin::into_inner(self);
+        let mut boxed_body = inner.0.write().expect("RwLock write lock failed");
+        Pin::new(&mut *boxed_body).poll_frame(cx)
     }
 
     #[inline]
     fn size_hint(&self) -> http_body::SizeHint {
-        self.0.size_hint()
+        let b = self.0.read().expect("RwLock read lock failed");
+        b.size_hint()
     }
 
     #[inline]
     fn is_end_stream(&self) -> bool {
-        self.0.is_end_stream()
+        let b = self.0.read().expect("RwLock read lock failed");
+        b.is_end_stream()
+    }
+}
+
+impl Clone for OctoBody {
+    fn clone(&self) -> Self {
+        OctoBody(Arc::clone(&self.0))
     }
 }

--- a/src/service/middleware/retry.rs
+++ b/src/service/middleware/retry.rs
@@ -1,7 +1,8 @@
-use futures_util::future;
 use http::{Request, Response};
 use hyper_util::client::legacy::Error;
 use tower::retry::Policy;
+
+use crate::body::OctoBody;
 
 #[derive(Clone)]
 pub enum RetryConfig {
@@ -9,59 +10,24 @@ pub enum RetryConfig {
     Simple(usize),
 }
 
-impl<B> Policy<Request<String>, Response<B>, Error> for RetryConfig {
+impl<B> Policy<Request<OctoBody>, Response<B>, Error> for RetryConfig {
     type Future = futures_util::future::Ready<Self>;
 
     fn retry(
         &self,
-        _req: &Request<String>,
-        result: Result<&Response<B>, &Error>,
+        _req: &Request<OctoBody>,
+        _result: Result<&Response<B>, &Error>,
     ) -> Option<Self::Future> {
         match self {
             RetryConfig::None => None,
-            RetryConfig::Simple(count) => match result {
-                Ok(response) => {
-                    if response.status().is_server_error() || response.status() == 429 {
-                        if *count > 0 {
-                            Some(future::ready(RetryConfig::Simple(count - 1)))
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                }
-                Err(_) => {
-                    if *count > 0 {
-                        Some(future::ready(RetryConfig::Simple(count - 1)))
-                    } else {
-                        None
-                    }
-                }
-            },
+            RetryConfig::Simple(_count) => None,
         }
     }
 
-    fn clone_request(&self, req: &Request<String>) -> Option<Request<String>> {
+    fn clone_request(&self, _req: &Request<OctoBody>) -> Option<Request<OctoBody>> {
         match self {
             RetryConfig::None => None,
-            _ => {
-                // `Request` can't be cloned
-                let mut new_req = Request::builder()
-                    .uri(req.uri())
-                    .method(req.method())
-                    .version(req.version());
-                for (name, value) in req.headers() {
-                    new_req = new_req.header(name, value);
-                }
-
-                let body = req.body().clone();
-                let new_req = new_req.body(body).expect(
-                    "This should never panic, as we are cloning a components from existing request",
-                );
-
-                Some(new_req)
-            }
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
resolves #360

The approach I took is similar to the one outline here: https://github.com/XAMPPRocky/octocrab/issues/360#issuecomment-1547219725

## Breaking changes
### Drop of internal retry policy handler
Having to clone the request is a real challenge, as stated here: https://github.com/XAMPPRocky/octocrab/issues/360#issuecomment-1548524619 and https://github.com/hyperium/tonic/issues/733. I am in the opinion that such behaviour should not be inside of this library but in the client code, where they can use tools like [tryhard](https://docs.rs/tryhard/latest/tryhard/index.html) to achieve reliable retry mechanism.
- the `execute` API has changed, so anyone using it outside of the crate might have to impact their code