### PR TITLE
Only add base_path if req_pandq does not contain it

### DIFF
--- a/src/service/middleware/base_uri.rs
+++ b/src/service/middleware/base_uri.rs
@@ -89,7 +89,11 @@ fn overwrite_base_uri(base_uri: &http::Uri, current_uri: Uri) -> http::Uri {
             // Remove any trailing slashes and join.
             // `PathAndQuery` always starts with a slash.
             let base_path = pandq.path().trim_end_matches('/');
-            builder.path_and_query(format!("{base_path}{req_pandq}"))
+            if !req_pandq.as_str().starts_with(base_path) {
+                builder.path_and_query(format!("{base_path}{req_pandq}"))
+            } else {
+                builder.path_and_query(req_pandq.as_str())
+            }
         } else {
             builder.path_and_query(pandq.as_str())
         };


### PR DESCRIPTION
* avoids adding it twice
* fixes issue with pagination not working due to base path added twice

Fixes https://github.com/XAMPPRocky/octocrab/issues/507