### PR TITLE
Make Fields in `models::timelines` Structs Public

### DIFF
--- a/src/models/timelines.rs
+++ b/src/models/timelines.rs
@@ -88,24 +88,24 @@ pub struct TimelineEvent {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct DismissedReview {
-    state: pulls::ReviewState,
-    review_id: ReviewId,
-    dismissal_message: Option<String>,
-    dismissal_commit_id: Option<String>,
+    pub state: pulls::ReviewState,
+    pub review_id: ReviewId,
+    pub dismissal_message: Option<String>,
+    pub dismissal_commit_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct Source {
-    issue: issues::Issue,
-    r#type: String,
+    pub issue: issues::Issue,
+    pub r#type: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct Rename {
-    from: String,
-    to: String,
+    pub from: String,
+    pub to: String,
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
#705
Changed the visibility of certain struct fields in `models::timelines` from private to public.

- Private fields in these structs make it difficult to access issue and pull request information from timeline events.
- Making these fields public allows developers to directly access the required data without encountering access errors.