### PR TITLE
fix(installation)!: Return Result instead of panicking

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,7 @@ impl std::error::Error for UriParseError {}
 /// An error that could have occurred while using [`crate::Octocrab`].
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum Error {
     GitHub {
         source: GitHubError,
@@ -35,7 +36,10 @@ pub enum Error {
         source: InvalidUri,
         backtrace: Backtrace,
     },
-
+    Installation {
+        source: InstallationError,
+        backtrace: Backtrace,
+    },
     InvalidHeaderValue {
         source: http::header::InvalidHeaderValue,
         backtrace: Backtrace,
@@ -126,3 +130,25 @@ impl fmt::Display for GitHubError {
 }
 
 impl std::error::Error for GitHubError {}
+
+/// An error that could have occurred while trying to target an installation.
+#[derive(Debug, Clone)]
+pub struct InstallationError {
+    pub message: String,
+}
+
+impl InstallationError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for InstallationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for InstallationError {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,10 +36,8 @@ pub enum Error {
         source: InvalidUri,
         backtrace: Backtrace,
     },
-    Installation {
-        source: InstallationError,
-        backtrace: Backtrace,
-    },
+    #[snafu(display("Installation Error: Github App authorization is required to target an installation.\n\nFound at {}", backtrace))]
+    Installation { backtrace: Backtrace },
     InvalidHeaderValue {
         source: http::header::InvalidHeaderValue,
         backtrace: Backtrace,
@@ -130,25 +128,3 @@ impl fmt::Display for GitHubError {
 }
 
 impl std::error::Error for GitHubError {}
-
-/// An error that could have occurred while trying to target an installation.
-#[derive(Debug, Clone)]
-pub struct InstallationError {
-    pub message: String,
-}
-
-impl InstallationError {
-    pub fn new(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-        }
-    }
-}
-
-impl fmt::Display for InstallationError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl std::error::Error for InstallationError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ use crate::service::middleware::retry::RetryConfig;
 
 use crate::api::{code_scannings, users};
 use auth::{AppAuth, Auth};
-use models::{AppId, Installation, InstallationId, InstallationToken};
+use models::{AppId, InstallationId, InstallationToken};
 
 pub use self::{
     api::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1014,9 +1014,6 @@ impl Octocrab {
         } else {
             return Err(Error::Installation {
                 backtrace: Backtrace::generate(),
-                source: error::InstallationError::new(
-                    "Github App authorization is required to target an installation",
-                ),
             });
         };
         Ok(Octocrab {
@@ -1487,7 +1484,6 @@ impl Octocrab {
         } else {
             return Err(Error::Installation {
                 backtrace: Backtrace::generate(),
-                source: error::InstallationError::new("Installation not configured"),
             });
         };
         let mut request = Builder::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1012,7 +1012,7 @@ impl Octocrab {
         let app_auth = if let AuthState::App(ref app_auth) = self.auth_state {
             app_auth.clone()
         } else {
-            let source = return Err(Error::Installation {
+            return Err(Error::Installation {
                 backtrace: Backtrace::generate(),
                 source: error::InstallationError::new(
                     "Github App authorization is required to target an installation",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ use crate::service::middleware::retry::RetryConfig;
 
 use crate::api::{code_scannings, users};
 use auth::{AppAuth, Auth};
-use models::{AppId, InstallationId, InstallationToken};
+use models::{AppId, Installation, InstallationId, InstallationToken};
 
 pub use self::{
     api::{
@@ -1012,13 +1012,11 @@ impl Octocrab {
         let app_auth = if let AuthState::App(ref app_auth) = self.auth_state {
             app_auth.clone()
         } else {
-            let source = std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Github App authorization is required to target an installation",
-            );
-            return Err(Error::Other {
-                backtrace: Backtrace::generate_with_source(&source),
-                source: Box::new(source),
+            let source = return Err(Error::Installation {
+                backtrace: Backtrace::generate(),
+                source: error::InstallationError::new(
+                    "Github App authorization is required to target an installation",
+                ),
             });
         };
         Ok(Octocrab {
@@ -1487,11 +1485,9 @@ impl Octocrab {
         {
             (app, installation, token)
         } else {
-            let source =
-                std::io::Error::new(std::io::ErrorKind::Other, "Installation not configured");
-            return Err(Error::Other {
-                backtrace: Backtrace::generate_with_source(&source),
-                source: Box::new(source),
+            return Err(Error::Installation {
+                backtrace: Backtrace::generate(),
+                source: error::InstallationError::new("Installation not configured"),
             });
         };
         let mut request = Builder::new();


### PR DESCRIPTION
As #641 describes, returning a Result when calling `Octocrab::installation` is nicer than panicking outright. 

I'm definitely not happy with how I build and return the Errors - is there a better way to build Errors directly?

This PR changes the public API behavior, since `Octocrab::installation` is exposed to the user.

(closes: #641)