### PR TITLE
fix(refs)!: remove `Reference::Commit` variant

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -481,7 +481,6 @@ pub mod repos {
     pub enum Reference {
         Branch(String),
         Tag(String),
-        Commit(String),
     }
 
     impl Reference {
@@ -489,15 +488,11 @@ pub mod repos {
             match self {
                 Self::Branch(branch) => format!("heads/{branch}"),
                 Self::Tag(tag) => format!("tags/{tag}"),
-                Self::Commit(sha) => sha.clone(),
             }
         }
 
         pub fn full_ref_url(&self) -> String {
-            match self {
-                Self::Branch(_) | Self::Tag(_) => format!("refs/{}", self.ref_url()),
-                Self::Commit(sha) => sha.clone(),
-            }
+            format!("refs/{}", self.ref_url())
         }
     }
 


### PR DESCRIPTION
Closes: #608

Commits aren't valid refs and using the `Reference::Commit` variant will always return a 404, so this PR removes the variant altogether. 

This PR technically introduces a breaking change, but given that the feature doesn't work anyway, removing it should be safe.