### PR TITLE
Add "merged" field to PullRequest model

### DIFF
--- a/src/models/pulls.rs
+++ b/src/models/pulls.rs
@@ -62,6 +62,8 @@ pub struct PullRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mergeable_state: Option<MergeableState>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub merged: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub merged_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub merged_by: Option<Box<Author>>,


### PR DESCRIPTION
This PR adds the `merged` field to the PullRequest model struct.

Documentation: https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request

Here's a screenshot of the specific field:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/c3c6ac0c-0d74-4c6d-9d7a-f53d6bf6cf9f">
