### PR TITLE
Partial implementation of Organization CoPilot APIs

### DIFF
--- a/src/api/orgs.rs
+++ b/src/api/orgs.rs
@@ -236,7 +236,7 @@ impl<'octo> OrgHandler<'octo> {
 
     /// Handle copilot-related calls on the organization
     ///
-    ///  # Examples
+    /// # Examples
     /// ```no_run
     /// let copilot_usage = octocrab::instance().orgs("org").copilot().metrics().await?;
     /// ```

--- a/src/api/orgs.rs
+++ b/src/api/orgs.rs
@@ -1,5 +1,6 @@
 //! The Organization API.
 
+mod copilot;
 mod events;
 mod list_members;
 mod list_repos;
@@ -231,5 +232,15 @@ impl<'octo> OrgHandler<'octo> {
     /// ```
     pub fn secrets(&self) -> secrets::OrgSecretsHandler<'_> {
         secrets::OrgSecretsHandler::new(self)
+    }
+
+    /// Handle copilot-related calls on the organization
+    ///
+    ///  # Examples
+    /// ```no_run
+    /// let copilot_usage = octocrab::instance().orgs("org").copilot().metrics().await?;
+    /// ```
+    pub fn copilot(&self) -> copilot::CopilotHandler {
+        copilot::CopilotHandler::new(self)
     }
 }

--- a/src/api/orgs/copilot.rs
+++ b/src/api/orgs/copilot.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+#[derive(serde::Serialize)]
+pub struct CopilotHandler<'octo, 'r> {
+    #[serde(skip)]
+    handler: &'r OrgHandler<'octo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    since: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    until: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl<'octo, 'r> CopilotHandler<'octo, 'r> {
+    pub fn new(handler: &'r OrgHandler<'octo>) -> Self {
+        Self {
+            handler,
+            per_page: None,
+            page: None,
+            since: None,
+            until: None,
+        }
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.page = Some(page.into());
+        self
+    }
+
+    // Show usage metrics since this date.
+    // This is a timestamp in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ).
+    // Maximum value is 28 days ago.
+    pub fn since(mut self, since: chrono::DateTime<chrono::Utc>) -> Self {
+        self.since = Some(since);
+        self
+    }
+
+    // Show usage metrics until this date.
+    // This is a timestamp in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ) and should not preceed the since date if it is passed.
+    pub fn until(mut self, until: chrono::DateTime<chrono::Utc>) -> Self {
+        self.until = Some(until);
+        self
+    }
+
+    // Retrieve copilot metrics for the entire organization
+    pub async fn metrics(
+        self,
+    ) -> crate::Result<crate::Page<Vec<crate::models::orgs_copilot::metrics::CopilotMetrics>>> {
+        let route = format!("/orgs/{org}/copilot/metrics", org = self.handler.owner);
+
+        self.handler.crab.get(route, Some(&self)).await
+    }
+
+    // Retrieve copilot metrics for a specific team within the organization
+    pub async fn metrics_team<T: ToString>(
+        self,
+        team: T,
+    ) -> crate::Result<crate::Page<Vec<crate::models::orgs_copilot::metrics::CopilotMetrics>>> {
+        let route = format!(
+            "/orgs/{org}/team/{team}/copilot/metrics",
+            org = self.handler.owner,
+            team = team.to_string()
+        );
+
+        self.handler.crab.get(route, Some(&self)).await
+    }
+}

--- a/src/api/orgs/copilot.rs
+++ b/src/api/orgs/copilot.rs
@@ -74,4 +74,23 @@ impl<'octo, 'r> CopilotHandler<'octo, 'r> {
 
         self.handler.crab.get(route, Some(&self)).await
     }
+
+    pub async fn billing(
+        self,
+    ) -> crate::Result<crate::models::orgs_copilot::billing::CopilotBilling> {
+        let route = format!("/orgs/{org}/copilot/billing", org = self.handler.owner);
+
+        self.handler.crab.get(route, Some(&self)).await
+    }
+
+    pub async fn billing_seats(
+        self,
+    ) -> crate::Result<crate::models::orgs_copilot::billing::CopilotBillingSeats> {
+        let route = format!(
+            "/orgs/{org}/copilot/billing/seats",
+            org = self.handler.owner,
+        );
+
+        self.handler.crab.get(route, Some(&self)).await
+    }
 }

--- a/src/api/orgs/copilot.rs
+++ b/src/api/orgs/copilot.rs
@@ -75,6 +75,27 @@ impl<'octo, 'r> CopilotHandler<'octo, 'r> {
         self.handler.crab.get(route, Some(&self)).await
     }
 
