### PR TITLE
Enable client reuse when authenticating with app user access tokens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -983,6 +983,11 @@ pub enum AuthState {
         /// The cached access token, if any
         token: CachedToken,
     },
+    /// Access token based authentication.
+    AccessToken {
+        /// The access token
+        token: SecretString,
+    },
 }
 
 pub type OctocrabService = Buffer<
@@ -1105,6 +1110,19 @@ impl Octocrab {
         let crab = self.installation(id)?;
         let token = crab.request_installation_auth_token().await?;
         Ok((crab, token))
+    }
+
+    /// Returns a new `Octocrab` based on the current builder but
+    /// authorizing via an access token.
+    ///
+    /// See also https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app
+    pub fn user_access_token<S: Into<SecretString>>(&self, token: S) -> Result<Self> {
+        Ok(Octocrab {
+            client: self.client.clone(),
+            auth_state: AuthState::AccessToken {
+                token: token.into(),
+            },
+        })
     }
 }
 
@@ -1681,6 +1699,11 @@ impl Octocrab {
                         .context(HttpSnafu)?,
                 )
             }
+            AuthState::AccessToken { ref token } => Some(
+                HeaderValue::from_str(format!("Bearer {}", token.expose_secret()).as_str())
+                    .map_err(http::Error::from)
+                    .context(HttpSnafu)?,
+            ),
         };
 
         if let Some(mut auth_header) = auth_header {


### PR DESCRIPTION
This PR allows octocrab instances to be reused with different Github app user access tokens, similar the `installation` function enabling an instance to be reused with different installations of an app.

The motivation is to avoid creating a new connection every time a request needs made for a different user, user access token. I didn't see any good way to reuse or provide the connection created in `build` ([code](https://github.com/XAMPPRocky/octocrab/blob/fae5b089161f6e97a7cd1eb7b4c7c6aa2589ee61/src/lib.rs#L674))

Here's how it looks:

```rust
let octocrab = OctocrabBuilder::new().build()?;

// Later, use the client with many, varying access tokens.
let octocrab = octocrab.user_access_token(token)?
```

An alternative is to expose an `Octocrab::toBuilder` method to effectively clone the existing client with varying configuration. This looks hard given how configuration ends up embedded in service layers.

User access token documentation: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app

