### PR TITLE
fix: rustls hard-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ pretty_assertions = "1.4.0"
 graphql_client = "0.14.0"
 
 [features]
-default = ["follow-redirect", "retry", "rustls", "timeout", "tracing", "default-client", "rustls-aws-lc-rs"]
+default = ["follow-redirect", "retry", "rustls", "timeout", "tracing", "default-client", "rustls-ring"]
 
 follow-redirect = ["tower-http/follow-redirect"]
 retry = ["tower/retry", "futures-util"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,12 @@ http = "1.0.0"
 http-body = "1.0.0"
 http-body-util = "0.1.0"
 hyper = "1.1.0"
-hyper-rustls = { version = "0.27.0", optional = true }
+hyper-rustls = { version = "0.27.0", optional = true, default-features = false, features = [
+    "http1",
+	"logging",
+	"native-tokio",
+	"tls12",
+]}
 hyper-timeout = { version = "0.5.1", optional = true }
 hyper-tls = { version = "0.6.0", optional = true }
 hyper-util = { version = "0.1.3", features = ["http1"] }
@@ -71,11 +76,13 @@ pretty_assertions = "1.4.0"
 graphql_client = "0.14.0"
 
 [features]
-default = ["follow-redirect", "retry", "rustls", "timeout", "tracing", "default-client"]
+default = ["follow-redirect", "retry", "rustls", "timeout", "tracing", "default-client", "rustls-aws-lc-rs"]
 
 follow-redirect = ["tower-http/follow-redirect"]
 retry = ["tower/retry", "futures-util"]
 rustls = ["hyper-rustls"]
+rustls-ring = ["hyper-rustls/ring"]
+rustls-aws-lc-rs = ["hyper-rustls/aws-lc-rs"]
 rustls-webpki-tokio = ["hyper-rustls/webpki-tokio"]
 opentls = ["hyper-tls"]
 stream = ["futures-core", "futures-util"]


### PR DESCRIPTION
Remove hard-dependency on `aws-lc-sys` by adding two new features: `rustls-ring` and `rustls-aws-lc-rs`.

By default, `rustls-aws-lc-rs` is enabled (which is also a default feature for `hyper-rustls`), but the dependency on aws-lc-rs can be overriden by consumers of the library.

This should fix compilation on ARM, but we should maybe add a section about this in the README to let consumers know how to fix compilation issues for ARM.

Let me know if I should add a section to the README, or if there's better place to let user's know about this fix. 

Closes: #706