+    pub async fn usage(
+        self,
+    ) -> crate::Result<crate::Page<Vec<crate::models::orgs_copilot::usage::CopilotUsage>>> {
+        let route = format!("/orgs/{org}/copilot/usage", org = self.handler.owner);
+
+        self.handler.crab.get(route, Some(&self)).await
+    }
+
+    pub async fn usage_team<T: ToString>(
+        self,
+        team: T,
+    ) -> crate::Result<crate::Page<Vec<crate::models::orgs_copilot::usage::CopilotUsage>>> {
+        let route = format!(
+            "/orgs/{org}/team/{team}/copilot/usage",
+            org = self.handler.owner,
+            team = team.to_string()
+        );
+
+        self.handler.crab.get(route, Some(&self)).await
+    }
+
     pub async fn billing(
         self,
     ) -> crate::Result<crate::models::orgs_copilot::billing::CopilotBilling> {

--- a/src/models.rs
+++ b/src/models.rs
@@ -22,6 +22,7 @@ pub mod gists;
 pub mod hooks;
 pub mod issues;
 pub mod orgs;
+pub mod orgs_copilot;
 pub mod pulls;
 pub mod reactions;
 pub mod repos;

--- a/src/models/orgs_copilot.rs
+++ b/src/models/orgs_copilot.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+pub mod billing;
+pub mod metrics;

--- a/src/models/orgs_copilot.rs
+++ b/src/models/orgs_copilot.rs
@@ -2,3 +2,4 @@ use super::*;
 
 pub mod billing;
 pub mod metrics;
+pub mod usage;

--- a/src/models/orgs_copilot/billing.rs
+++ b/src/models/orgs_copilot/billing.rs
@@ -1,1 +1,3 @@
-pub mod seats;
+mod seats;
+
+pub use seats::*;

--- a/src/models/orgs_copilot/billing.rs
+++ b/src/models/orgs_copilot/billing.rs
@@ -1,0 +1,1 @@
+pub mod seats;

--- a/src/models/orgs_copilot/billing/seats.rs
+++ b/src/models/orgs_copilot/billing/seats.rs
@@ -12,9 +12,8 @@ use super::super::*;
 // missing:
 // - billing/seats misses the assigning_team field
 //
-// This requires a API Key with the `copilot:billing` or `enterprise:billing` scope and authorized
-// to access an enterprise. As of writing, the `copilot` scope is only
-// available to GitHub Enterprise customers and limited to Enterprise Administrators.
+// OAuth app tokens and personal access tokens (classic) need either the manage_billing:copilot, read:org, or read:enterprise scopes to use this endpoint.
+// Some of these permissions, as of writing, are only available to GitHub Enterprise customers and further limited to Enterprise Administrators.
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CopilotBilling {

--- a/src/models/orgs_copilot/billing/seats.rs
+++ b/src/models/orgs_copilot/billing/seats.rs
@@ -1,0 +1,54 @@
+use super::super::*;
+
+// implements https://docs.github.com/en/rest/copilot/copilot-user-management
+// as of API Version 2022-11-28
+//
+// We have chosen to not map out the enums as the copilot API is still fresh,
+// this means GitHub may add additional enums in the future and they would
+// require more maintenance than just providing a String.
+//
+// For a list of available enums, refer to the "response schema" in the link above.
+//
+// missing:
+// - billing/seats misses the assigning_team field
+//
+// This requires a API Key with the `copilot:billing` or `enterprise:billing` scope and authorized
+// to access an enterprise. As of writing, the `copilot` scope is only
+// available to GitHub Enterprise customers and limited to Enterprise Administrators.
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CopilotBilling {
+    pub seat_breakdown: CopilotSeatBreakdown,
+    pub seat_management_setting: String,
+    pub ide_chat: String,
+    pub platform_chat: String,
+    pub cli: String,
+    pub public_code_suggestions: String,
+    pub plan_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CopilotSeatBreakdown {
+    pub total: u32,
+    pub added_this_cycle: u32,
+    pub pending_invitation: u32,
+    pub pending_cancellation: u32,
+    pub active_this_cycle: u32,
+    pub inactive_this_cycle: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CopilotBillingSeats {
+    pub total_seats: u32,
+    pub seats: Vec<CopilotSeat>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CopilotSeat {
+    pub created_at: DateTime<Utc>,
+    pub pending_cancellation_date: Option<String>,
+    pub last_activity_at: Option<DateTime<Utc>>,
+    pub last_activity_editor: Option<String>,
+    pub plan_type: Option<String>,
+    pub assignee: SimpleUser,
+}

--- a/src/models/orgs_copilot/metrics.rs
+++ b/src/models/orgs_copilot/metrics.rs
@@ -1,0 +1,62 @@
+use chrono::NaiveDate;
+
+use super::super::*;
+
+// implements https://docs.github.com/en/rest/copilot/copilot-metrics
+// as of API Version 2022-11-28
+// missing:
+// - copilot_dotcom_chat
+// - copilot_dotcom_pull_requests
+// - copilot_ide_chat
+//
+// This requires a API Key with the `copilot` scope and authorized
+// to access an enterprise. As of writing, the `copilot` scope is only
+// available to GitHub Enterprise customers and limited to Enterprise Administrators.
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CopilotMetrics {
+    pub date: NaiveDate,
+    pub total_active_users: u32,
+    pub total_engaged_users: u32,
+    pub copilot_ide_code_completions: CopilotIdeCodeCompletions,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CopilotIdeCodeCompletions {
+    pub total_engaged_users: u32,
+    pub languages: Vec<Language>,
+    pub editors: Vec<Editor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Language {
+    pub name: String,
+    pub total_engaged_users: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Editor {
+    pub name: String,
+    pub total_engaged_users: u32,
+    pub models: Vec<Model>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Model {
+    pub name: String,
+    pub is_custom_model: bool,
+    pub custom_model_training_date: Option<NaiveDate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_engaged_users: Option<u32>,
+    pub languages: Vec<EditorLanguage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EditorLanguage {
+    pub name: String,
+    pub total_engaged_users: u32,
+    pub total_code_suggestions: u32,
+    pub total_code_acceptances: u32,
+    pub total_code_lines_suggested: u32,
+    pub total_code_lines_accepted: u32,
+}

--- a/src/models/orgs_copilot/metrics.rs
+++ b/src/models/orgs_copilot/metrics.rs
@@ -9,9 +9,8 @@ use super::super::*;
 // - copilot_dotcom_pull_requests
 // - copilot_ide_chat
 //
-// This requires a API Key with the `copilot` scope and authorized
-// to access an enterprise. As of writing, the `copilot` scope is only
-// available to GitHub Enterprise customers and limited to Enterprise Administrators.
+// OAuth app tokens and personal access tokens (classic) need either the manage_billing:copilot, read:org, or read:enterprise scopes to use this endpoint.
+// Some of these permissions, as of writing, are only available to GitHub Enterprise customers and further limited to Enterprise Administrators.
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CopilotMetrics {

--- a/src/models/orgs_copilot/usage.rs
+++ b/src/models/orgs_copilot/usage.rs
@@ -1,0 +1,34 @@
+use chrono::NaiveDate;
+
+use super::super::*;
+
+// implements https://docs.github.com/en/rest/copilot/copilot-usage
+// as of API Version 2022-11-28
+//
+// OAuth app tokens and personal access tokens (classic) need either the manage_billing:copilot, read:org, or read:enterprise scopes to use this endpoint.
+// Some of these permissions, as of writing, are only available to GitHub Enterprise customers and further limited to Enterprise Administrators.
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CopilotUsage {
+    pub day: NaiveDate,
+    pub total_suggestions_count: u32,
+    pub total_acceptances_count: u32,
+    pub total_lines_suggested: u32,
+    pub total_lines_accepted: u32,
+    pub total_active_users: u32,
+    pub total_chat_acceptances: u32,
+    pub total_chat_turns: u32,
+    pub total_active_chat_users: u32,
+    pub breakdown: Vec<CopilotBreakdown>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CopilotBreakdown {
+    pub language: String,
+    pub editor: String,
+    pub suggestions_count: u32,
+    pub acceptances_count: u32,
+    pub lines_suggested: u32,
+    pub lines_accepted: u32,
+    pub active_users: u32,
+}

--- a/tests/org_copilot_billing_seats_tests.rs
+++ b/tests/org_copilot_billing_seats_tests.rs
@@ -1,0 +1,134 @@
+// Tests for calls to the /repos/{owner}/members API.
+mod mock_error;
+
+use mock_error::setup_error_handler;
+use octocrab::{models::orgs_copilot::billing::CopilotBillingSeats, Octocrab};
+use serde::{Deserialize, Serialize};
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+#[derive(Serialize, Deserialize)]
+struct FakePage<T> {
+    items: Vec<T>,
+}
+
+async fn setup_billing_api(template: ResponseTemplate) -> MockServer {
+    let org = "org";
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/orgs/{org}/copilot/billing/seats")))
+        .respond_with(template)
+        .mount(&mock_server)
+        .await;
+    setup_error_handler(
+        &mock_server,
+        &format!("GET on /orgs/{org}/copilot/billing/seats was not received"),
+    )
+    .await;
+    mock_server
+}
+
+fn setup_octocrab(uri: &str) -> Octocrab {
+    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
+}
+
+const ORG: &str = "org";
+
+#[tokio::test]
+async fn should_return_page_with_billing_seats_info() {
+    let billing: CopilotBillingSeats =
+        serde_json::from_str(include_str!("resources/org_copilot_billing_seats.json")).unwrap();
+    let template = ResponseTemplate::new(200).set_body_json(&billing);
+    let mock_server = setup_billing_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().billing_seats().await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+
+    let r = result.unwrap();
+    assert_eq!(r.seats[0].assignee.login, "octocat");
+    assert_eq!(r.total_seats, 2);
+}
+
+#[tokio::test]
+async fn org_check_copilot_billing_401() {
+    let template = ResponseTemplate::new(401);
+    let mock_server = setup_billing_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_check_copilot_billing_403() {
+    let template = ResponseTemplate::new(403);
+    let mock_server = setup_billing_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_check_copilot_billing_404() {
+    let template = ResponseTemplate::new(404);
+    let mock_server = setup_billing_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_check_copilot_billing_422() {
+    let template = ResponseTemplate::new(422);
+    let mock_server = setup_billing_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_check_copilot_billing_500() {
+    let template = ResponseTemplate::new(500);
+    let mock_server = setup_billing_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success somehow: {:#?}",
+        result
+    );
+}

--- a/tests/org_copilot_billing_seats_tests.rs
+++ b/tests/org_copilot_billing_seats_tests.rs
@@ -1,4 +1,3 @@
-// Tests for calls to the /repos/{owner}/members API.
 mod mock_error;
 
 use mock_error::setup_error_handler;

--- a/tests/org_copilot_billing_tests.rs
+++ b/tests/org_copilot_billing_tests.rs
@@ -1,0 +1,132 @@
+// Tests for calls to the /repos/{owner}/members API.
+mod mock_error;
+
+use mock_error::setup_error_handler;
+use octocrab::{models::orgs_copilot::billing::CopilotBilling, Octocrab};
+use serde::{Deserialize, Serialize};
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+#[derive(Serialize, Deserialize)]
+struct FakePage<T> {
+    items: Vec<T>,
+}
+
+async fn setup_billing_api(template: ResponseTemplate) -> MockServer {
+    let org = "org";
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/orgs/{org}/copilot/billing")))
+        .respond_with(template)
+        .mount(&mock_server)
+        .await;
+    setup_error_handler(
+        &mock_server,
+        &format!("GET on /orgs/{org}/copilot/billing was not received"),
+    )
+    .await;
+    mock_server
+}
+
+fn setup_octocrab(uri: &str) -> Octocrab {
+    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
+}
+
+const ORG: &str = "org";
+
+#[tokio::test]
+async fn should_return_page_with_billing_info() {
+    let billing: CopilotBilling =
+        serde_json::from_str(include_str!("resources/org_copilot_billing.json")).unwrap();
+    let template = ResponseTemplate::new(200).set_body_json(&billing);
+    let mock_server = setup_billing_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().billing().await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+
+    assert_eq!(result.unwrap().seat_breakdown.total, 12);
+}
+
+#[tokio::test]
+async fn org_check_copilot_billing_401() {
+    let template = ResponseTemplate::new(401);
+    let mock_server = setup_billing_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_check_copilot_billing_403() {
+    let template = ResponseTemplate::new(403);
+    let mock_server = setup_billing_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_check_copilot_billing_404() {
+    let template = ResponseTemplate::new(404);
+    let mock_server = setup_billing_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_check_copilot_billing_422() {
+    let template = ResponseTemplate::new(422);
+    let mock_server = setup_billing_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_check_copilot_billing_500() {
+    let template = ResponseTemplate::new(500);
+    let mock_server = setup_billing_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success somehow: {:#?}",
+        result
+    );
+}

--- a/tests/org_copilot_billing_tests.rs
+++ b/tests/org_copilot_billing_tests.rs
@@ -1,4 +1,3 @@
-// Tests for calls to the /repos/{owner}/members API.
 mod mock_error;
 
 use mock_error::setup_error_handler;

--- a/tests/org_copilot_metrics_tests.rs
+++ b/tests/org_copilot_metrics_tests.rs
@@ -1,0 +1,157 @@
+// Tests for calls to the /repos/{owner}/members API.
+mod mock_error;
+
+use mock_error::setup_error_handler;
+use octocrab::{models::orgs_copilot::metrics::CopilotMetrics, Octocrab, Page};
+use serde::{Deserialize, Serialize};
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+#[derive(Serialize, Deserialize)]
+struct FakePage<T> {
+    items: Vec<T>,
+}
+
+async fn setup_metrics_api(template: ResponseTemplate, team_query: bool) -> MockServer {
+    let org = "org";
+    let team = "team";
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(if !team_query {
+            format!("/orgs/{org}/copilot/metrics")
+        } else {
+            format!("/orgs/{org}/team/{team}/copilot/metrics")
+        }))
+        .respond_with(template)
+        .mount(&mock_server)
+        .await;
+    setup_error_handler(
+        &mock_server,
+        &format!("GET on /orgs/{org}/copilot/metrics (team = {team_query}) was not received"),
+    )
+    .await;
+    mock_server
+}
+
+fn setup_octocrab(uri: &str) -> Octocrab {
+    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
+}
+
+const ORG: &str = "org";
+
+#[tokio::test]
+async fn should_return_page_with_metrics() {
+    let metrics: Vec<CopilotMetrics> =
+        serde_json::from_str(include_str!("resources/org_copilot_metrics.json")).unwrap();
+    let page_response = FakePage {
+        items: vec![metrics],
+    };
+    let template = ResponseTemplate::new(200).set_body_json(&page_response);
+    let mock_server = setup_metrics_api(template, false).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+
+    let Page { items, .. } = result.unwrap();
+    assert_eq!(items.len(), 1);
+    let first_pg = items.first().unwrap();
+    assert_eq!(first_pg.len(), 1);
+    let first_item = first_pg.first().unwrap();
+    assert_eq!(first_item.total_active_users, 24);
+}
+
+#[tokio::test]
+async fn should_return_page_with_metrics_by_team() {
+    let metrics: Vec<CopilotMetrics> =
+        serde_json::from_str(include_str!("resources/org_copilot_metrics.json")).unwrap();
+    let page_response = FakePage {
+        items: vec![metrics],
+    };
+    let template = ResponseTemplate::new(200).set_body_json(&page_response);
+    let mock_server = setup_metrics_api(template, true).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics_team("team".to_string()).await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+
+    let Page { items, .. } = result.unwrap();
+    assert_eq!(items.len(), 1);
+    let first_pg = items.first().unwrap();
+    assert_eq!(first_pg.len(), 1);
+    let first_item = first_pg.first().unwrap();
+    assert_eq!(first_item.total_active_users, 24);
+}
+
+#[tokio::test]
+async fn org_check_metrics_403() {
+    let template = ResponseTemplate::new(403);
+    let mock_server = setup_metrics_api(template, false).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_check_metrics_404() {
+    let template = ResponseTemplate::new(404);
+    let mock_server = setup_metrics_api(template, false).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_check_metrics_422() {
+    let template = ResponseTemplate::new(422);
+    let mock_server = setup_metrics_api(template, false).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_check_metrics_500() {
+    let template = ResponseTemplate::new(500);
+    let mock_server = setup_metrics_api(template, false).await;
+    let client = setup_octocrab(&mock_server.uri());
+    let org = client.orgs(ORG.to_owned());
+    let result = org.copilot().metrics().await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success somehow: {:#?}",
+        result
+    );
+}

--- a/tests/org_copilot_usage_tests.rs
+++ b/tests/org_copilot_usage_tests.rs
@@ -1,7 +1,7 @@
 mod mock_error;
 
 use mock_error::setup_error_handler;
-use octocrab::{models::orgs_copilot::metrics::CopilotMetrics, Octocrab, Page};
+use octocrab::{models::orgs_copilot::usage::CopilotUsage, Octocrab, Page};
 use serde::{Deserialize, Serialize};
 use wiremock::{
     matchers::{method, path},
@@ -13,16 +13,16 @@ struct FakePage<T> {
     items: Vec<T>,
 }
 
-async fn setup_metrics_api(template: ResponseTemplate, team_query: bool) -> MockServer {
+async fn setup_usage_api(template: ResponseTemplate, team_query: bool) -> MockServer {
     let org = "org";
     let team = "team";
     let mock_server = MockServer::start().await;
 
     Mock::given(method("GET"))
         .and(path(if !team_query {
-            format!("/orgs/{org}/copilot/metrics")
+            format!("/orgs/{org}/copilot/usage")
         } else {
-            format!("/orgs/{org}/team/{team}/copilot/metrics")
+            format!("/orgs/{org}/team/{team}/copilot/usage")
         }))
         .respond_with(template)
         .mount(&mock_server)
@@ -42,17 +42,17 @@ fn setup_octocrab(uri: &str) -> Octocrab {
 const ORG: &str = "org";
 
 #[tokio::test]
-async fn should_return_page_with_metrics() {
-    let metrics: Vec<CopilotMetrics> =
-        serde_json::from_str(include_str!("resources/org_copilot_metrics.json")).unwrap();
+async fn should_return_page_with_usage() {
+    let metrics: Vec<CopilotUsage> =
+        serde_json::from_str(include_str!("resources/org_copilot_usage.json")).unwrap();
     let page_response = FakePage {
         items: vec![metrics],
     };
     let template = ResponseTemplate::new(200).set_body_json(&page_response);
-    let mock_server = setup_metrics_api(template, false).await;
+    let mock_server = setup_usage_api(template, false).await;
     let client = setup_octocrab(&mock_server.uri());
     let org = client.orgs(ORG.to_owned());
-    let result = org.copilot().metrics().await;
+    let result = org.copilot().usage().await;
 
     assert!(
         result.is_ok(),
@@ -63,23 +63,23 @@ async fn should_return_page_with_metrics() {
     let Page { items, .. } = result.unwrap();
     assert_eq!(items.len(), 1);
     let first_pg = items.first().unwrap();
-    assert_eq!(first_pg.len(), 1);
+    assert_eq!(first_pg.len(), 2);
     let first_item = first_pg.first().unwrap();
-    assert_eq!(first_item.total_active_users, 24);
+    assert_eq!(first_item.breakdown[0].acceptances_count, 250);
 }
 
 #[tokio::test]
 async fn should_return_page_with_metrics_by_team() {
-    let metrics: Vec<CopilotMetrics> =
-        serde_json::from_str(include_str!("resources/org_copilot_metrics.json")).unwrap();
+    let metrics: Vec<CopilotUsage> =
+        serde_json::from_str(include_str!("resources/org_copilot_usage.json")).unwrap();
     let page_response = FakePage {
         items: vec![metrics],
     };
     let template = ResponseTemplate::new(200).set_body_json(&page_response);
-    let mock_server = setup_metrics_api(template, true).await;
+    let mock_server = setup_usage_api(template, true).await;
     let client = setup_octocrab(&mock_server.uri());
     let org = client.orgs(ORG.to_owned());
-    let result = org.copilot().metrics_team("team".to_string()).await;
+    let result = org.copilot().usage_team("team".to_string()).await;
 
     assert!(
         result.is_ok(),
@@ -90,15 +90,15 @@ async fn should_return_page_with_metrics_by_team() {
     let Page { items, .. } = result.unwrap();
     assert_eq!(items.len(), 1);
     let first_pg = items.first().unwrap();
-    assert_eq!(first_pg.len(), 1);
+    assert_eq!(first_pg.len(), 2);
     let first_item = first_pg.first().unwrap();
-    assert_eq!(first_item.total_active_users, 24);
+    assert_eq!(first_item.breakdown[0].acceptances_count, 250);
 }
 
 #[tokio::test]
 async fn org_check_metrics_403() {
     let template = ResponseTemplate::new(403);
-    let mock_server = setup_metrics_api(template, false).await;
+    let mock_server = setup_usage_api(template, false).await;
     let client = setup_octocrab(&mock_server.uri());
     let org = client.orgs(ORG.to_owned());
     let result = org.copilot().metrics().await;
@@ -113,7 +113,7 @@ async fn org_check_metrics_403() {
 #[tokio::test]
 async fn org_check_metrics_404() {
     let template = ResponseTemplate::new(404);
-    let mock_server = setup_metrics_api(template, false).await;
+    let mock_server = setup_usage_api(template, false).await;
     let client = setup_octocrab(&mock_server.uri());
     let org = client.orgs(ORG.to_owned());
     let result = org.copilot().metrics().await;
@@ -128,7 +128,7 @@ async fn org_check_metrics_404() {
 #[tokio::test]
 async fn org_check_metrics_422() {
     let template = ResponseTemplate::new(422);
-    let mock_server = setup_metrics_api(template, false).await;
+    let mock_server = setup_usage_api(template, false).await;
     let client = setup_octocrab(&mock_server.uri());
     let org = client.orgs(ORG.to_owned());
     let result = org.copilot().metrics().await;
@@ -143,7 +143,7 @@ async fn org_check_metrics_422() {
 #[tokio::test]
 async fn org_check_metrics_500() {
     let template = ResponseTemplate::new(500);
-    let mock_server = setup_metrics_api(template, false).await;
+    let mock_server = setup_usage_api(template, false).await;
     let client = setup_octocrab(&mock_server.uri());
     let org = client.orgs(ORG.to_owned());
     let result = org.copilot().metrics().await;

--- a/tests/resources/org_copilot_billing.json
+++ b/tests/resources/org_copilot_billing.json
@@ -1,0 +1,16 @@
+{
+    "seat_breakdown": {
+        "total": 12,
+        "added_this_cycle": 9,
+        "pending_invitation": 0,
+        "pending_cancellation": 0,
+        "active_this_cycle": 12,
+        "inactive_this_cycle": 11
+    },
+    "seat_management_setting": "assign_selected",
+    "ide_chat": "enabled",
+    "platform_chat": "enabled",
+    "cli": "enabled",
+    "public_code_suggestions": "block",
+    "plan_type": "business"
+}

--- a/tests/resources/org_copilot_billing_seats.json
+++ b/tests/resources/org_copilot_billing_seats.json
@@ -1,0 +1,75 @@
+{
+    "total_seats": 2,
+    "seats": [
+        {
+            "created_at": "2021-08-03T18:00:00-06:00",
+            "updated_at": "2021-09-23T15:00:00-06:00",
+            "pending_cancellation_date": null,
+            "last_activity_at": "2021-10-14T00:53:32-06:00",
+            "last_activity_editor": "vscode/1.77.3/copilot/1.86.82",
+            "plan_type": "business",
+            "assignee": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "assigning_team": {
+                "id": 1,
+                "node_id": "MDQ6VGVhbTE=",
+                "url": "https://api.github.com/teams/1",
+                "html_url": "https://github.com/orgs/github/teams/justice-league",
+                "name": "Justice League",
+                "slug": "justice-league",
+                "description": "A great team.",
+                "privacy": "closed",
+                "notification_setting": "notifications_enabled",
+                "permission": "admin",
+                "members_url": "https://api.github.com/teams/1/members{/member}",
+                "repositories_url": "https://api.github.com/teams/1/repos",
+                "parent": null
+            }
+        },
+        {
+            "created_at": "2021-09-23T18:00:00-06:00",
+            "updated_at": "2021-09-23T15:00:00-06:00",
+            "pending_cancellation_date": "2021-11-01",
+            "last_activity_at": "2021-10-13T00:53:32-06:00",
+            "last_activity_editor": "vscode/1.77.3/copilot/1.86.82",
+            "assignee": {
+                "login": "octokitten",
+                "id": 1,
+                "node_id": "MDQ76VNlcjE=",
+                "avatar_url": "https://github.com/images/error/octokitten_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octokitten",
+                "html_url": "https://github.com/octokitten",
+                "followers_url": "https://api.github.com/users/octokitten/followers",
+                "following_url": "https://api.github.com/users/octokitten/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octokitten/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octokitten/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octokitten/subscriptions",
+                "organizations_url": "https://api.github.com/users/octokitten/orgs",
+                "repos_url": "https://api.github.com/users/octokitten/repos",
+                "events_url": "https://api.github.com/users/octokitten/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octokitten/received_events",
+                "type": "User",
+                "site_admin": false
+            }
+        }
+    ]
+}

--- a/tests/resources/org_copilot_metrics.json
+++ b/tests/resources/org_copilot_metrics.json
@@ -1,0 +1,153 @@
+[
+    {
+        "date": "2024-06-24",
+        "total_active_users": 24,
+        "total_engaged_users": 20,
+        "copilot_ide_code_completions": {
+            "total_engaged_users": 20,
+            "languages": [
+                {
+                    "name": "python",
+                    "total_engaged_users": 10
+                },
+                {
+                    "name": "ruby",
+                    "total_engaged_users": 10
+                }
+            ],
+            "editors": [
+                {
+                    "name": "vscode",
+                    "total_engaged_users": 13,
+                    "models": [
+                        {
+                            "name": "default",
+                            "is_custom_model": false,
+                            "custom_model_training_date": null,
+                            "total_engaged_users": 13,
+                            "languages": [
+                                {
+                                    "name": "python",
+                                    "total_engaged_users": 6,
+                                    "total_code_suggestions": 249,
+                                    "total_code_acceptances": 123,
+                                    "total_code_lines_suggested": 225,
+                                    "total_code_lines_accepted": 135
+                                },
+                                {
+                                    "name": "ruby",
+                                    "total_engaged_users": 7,
+                                    "total_code_suggestions": 496,
+                                    "total_code_acceptances": 253,
+                                    "total_code_lines_suggested": 520,
+                                    "total_code_lines_accepted": 270
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "neovim",
+                    "total_engaged_users": 7,
+                    "models": [
+                        {
+                            "name": "a-custom-model",
+                            "is_custom_model": true,
+                            "custom_model_training_date": "2024-02-01",
+                            "languages": [
+                                {
+                                    "name": "typescript",
+                                    "total_engaged_users": 3,
+                                    "total_code_suggestions": 112,
+                                    "total_code_acceptances": 56,
+                                    "total_code_lines_suggested": 143,
+                                    "total_code_lines_accepted": 61
+                                },
+                                {
+                                    "name": "go",
+                                    "total_engaged_users": 4,
+                                    "total_code_suggestions": 132,
+                                    "total_code_acceptances": 67,
+                                    "total_code_lines_suggested": 154,
+                                    "total_code_lines_accepted": 72
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "copilot_ide_chat": {
+            "total_engaged_users": 13,
+            "editors": [
+                {
+                    "name": "vscode",
+                    "total_engaged_users": 13,
+                    "models": [
+                        {
+                            "name": "default",
+                            "is_custom_model": false,
+                            "custom_model_training_date": null,
+                            "total_engaged_users": 12,
+                            "total_chats": 45,
+                            "total_chat_insertion_events": 12,
+                            "total_chat_copy_events": 16
+                        },
+                        {
+                            "name": "a-custom-model",
+                            "is_custom_model": true,
+                            "custom_model_training_date": "2024-02-01",
+                            "total_engaged_users": 1,
+                            "total_chats": 10,
+                            "total_chat_insertion_events": 11,
+                            "total_chat_copy_events": 3
+                        }
+                    ]
+                }
+            ]
+        },
+        "copilot_dotcom_chat": {
+            "total_engaged_users": 14,
+            "models": [
+                {
+                    "name": "default",
+                    "is_custom_model": false,
+                    "custom_model_training_date": null,
+                    "total_engaged_users": 14,
+                    "total_chats": 38
+                }
+            ]
+        },
+        "copilot_dotcom_pull_requests": {
+            "total_engaged_users": 12,
+            "repositories": [
+                {
+                    "name": "demo/repo1",
+                    "total_engaged_users": 8,
+                    "models": [
+                        {
+                            "name": "default",
+                            "is_custom_model": false,
+                            "custom_model_training_date": null,
+                            "total_pr_summaries_created": 6,
+                            "total_engaged_users": 8
+                        }
+                    ]
+                },
+                {
+                    "name": "demo/repo2",
+                    "total_engaged_users": 4,
+                    "models": [
+                        {
+                            "name": "a-custom-model",
+                            "is_custom_model": true,
+                            "custom_model_training_date": "2024-02-01",
+                            "total_pr_summaries_created": 10,
+                            "total_engaged_users": 4
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/tests/resources/org_copilot_usage.json
+++ b/tests/resources/org_copilot_usage.json
@@ -1,0 +1,153 @@
+[
+    {
+        "date": "2024-06-24",
+        "total_active_users": 24,
+        "total_engaged_users": 20,
+        "copilot_ide_code_completions": {
+            "total_engaged_users": 20,
+            "languages": [
+                {
+                    "name": "python",
+                    "total_engaged_users": 10
+                },
+                {
+                    "name": "ruby",
+                    "total_engaged_users": 10
+                }
+            ],
+            "editors": [
+                {
+                    "name": "vscode",
+                    "total_engaged_users": 13,
+                    "models": [
+                        {
+                            "name": "default",
+                            "is_custom_model": false,
+                            "custom_model_training_date": null,
+                            "total_engaged_users": 13,
+                            "languages": [
+                                {
+                                    "name": "python",
+                                    "total_engaged_users": 6,
+                                    "total_code_suggestions": 249,
+                                    "total_code_acceptances": 123,
+                                    "total_code_lines_suggested": 225,
+                                    "total_code_lines_accepted": 135
+                                },
+                                {
+                                    "name": "ruby",
+                                    "total_engaged_users": 7,
+                                    "total_code_suggestions": 496,
+                                    "total_code_acceptances": 253,
+                                    "total_code_lines_suggested": 520,
+                                    "total_code_lines_accepted": 270
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "neovim",
+                    "total_engaged_users": 7,
+                    "models": [
+                        {
+                            "name": "a-custom-model",
+                            "is_custom_model": true,
+                            "custom_model_training_date": "2024-02-01",
+                            "languages": [
+                                {
+                                    "name": "typescript",
+                                    "total_engaged_users": 3,
+                                    "total_code_suggestions": 112,
+                                    "total_code_acceptances": 56,
+                                    "total_code_lines_suggested": 143,
+                                    "total_code_lines_accepted": 61
+                                },
+                                {
+                                    "name": "go",
+                                    "total_engaged_users": 4,
+                                    "total_code_suggestions": 132,
+                                    "total_code_acceptances": 67,
+                                    "total_code_lines_suggested": 154,
+                                    "total_code_lines_accepted": 72
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "copilot_ide_chat": {
+            "total_engaged_users": 13,
+            "editors": [
+                {
+                    "name": "vscode",
+                    "total_engaged_users": 13,
+                    "models": [
+                        {
+                            "name": "default",
+                            "is_custom_model": false,
+                            "custom_model_training_date": null,
+                            "total_engaged_users": 12,
+                            "total_chats": 45,
+                            "total_chat_insertion_events": 12,
+                            "total_chat_copy_events": 16
+                        },
+                        {
+                            "name": "a-custom-model",
+                            "is_custom_model": true,
+                            "custom_model_training_date": "2024-02-01",
+                            "total_engaged_users": 1,
+                            "total_chats": 10,
+                            "total_chat_insertion_events": 11,
+                            "total_chat_copy_events": 3
+                        }
+                    ]
+                }
+            ]
+        },
+        "copilot_dotcom_chat": {
+            "total_engaged_users": 14,
+            "models": [
+                {
+                    "name": "default",
+                    "is_custom_model": false,
+                    "custom_model_training_date": null,
+                    "total_engaged_users": 14,
+                    "total_chats": 38
+                }
+            ]
+        },
+        "copilot_dotcom_pull_requests": {
+            "total_engaged_users": 12,
+            "repositories": [
+                {
+                    "name": "demo/repo1",
+                    "total_engaged_users": 8,
+                    "models": [
+                        {
+                            "name": "default",
+                            "is_custom_model": false,
+                            "custom_model_training_date": null,
+                            "total_pr_summaries_created": 6,
+                            "total_engaged_users": 8
+                        }
+                    ]
+                },
+                {
+                    "name": "demo/repo2",
+                    "total_engaged_users": 4,
+                    "models": [
+                        {
+                            "name": "a-custom-model",
+                            "is_custom_model": true,
+                            "custom_model_training_date": "2024-02-01",
+                            "total_pr_summaries_created": 10,
+                            "total_engaged_users": 4
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+]


### PR DESCRIPTION
I am an enterprise administrator for our organization's GitHub instance, we use copilot at our organization. I've been developing software that uses these metrics and seats but the library did not yet support the endpoints I required.

This partially tackles https://github.com/XAMPPRocky/octocrab/issues/525

I have done a best effort of implementing the stuff I needed, I have left comments on things I did not [yet] implement. 

The testsuite tests against data GitHub gives but their samples are not entirely feature complete. It is possible I missed a nullable somewhere. Across this week, I will be testing against real data using my fork, if you'd like to wait until I've narrowed down the bugs I could find I'd advocate waiting until the testing checkboxes at the bottom is checked, but I'm also happy to submit follow up PRs to fixes if required.

### Implementation 

```rust
let org = client.orgs("foo");
let result: Page<Vec<CopilotUsage>> = org.copilot().usage().await?;
// ... 
```


- [x] copilot/billing
    - [ ] billing enum support 
- [x] copilot/billing/seats
- [x] copilot/metrics (PARTIAL)
    - [ ] complete api response (e.g. copilot chat, copilot merge request metrics) 
- [x] copilot/metrics/team (PARTIAL)
    - [ ] complete api response (e.g. copilot chat, copilot merge request metrics) 
- [x] copilot/usage (note: experimental API, but it has been around for a while)
- [x] copilot/usage/team (note: experimental API, but it has been around for a while)

https://docs.github.com/en/rest/copilot?apiVersion=2022-11-28

#### Implementation Notes

1: there is an interesting "API design" from GitHub where their json is effectively like this:

```
[
  { ... }
]
```

There is no reason I observed to wrap this into an one-element array, this means the code also looks kind of ugly: `usage` and `metrics` APIs return a `Vec<Vec<Struct>>`, because the documentation says they can be paginated but realistically nobody will. It's kind of awkward but I opted to translate literally and suggest library consumers make prettier wrappers around it. As the copilot API is changing from time to time and some are marked experimental (e.g. usage) trying to fix their issues.

2: 
Copilot usage APIs are experimental;

>This endpoint is in public preview and is subject to change.


#### Testing progress:

- [x] Tested against payloads from GitHub's documentation
- [ ] Tested with real data

Note that even if I tested against real data, it does not guarantee perfect infallibility. We are only human :)

### Disclosure

It is worth noting that some of this code was generated using GitHub Copilot, in particular the struct boilerplate of the models after I copy/pasted the API response as a comment. If the maintainers of this project would rather not have GenAI generated code in your project I encourage declining this PR. Those exact copy/paste's are visible in the test `.json` files.