### PR TITLE
issues can now be closed as `duplicate`

### DIFF
--- a/src/models/issues.rs
+++ b/src/models/issues.rs
@@ -71,6 +71,7 @@ pub enum IssueStateReason {
     Completed,
     NotPlanned,
     Reopened,
+    Duplicate,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Recently, GitHub added the ability to [explicitly close an issue as a duplicate](https://github.blog/changelog/2024-12-12-github-issues-projects-close-issue-as-a-duplicate-rest-api-for-sub-issues-and-more/#close-an-issue-as-a-duplicate). When you close an issue as a duplicate, in addition to linking it to the issue and putting an event in the timeline, it _also_ sets the the issue state reason to `duplicate`. I cannot find this behavior documented in the current GitHub API docs, but I have seen it in the wild on a few recent issues in the rust-analyzer repository.