### PR TITLE
Custom executor for Wasm Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,9 @@ bytes = "1.0.1"
 chrono = { version = "0.4.19", default-features = false, features = [
     "serde",
     "clock",
+    "wasmbind"
 ] }
+web-time = { version = "1.1.0", features = ["serde"] }
 cfg-if = "1.0.0"
 either = "1.8.0"
 futures = { version = "0.3.15" }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -7,7 +7,7 @@ use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::time::{Duration, SystemTime};
+use web_time::{Duration, SystemTime};
 
 use snafu::*;
 


### PR DESCRIPTION
This PR enables Octocrab to use a custom executor by using `Buffer::pair` instead of `Buffer::new` which relies on the Tokio runtime. It also change `std::time` to `webtime` crate which is a drop-in replacement for time that compiles on wasm.

This was tested on a wasm environment (specifically Cloudflare Workers)