### PR TITLE
add additional webhook model fields

### DIFF
--- a/src/models/webhook_events/payload/issues.rs
+++ b/src/models/webhook_events/payload/issues.rs
@@ -43,4 +43,5 @@ pub enum IssuesWebhookEventAction {
 pub struct IssuesWebhookEventChanges {
     pub body: Option<OldValue<String>>,
     pub title: Option<OldValue<String>>,
+    pub assignee: Option<OldValue<Author>>,
 }

--- a/src/models/webhook_events/payload/repository.rs
+++ b/src/models/webhook_events/payload/repository.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::models::Author;
+
 use super::OldValue;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -32,4 +34,18 @@ pub struct RepositoryWebhookEventChanges {
     pub description: Option<OldValue<Option<String>>>,
     pub homepage: Option<OldValue<Option<String>>>,
     pub topics: Option<OldValue<Option<Vec<String>>>>,
+    pub owner: Option<OldValue<RepositoryWebhookEventChangesOwner>>,
+    pub repository: Option<RepositoryWebhookEventChangesRepository>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RepositoryWebhookEventChangesOwner {
+    pub user: Author,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RepositoryWebhookEventChangesRepository {
+    pub name: Option<OldValue<String>>,
 }


### PR DESCRIPTION
i'm building a webhook handler and switched to octocrab's models today instead of my own hand-rolled models. there were a couple of fields i needed that weren't supported, so i've added them in and confirmed they seem to work as intended.

the naming of the repo change structs i added (owner/repo name) are a little confusing but the nesting is so deep i wasn't sure which way to go with it. let me know if you'd prefer something else!

if it helps at all, i have some example deliveries with these fields on them:

- repository.renamed: https://github.com/catppuccin/rockdove/blob/main/fixtures/repository_renamed.json#L3-L9
- repository.transferred: https://github.com/catppuccin/rockdove/blob/main/fixtures/repository_transferred.json#L3-L28