### PR TITLE
`sha` is optional in `DiffEntry` if file contents are unchanged

### DIFF
--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -79,7 +79,8 @@ pub struct Verification {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct DiffEntry {
-    pub sha: String,
+    // unlike the schema online, this can be null if only metadata changed
+    pub sha: Option<String>,
     pub filename: String,
     pub status: DiffEntryStatus,
     pub additions: u64,


### PR DESCRIPTION
When only metadata changes for a file, the `sha` field is null when requesting a commit. An example of this is if the file mode was changed.

This behavior is different from what the online documentation says, which is that this is a required field.

Fixes: #749 