### PR TITLE
Add `DeviceCodes::poll_until_available` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = "1.0.64"
 serde_path_to_error = "0.1.4"
 serde_urlencoded = "0.7.1"
 snafu = "0.8"
-tokio = { version = "1.17.0", default-features = false, optional = true }
+tokio = { version = "1.17.0", default-features = false, features = ["time"], optional = true }
 tower = { version = "0.4.13", default-features = false, features = ["util", "buffer"] }
 tower-http = { version = "0.5.1", features = ["map-response-body", "trace"] }
 tracing = { version = "0.1.37", features = ["log"], optional = true }

--- a/examples/device_flow.rs
+++ b/examples/device_flow.rs
@@ -1,6 +1,4 @@
-use either::Either;
 use http::header::ACCEPT;
-use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> octocrab::Result<()> {
@@ -17,28 +15,7 @@ async fn main() -> octocrab::Result<()> {
         "Go to {} and enter code {}",
         codes.verification_uri, codes.user_code
     );
-    let mut interval = Duration::from_secs(codes.interval);
-    let mut clock = tokio::time::interval(interval);
-    let auth = loop {
-        clock.tick().await;
-        match codes.poll_once(&crab, &client_id).await? {
-            Either::Left(auth) => break auth,
-            Either::Right(cont) => match cont {
-                octocrab::auth::Continue::SlowDown => {
-                    // We were request to slow down. We add five seconds to the polling
-                    // duration.
-                    interval += Duration::from_secs(5);
-                    clock = tokio::time::interval(interval);
-                    // The first tick happens instantly, so we tick that off immediately.
-                    clock.tick().await;
-                }
-                octocrab::auth::Continue::AuthorizationPending => {
-                    // The user has not clicked authorize yet, but nothing has gone wrong.
-                    // We keep polling.
-                }
-            },
-        }
-    };
+    let auth = codes.poll_until_available(&crab, &client_id).await?;
 
     println!("Authorization succeeded with access to {:?}", auth.scope);
     Ok(())


### PR DESCRIPTION
The polling behavior is specified by the GitHub API (such as waiting minimum 5 seconds between polls and what to do if you get a `slow_down` error). Therefore, it would be best for users not to implement this logic themselves as they may get it wrong. In principle it might even be a good idea to remove the `poll_once` method and just have `poll_until_available`.

I'm not sure if `await`-ing this function will actually block, but I'm assuming tokio will properly schedule other things while we're waiting to poll.