### PR TITLE
Implement some style improvements

### DIFF
--- a/src/api/commits/associated_pull_requests.rs
+++ b/src/api/commits/associated_pull_requests.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use super::*;
 
 /// helper to let users know they can pass a branch name or a commit sha
@@ -8,11 +10,11 @@ pub enum PullRequestTarget {
     Sha(String),
 }
 
-impl ToString for PullRequestTarget {
-    fn to_string(&self) -> String {
+impl Display for PullRequestTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Branch(branch) => branch.to_string(),
-            Self::Sha(commit) => commit.to_string(),
+            Self::Branch(branch) => write!(f, "{}", branch),
+            Self::Sha(commit) => write!(f, "{}", commit),
         }
     }
 }
@@ -59,7 +61,7 @@ impl<'octo, 'r> AssociatedPullRequestsBuilder<'octo, 'r> {
             "/repos/{owner}/{repo}/commits/{target}/pulls",
             owner = self.handler.owner,
             repo = self.handler.repo,
-            target = self.target.to_string(),
+            target = self.target,
         );
 
         self.handler.crab.get(route, Some(&self)).await

--- a/src/api/gists.rs
+++ b/src/api/gists.rs
@@ -39,11 +39,11 @@ impl<'octo> GistsHandler<'octo> {
     ///
     /// # Note
     /// * Calling with an authentication token will list all the gists of the
-    /// authenticated user
+    ///   authenticated user
     ///
     /// * If no authentication token will list all the public gists from
-    /// GitHub's API. This can potentially produce a lot of results, so care is
-    /// advised.
+    ///   GitHub's API. This can potentially produce a lot of results, so care is
+    ///   advised.
     ///
     /// # Example
     ///

--- a/src/params.rs
+++ b/src/params.rs
@@ -386,6 +386,7 @@ pub mod pulls {
     }
 
     /// Custom media types are used in the API to let consumers choose the
+    ///
     /// format of the data they wish to receive. This is done by adding one or
     /// more of the following types to the Accept header when you make a
     /// request. Media types are specific to resources, allowing them to change
@@ -508,6 +509,7 @@ pub mod repos {
     }
 
     /// A Git reference of unknown type.
+    ///
     /// In some cases clients may have a string identifying a commit, but not
     /// know whether it's a branch or a tag or commit hash.
     /// Many Github APIs accept such strings. These APIs also accept `heads/` or `tags/`.

--- a/tests/pull_request_review_operations_test.rs
+++ b/tests/pull_request_review_operations_test.rs
@@ -93,50 +93,38 @@ async fn should_work_with_specific_review() {
 
     let result = client
         .pulls(OWNER, REPO)
-        .pull_number(PULL_NUMBER)
-        .reviews()
-        .review(REVIEW_ID)
+        .pr_review_actions(PULL_NUMBER, REVIEW_ID)
         .get()
         .await;
     assert_eq!(result.unwrap(), review_ops_response);
     let result = client
         .pulls(OWNER, REPO)
-        .pull_number(PULL_NUMBER)
-        .reviews()
-        .review(REVIEW_ID)
+        .pr_review_actions(PULL_NUMBER, REVIEW_ID)
         .update("test")
         .await;
     assert_eq!(result.unwrap(), review_ops_response);
     let result = client
         .pulls(OWNER, REPO)
-        .pull_number(PULL_NUMBER)
-        .reviews()
-        .review(REVIEW_ID)
+        .pr_review_actions(PULL_NUMBER, REVIEW_ID)
         .delete_pending()
         .await;
     assert_eq!(result.unwrap(), review_ops_response);
     let result = client
         .pulls(OWNER, REPO)
-        .pull_number(PULL_NUMBER)
-        .reviews()
-        .review(REVIEW_ID)
+        .pr_review_actions(PULL_NUMBER, REVIEW_ID)
         .submit(ReviewAction::Comment, "test")
         .await;
     assert_eq!(result.unwrap(), review_ops_response);
     let result = client
         .pulls(OWNER, REPO)
-        .pull_number(PULL_NUMBER)
-        .reviews()
-        .review(REVIEW_ID)
+        .pr_review_actions(PULL_NUMBER, REVIEW_ID)
         .dismiss("test")
         .await;
     assert_eq!(result.unwrap(), review_ops_response);
 
     let result = client
         .pulls(OWNER, REPO)
-        .pull_number(PULL_NUMBER)
-        .reviews()
-        .review(REVIEW_ID)
+        .pr_review_actions(PULL_NUMBER, REVIEW_ID)
         .list_comments()
         .per_page(15)
         .send()
@@ -146,9 +134,7 @@ async fn should_work_with_specific_review() {
 
     let result = client
         .pulls(OWNER, REPO)
-        .pull_number(PULL_NUMBER)
-        .comment(COMMENT_ID.into())
-        .reply("test")
+        .reply_to_comment(PULL_NUMBER, COMMENT_ID.into(), "test")
         .await;
     assert_eq!(result.unwrap(), pr_comment_response);
 }

--- a/tests/user_blocks_tests.rs
+++ b/tests/user_blocks_tests.rs
@@ -115,5 +115,5 @@ async fn should_respond_user_unblocked() {
     .await;
     let client = setup_octocrab(&mock_server.uri());
     let result = client.users("some-user").unblock_user(NOT_BLOCKED).await;
-    assert!(!result.is_ok());
+    assert!(result.is_err());
 }


### PR DESCRIPTION
- Remove deprecated function calls in pr review tests, use the new functions
- Break-up large first paragraphs in doc comments
- Indent new lines on list elements in doc comments
- Call `assert!(result.is_err())` instead of `assert!(!result.is_ok())` in user blocks tests
- Implement `Display` trait instead of directly implementing `ToString` for `PullRequestTarget`