### PR TITLE
fix: don't capture backtraces by default

### DIFF
--- a/src/api/orgs/secrets.rs
+++ b/src/api/orgs/secrets.rs
@@ -129,7 +129,7 @@ impl<'octo> OrgSecretsHandler<'octo> {
                     status_code.as_str()
                 )
                 .into(),
-                backtrace: snafu::Backtrace::generate(),
+                backtrace: snafu::Backtrace::capture(),
             }),
         }
     }

--- a/src/api/repos/secrets.rs
+++ b/src/api/repos/secrets.rs
@@ -126,7 +126,7 @@ impl<'octo> RepoSecretsHandler<'octo> {
                     status_code.as_str()
                 )
                 .into(),
-                backtrace: snafu::Backtrace::generate(),
+                backtrace: snafu::Backtrace::capture(),
             }),
         }
     }

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -116,7 +116,7 @@ impl<'octo> UserHandler<'octo> {
                     errors: None,
                     message: "".to_string(),
                 },
-                backtrace: Backtrace::generate(),
+                backtrace: Backtrace::capture(),
             }),
             Err(_v) => Ok(()),
         }

--- a/src/body.rs
+++ b/src/body.rs
@@ -18,7 +18,7 @@ where
     try_downcast(body).unwrap_or_else(|body| {
         body.map_err(|e| crate::Error::Other {
             source: e.into(),
-            backtrace: Backtrace::generate(),
+            backtrace: Backtrace::capture(),
         })
         .boxed()
     })

--- a/src/etag.rs
+++ b/src/etag.rs
@@ -82,7 +82,7 @@ impl EntityTag {
                 .parse()
                 .map_err(|err: InvalidHeaderValue| crate::Error::InvalidHeaderValue {
                     source: err,
-                    backtrace: snafu::Backtrace::generate(),
+                    backtrace: snafu::Backtrace::capture(),
                 })?,
         );
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,7 +329,7 @@ pub async fn map_github_error(
                 errors,
                 message,
             },
-            backtrace: Backtrace::generate(),
+            backtrace: Backtrace::capture(),
         })
     }
 }
@@ -1015,7 +1015,7 @@ impl Octocrab {
             app_auth.clone()
         } else {
             return Err(Error::Installation {
-                backtrace: Backtrace::generate(),
+                backtrace: Backtrace::capture(),
             });
         };
         Ok(Octocrab {
@@ -1502,7 +1502,7 @@ impl Octocrab {
             (app, installation, token)
         } else {
             return Err(Error::Installation {
-                backtrace: Backtrace::generate(),
+                backtrace: Backtrace::capture(),
             });
         };
         let mut request = Builder::new();
@@ -1534,7 +1534,7 @@ impl Octocrab {
             .map(|time| {
                 DateTime::<Utc>::from_str(&time).map_err(|e| error::Error::Other {
                     source: Box::new(e),
-                    backtrace: snafu::Backtrace::generate(),
+                    backtrace: snafu::Backtrace::capture(),
                 })
             })
             .transpose()?;

--- a/src/page.rs
+++ b/src/page.rs
@@ -242,7 +242,7 @@ fn get_links(headers: &http::header::HeaderMap) -> crate::Result<HeaderLinks> {
     if let Some(link) = headers.get("Link") {
         let links = link.to_str().map_err(|err| crate::Error::Other {
             source: Box::new(err),
-            backtrace: snafu::Backtrace::generate(),
+            backtrace: snafu::Backtrace::capture(),
         })?;
 
         for url_with_params in links.split(',') {


### PR DESCRIPTION
Call `Backtrace::capture()` instead of the `Backtrace::generate()` method provided by snafu. This disables backtrace capturing unless either the `RUST_BACKTRACE` or `RUST_LIB_BACKTRACE` environment variables are set at runtime.

This completely disables backtrace capturing, not just displaying the backtrace though, so if the backtrace is too important to disable it completely by default, I could also refactor this PR to change the display behavior - maybe through a feature flag letting consumers decide if they want to work with backtraces or not.

Closes: #649