### PR TITLE
Use a single setup_octocrab

### DIFF
--- a/tests/actions_add_selected_repo_to_org_secret_test.rs
+++ b/tests/actions_add_selected_repo_to_org_secret_test.rs
@@ -1,7 +1,6 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -28,10 +27,6 @@ async fn setup_put_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const ORG: &str = "org";

--- a/tests/actions_delete_workflow_run_logs_test.rs
+++ b/tests/actions_delete_workflow_run_logs_test.rs
@@ -1,7 +1,6 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -28,10 +27,6 @@ async fn setup_delete_workflow_run_logs_api(template: ResponseTemplate) -> MockS
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/actions_remove_selected_repo_from_org_secret_test.rs
+++ b/tests/actions_remove_selected_repo_from_org_secret_test.rs
@@ -1,7 +1,6 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -28,10 +27,6 @@ async fn setup_delete_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const ORG: &str = "org";

--- a/tests/actions_self_hosted_runners.rs
+++ b/tests/actions_self_hosted_runners.rs
@@ -1,10 +1,9 @@
 // Tests for calls to the actions self-hosted runners API:
 // - /repos/{owner}/{repo}/actions/runners
 // - /orgs/{org}/actions/runners
-mod mock_error;
+mod test_common;
 
 use http::StatusCode;
-use mock_error::setup_error_handler;
 use octocrab::{
     models::{
         actions::{SelfHostedRunner, SelfHostedRunnerJitConfig, SelfHostedRunnerToken},
@@ -14,6 +13,7 @@ use octocrab::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use test_common::setup_error_handler;
 use wiremock::{
     matchers::{body_json, method, path},
     Mock, MockServer, ResponseTemplate,

--- a/tests/actions_workflows_dispatches_test.rs
+++ b/tests/actions_workflows_dispatches_test.rs
@@ -1,7 +1,6 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -28,10 +27,6 @@ async fn setup_post_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/check_suites.rs
+++ b/tests/check_suites.rs
@@ -3,14 +3,13 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::checks::{AutoTriggerCheck, CheckSuite, CheckSuitePreferences};
 use octocrab::models::{AppId, CheckRunId, CheckSuiteId};
 use octocrab::params::repos::Commitish;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
 /// Unit test for calls to the `/repos/OWNER/REPO/contributors` endpoint
-mod mock_error;
+mod test_common;
 
 const OWNER: &str = "XAMPPRocky";
 const REPO: &str = "octocrab";
@@ -29,10 +28,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/code_scanning_alert_update_test.rs
+++ b/tests/code_scanning_alert_update_test.rs
@@ -3,12 +3,11 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::code_scannings::CodeScanningAlert;
 use octocrab::params::AlertState;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
-mod mock_error;
+mod test_common;
 
 async fn setup_issue_check_assignee_api(template: ResponseTemplate) -> MockServer {
     let owner: &str = "org";
@@ -33,10 +32,6 @@ async fn setup_issue_check_assignee_api(template: ResponseTemplate) -> MockServe
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/code_scanning_alerts_list_test.rs
+++ b/tests/code_scanning_alerts_list_test.rs
@@ -3,11 +3,10 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::code_scannings::CodeScanningAlert;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
-mod mock_error;
+mod test_common;
 
 const OWNER: &str = "org";
 const REPO: &str = "some-repo";
@@ -53,10 +52,6 @@ async fn setup_codescanning_list_api(template: ResponseTemplate, is_org: bool) -
         .await;
     }
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/code_scanning_analysis_test.rs
+++ b/tests/code_scanning_analysis_test.rs
@@ -4,11 +4,10 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::code_scannings::CodeScanningAlert;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
-mod mock_error;
+mod test_common;
 
 async fn setup_issue_check_assignee_api(template: ResponseTemplate) -> MockServer {
     let owner: &str = "org";
@@ -33,10 +32,6 @@ async fn setup_issue_check_assignee_api(template: ResponseTemplate) -> MockServe
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/commit_associated_check_runs_tests.rs
+++ b/tests/commit_associated_check_runs_tests.rs
@@ -1,12 +1,12 @@
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
 use octocrab::models::checks::ListCheckRuns;
 use octocrab::models::CheckRunId;
 use octocrab::params::repos::Reference;
-use octocrab::{Error, Octocrab};
+use octocrab::Error;
 use serde_json::{json, Value};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -28,10 +28,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/current_user_orgs_test.rs
+++ b/tests/current_user_orgs_test.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /user/memberships/orgs API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::orgs::MembershipInvitation, Octocrab, Page};
+use octocrab::{models::orgs::MembershipInvitation, Page};
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -28,10 +28,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/dependabot_alerts_test.rs
+++ b/tests/dependabot_alerts_test.rs
@@ -3,11 +3,10 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::repos::dependabot::DependabotAlert;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
-mod mock_error;
+mod test_common;
 
 const OWNER: &str = "org";
 const REPO: &str = "some-repo";
@@ -35,10 +34,6 @@ async fn setup_dependabot_api(template: ResponseTemplate) -> MockServer {
     .await;
 
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/events_test.rs
+++ b/tests/events_test.rs
@@ -1,13 +1,12 @@
 // Tests for calls to the /repos/{owner}/{repo}/events API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
 use octocrab::{
     etag::{EntityTag, Etagged},
     models::events,
-    Octocrab,
 };
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -27,10 +26,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
         .await;
     setup_error_handler(&mock_server, "GET on /events was not received").await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/follow_redirect.rs
+++ b/tests/follow_redirect.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /repos/{owner}/{repo}/stargazers API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::StarGazer, Octocrab, Page};
+use octocrab::{models::StarGazer, Page};
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     http::HeaderValue,
     matchers::{method, path},
@@ -42,10 +42,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "old-owner";

--- a/tests/generate_release_notes_test.rs
+++ b/tests/generate_release_notes_test.rs
@@ -1,9 +1,9 @@
 /// Tests generating release notes:
 /// /repos/{owner}/{repo}/releases/generate-notes
-mod mock_error;
-use mock_error::setup_error_handler;
+mod test_common;
+
 use octocrab::models::repos::ReleaseNotes;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -25,10 +25,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/gists_test.rs
+++ b/tests/gists_test.rs
@@ -1,7 +1,6 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -81,10 +80,6 @@ async fn setup_put_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const GIST_ID: &str = "12c55a94bd03166ff33ed0596263b4c6";

--- a/tests/hooks_delivery_list.rs
+++ b/tests/hooks_delivery_list.rs
@@ -1,12 +1,12 @@
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
 use octocrab::models::hooks::Delivery;
 use octocrab::models::HookId;
-use octocrab::{Error, Octocrab};
+use octocrab::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -33,10 +33,6 @@ async fn setup_get_api(template: ResponseTemplate, number: u64) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/issues_check_assignee_test.rs
+++ b/tests/issues_check_assignee_test.rs
@@ -1,7 +1,6 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -26,10 +25,6 @@ async fn setup_issue_check_assignee_api(template: ResponseTemplate) -> MockServe
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/issues_comments_delete_test.rs
+++ b/tests/issues_comments_delete_test.rs
@@ -1,7 +1,6 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -28,10 +27,6 @@ async fn setup_remove_comment_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/issues_comments_reactions_delete_test.rs
+++ b/tests/issues_comments_reactions_delete_test.rs
@@ -1,7 +1,6 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -29,10 +28,6 @@ async fn setup_remove_comment_reaction_api(template: ResponseTemplate) -> MockSe
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/issues_labels_delete_test.rs
+++ b/tests/issues_labels_delete_test.rs
@@ -1,7 +1,7 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models, Octocrab};
+use octocrab::models;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -51,10 +51,6 @@ async fn setup_delete_label_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/issues_locking_test.rs
+++ b/tests/issues_locking_test.rs
@@ -1,7 +1,7 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{params::LockReason, Octocrab};
+use octocrab::params::LockReason;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -51,10 +51,6 @@ async fn setup_issue_unlock_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/issues_reactions_delete_test.rs
+++ b/tests/issues_reactions_delete_test.rs
@@ -1,7 +1,6 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -29,10 +28,6 @@ async fn setup_remove_reaction_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/notifications_threads_test.rs
+++ b/tests/notifications_threads_test.rs
@@ -1,7 +1,6 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -26,10 +25,6 @@ async fn setup_delete_thread_sub_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const THREAD_ID: u64 = 123u64;

--- a/tests/org_installations_test.rs
+++ b/tests/org_installations_test.rs
@@ -1,9 +1,8 @@
 // Tests for calls to the /orgs/{org}/installation endpoint.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
 use octocrab::models::{Author, Installation, InstallationId};
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -23,10 +22,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/org_members_tests.rs
+++ b/tests/org_members_tests.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /repos/{owner}/members API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::Author, Octocrab, Page};
+use octocrab::{models::Author, Page};
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -48,10 +48,6 @@ async fn setup_check_membership_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const ORG: &str = "org";

--- a/tests/org_secrets_test.rs
+++ b/tests/org_secrets_test.rs
@@ -1,18 +1,15 @@
 // Tests for calls to the /orgs/{ORG}/actions/secrets API.
-mod mock_error;
+mod test_common;
 
 use chrono::DateTime;
-use mock_error::setup_error_handler;
-use octocrab::{
-    models::{
-        orgs::secrets::{
-            CreateOrganizationSecret, CreateOrganizationSecretResponse, OrganizationSecret,
-            OrganizationSecrets, Visibility,
-        },
-        PublicKey,
+use octocrab::models::{
+    orgs::secrets::{
+        CreateOrganizationSecret, CreateOrganizationSecretResponse, OrganizationSecret,
+        OrganizationSecrets, Visibility,
     },
-    Octocrab,
+    PublicKey,
 };
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -66,10 +63,6 @@ async fn setup_delete_api(template: ResponseTemplate, secrets_path: &str) -> Moc
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/projects_org_create_project_test.rs
+++ b/tests/projects_org_create_project_test.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /orgs/{org}/projects API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::Project, Octocrab};
+use octocrab::models::Project;
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -28,10 +28,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/projects_org_list_projects_test.rs
+++ b/tests/projects_org_list_projects_test.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /orgs/{org}/projects API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::Project, Octocrab, Page};
+use octocrab::{models::Project, Page};
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -30,10 +30,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/projects_project_delete_test.rs
+++ b/tests/projects_project_delete_test.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /projects/{project_id} API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::Project, Octocrab};
+use octocrab::models::Project;
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -28,10 +28,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/projects_project_get_test.rs
+++ b/tests/projects_project_get_test.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /projects/{project_id} API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::Project, Octocrab};
+use octocrab::models::Project;
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -28,10 +28,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/projects_project_update_test.rs
+++ b/tests/projects_project_update_test.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /projects/{project_id} API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::Project, Octocrab};
+use octocrab::models::Project;
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -28,10 +28,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/projects_repo_create_project_test.rs
+++ b/tests/projects_repo_create_project_test.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /repos/{owner}/{repo}/projects API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::Project, Octocrab};
+use octocrab::models::Project;
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -29,10 +29,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/projects_repo_list_projects_test.rs
+++ b/tests/projects_repo_list_projects_test.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /repos/{owner}/{repo}/projects API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::Project, Octocrab, Page};
+use octocrab::{models::Project, Page};
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -32,10 +32,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/projects_user_create_project_test.rs
+++ b/tests/projects_user_create_project_test.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /projects/{project_id} API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::Project, Octocrab};
+use octocrab::models::Project;
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -24,10 +24,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
         .await;
     setup_error_handler(&mock_server, "POST on /users/projects was not received").await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/projects_user_list_projects_test.rs
+++ b/tests/projects_user_list_projects_test.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /users/{username}/projects API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::Project, Octocrab, Page};
+use octocrab::{models::Project, Page};
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -30,10 +30,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/pull_request_commits_test.rs
+++ b/tests/pull_request_commits_test.rs
@@ -3,12 +3,11 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::repos::RepoCommit;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
 /// Unit test for calls to the `/repos/OWNER/REPO/contributors` endpoint
-mod mock_error;
+mod test_common;
 
 const OWNER: &str = "XAMPPRocky";
 const REPO: &str = "octocrab";
@@ -30,10 +29,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/pull_request_review_comment_test.rs
+++ b/tests/pull_request_review_comment_test.rs
@@ -1,22 +1,18 @@
+use test_common::setup_octocrab;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use octocrab::models::pulls::Comment;
 use octocrab::models::CommentId;
-use octocrab::Octocrab;
 
-use crate::mock_error::setup_error_handler;
+use crate::test_common::setup_error_handler;
 
 /// Unit test for calls to the `/repos/{owner}/{repo}/pulls/comments/{comment_id}` endpoint
-mod mock_error;
+mod test_common;
 
 const OWNER: &str = "XAMPPRocky";
 const REPO: &str = "octocrab";
 const COMMENT_ID: u64 = 42;
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
-}
 
 #[tokio::test]
 async fn should_work_with_review_comment() {

--- a/tests/pull_request_review_operations_test.rs
+++ b/tests/pull_request_review_operations_test.rs
@@ -1,23 +1,19 @@
+use test_common::setup_octocrab;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use octocrab::models::pulls::{Review, ReviewAction, ReviewComment};
-use octocrab::Octocrab;
 
-use crate::mock_error::setup_error_handler;
+use crate::test_common::setup_error_handler;
 
 /// Unit test for calls to the `/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}` endpoint
-mod mock_error;
+mod test_common;
 
 const OWNER: &str = "XAMPPRocky";
 const REPO: &str = "octocrab";
 const PULL_NUMBER: u64 = 42;
 const REVIEW_ID: u64 = 42;
 const COMMENT_ID: u64 = 42;
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
-}
 
 #[tokio::test]
 async fn should_work_with_specific_review() {

--- a/tests/repo_contributors_test.rs
+++ b/tests/repo_contributors_test.rs
@@ -3,12 +3,11 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::{Author, Contributor};
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
 /// Unit test for calls to the `/repos/OWNER/REPO/contributors` endpoint
-mod mock_error;
+mod test_common;
 
 const OWNER: &str = "XAMPPRocky";
 const REPO: &str = "octocrab";
@@ -27,10 +26,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/repo_delete_ref_test.rs
+++ b/tests/repo_delete_ref_test.rs
@@ -1,7 +1,7 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{params::repos::Reference, Octocrab};
+use octocrab::params::repos::Reference;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -26,10 +26,6 @@ async fn setup_delete_ref_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/repo_secrets_test.rs
+++ b/tests/repo_secrets_test.rs
@@ -1,18 +1,14 @@
 // Tests for calls to the /repos/{owner}/{repo}/actions/secrets API.
-mod mock_error;
+mod test_common;
 
 use chrono::DateTime;
-use mock_error::setup_error_handler;
-use octocrab::{
-    models::{
-        repos::secrets::{
-            CreateRepositorySecret, CreateRepositorySecretResponse, RepositorySecret,
-            RepositorySecrets,
-        },
-        PublicKey,
+use octocrab::models::{
+    repos::secrets::{
+        CreateRepositorySecret, CreateRepositorySecretResponse, RepositorySecret, RepositorySecrets,
     },
-    Octocrab,
+    PublicKey,
 };
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -73,10 +69,6 @@ async fn setup_delete_api(template: ResponseTemplate, secrets_path: &str) -> Moc
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/repos_commit_test.rs
+++ b/tests/repos_commit_test.rs
@@ -1,7 +1,7 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::repos::RepoCommit, Octocrab};
+use octocrab::models::repos::RepoCommit;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -25,10 +25,6 @@ async fn setup_repos_commits_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/repos_delete_test.rs
+++ b/tests/repos_delete_test.rs
@@ -1,7 +1,6 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -25,10 +24,6 @@ async fn setup_delete_repo_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/repos_events_test.rs
+++ b/tests/repos_events_test.rs
@@ -1,13 +1,12 @@
 // Tests for calls to the /repos/{owner}/{repo}/events API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
 use octocrab::{
     etag::{EntityTag, Etagged},
     models::events,
-    Octocrab,
 };
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -33,10 +32,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "owner";

--- a/tests/repos_is_collaborator_test.rs
+++ b/tests/repos_is_collaborator_test.rs
@@ -1,7 +1,6 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -28,10 +27,6 @@ async fn setup_repo_collaborator_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/repos_merges_test.rs
+++ b/tests/repos_merges_test.rs
@@ -1,7 +1,7 @@
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::repos::MergeCommit, Octocrab};
+use octocrab::models::repos::MergeCommit;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -25,10 +25,6 @@ async fn setup_repos_merges_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "org";

--- a/tests/repos_releases_get_by_id.rs
+++ b/tests/repos_releases_get_by_id.rs
@@ -1,12 +1,12 @@
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
 use octocrab::models::repos::Release;
 use octocrab::models::ReleaseId;
-use octocrab::{Error, Octocrab};
+use octocrab::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -34,10 +34,6 @@ async fn setup_get_api(template: ResponseTemplate, number: u64) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/repos_releases_get_by_tag.rs
+++ b/tests/repos_releases_get_by_tag.rs
@@ -1,12 +1,12 @@
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
 use octocrab::models::repos::Release;
 use octocrab::models::ReleaseId;
-use octocrab::{Error, Octocrab};
+use octocrab::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -34,10 +34,6 @@ async fn setup_get_api(template: ResponseTemplate, tag: &str) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/repos_releases_get_latest.rs
+++ b/tests/repos_releases_get_latest.rs
@@ -1,12 +1,12 @@
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
 use octocrab::models::repos::Release;
 use octocrab::models::ReleaseId;
-use octocrab::{Error, Octocrab};
+use octocrab::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -34,10 +34,6 @@ async fn setup_get_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/repos_releases_list_test.rs
+++ b/tests/repos_releases_list_test.rs
@@ -1,12 +1,12 @@
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
 use octocrab::models::repos::Release;
 use octocrab::models::ReleaseId;
-use octocrab::{Error, Octocrab};
+use octocrab::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -34,10 +34,6 @@ async fn setup_get_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/repos_stargazers_tests.rs
+++ b/tests/repos_stargazers_tests.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /repos/{owner}/{repo}/stargazers API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::StarGazer, Octocrab, Page};
+use octocrab::{models::StarGazer, Page};
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -29,10 +29,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const OWNER: &str = "owner";

--- a/tests/secrets_alerts_test.rs
+++ b/tests/secrets_alerts_test.rs
@@ -1,14 +1,13 @@
+mod test_common;
+
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::repos::secret_scanning_alert::SecretScanningAlert;
 use octocrab::models::repos::secret_scanning_alert::SecretsScanningAlertLocation;
-use octocrab::Octocrab;
-
-mod mock_error;
+use test_common::{setup_error_handler, setup_octocrab};
 
 const OWNER: &str = "org";
 const REPO: &str = "some-repo";
@@ -62,10 +61,6 @@ async fn setup_secrets_locations_api(template: ResponseTemplate) -> MockServer {
     .await;
 
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/team_delete_test.rs
+++ b/tests/team_delete_test.rs
@@ -1,9 +1,8 @@
 // Tests for calls to the /orgs/{org}/teams/{team}/members API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -31,10 +30,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const ORG: &str = "org";

--- a/tests/team_invitations_tests.rs
+++ b/tests/team_invitations_tests.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /orgs/{org}/teams/{team}/invitations API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::teams::TeamInvitation, Octocrab, Page};
+use octocrab::{models::teams::TeamInvitation, Page};
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -30,10 +30,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const ORG: &str = "org";

--- a/tests/team_members_tests.rs
+++ b/tests/team_members_tests.rs
@@ -1,9 +1,9 @@
 // Tests for calls to the /orgs/{org}/teams/{team}/members API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::{models::Author, Octocrab, Page};
+use octocrab::{models::Author, Page};
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -30,10 +30,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const ORG: &str = "org";

--- a/tests/team_repos_tests.rs
+++ b/tests/team_repos_tests.rs
@@ -1,9 +1,8 @@
 // Tests for calls to the /orgs/{org}/teams/{team}/members API.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
-use octocrab::Octocrab;
 use serde::{Deserialize, Serialize};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -37,10 +36,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 const ORG: &str = "org";

--- a/tests/test_common.rs
+++ b/tests/test_common.rs
@@ -1,3 +1,4 @@
+use octocrab::Octocrab;
 use serde_json::json;
 use wiremock::{
     matchers::{method, path_regex},
@@ -19,4 +20,14 @@ pub async fn setup_error_handler(mock_server: &MockServer, message: &str) {
         })))
         .mount(mock_server)
         .await;
+}
+
+// Sets up an Octocrab client with the given URI.
+#[allow(dead_code)]
+pub fn setup_octocrab(uri: &str) -> octocrab::Octocrab {
+    Octocrab::builder()
+        .base_uri(uri)
+        .unwrap()
+        .build()
+        .expect("Could not create octocrab client")
 }

--- a/tests/user_blocks_tests.rs
+++ b/tests/user_blocks_tests.rs
@@ -4,12 +4,11 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::SimpleUser;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
 #[derive(Serialize, Deserialize)]
 struct FakePage<T> {
@@ -36,10 +35,6 @@ async fn setup_blocks_mock(
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/user_deserialize_test.rs
+++ b/tests/user_deserialize_test.rs
@@ -1,16 +1,11 @@
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
-use mock_error::setup_error_handler;
+mod test_common;
 use octocrab::models::UserProfile;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
 };
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
-}
 
 async fn setup_api(template: ResponseTemplate) -> MockServer {
     let mock_server = MockServer::start().await;

--- a/tests/user_emails_tests.rs
+++ b/tests/user_emails_tests.rs
@@ -4,13 +4,12 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::UserEmailInfo;
 use octocrab::params::users::emails::EmailVisibilityState;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
 async fn setup_emails_mock(
     http_method: &str,
@@ -30,10 +29,6 @@ async fn setup_emails_mock(
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/user_git_ssh_keys_tests.rs
+++ b/tests/user_git_ssh_keys_tests.rs
@@ -4,12 +4,11 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::GitSshKey;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
 const GIT_SSH_KEY_ID: u64 = 42;
 
@@ -31,10 +30,6 @@ async fn setup_git_ssh_keys_mock(
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/user_gpg_keys_tests.rs
+++ b/tests/user_gpg_keys_tests.rs
@@ -4,12 +4,11 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::GpgKey;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
 const GPG_KEY_ID: u64 = 42;
 
@@ -31,10 +30,6 @@ async fn setup_gpg_keys_mock(
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/user_repositories_tests.rs
+++ b/tests/user_repositories_tests.rs
@@ -1,11 +1,11 @@
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
-use mock_error::setup_error_handler;
 use octocrab::models::{Repository, RepositoryId};
-use octocrab::{Error, Octocrab};
+use octocrab::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use test_common::{setup_error_handler, setup_octocrab};
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
@@ -32,10 +32,6 @@ async fn setup_api(template: ResponseTemplate) -> MockServer {
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/user_social_accounts_tests.rs
+++ b/tests/user_social_accounts_tests.rs
@@ -4,12 +4,11 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::SocialAccount;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
 async fn setup_social_accounts_mock(
     http_method: &str,
@@ -29,10 +28,6 @@ async fn setup_social_accounts_mock(
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]

--- a/tests/user_ssh_signing_keys_tests.rs
+++ b/tests/user_ssh_signing_keys_tests.rs
@@ -4,12 +4,11 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use mock_error::setup_error_handler;
 use octocrab::models::SshSigningKey;
-use octocrab::Octocrab;
+use test_common::{setup_error_handler, setup_octocrab};
 
 /// Tests API calls related to check runs of a specific commit.
-mod mock_error;
+mod test_common;
 
 const SSH_SIGNING_KEY_ID: u64 = 42;
 
@@ -31,10 +30,6 @@ async fn setup_ssh_signing_keys_mock(
     )
     .await;
     mock_server
-}
-
-fn setup_octocrab(uri: &str) -> Octocrab {
-    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
 }
 
 #[tokio::test]


### PR DESCRIPTION
I noticed the same test function is repeated multiple times. Moved some stuff around so that `setup_octocrab` and `setup_error_handler` are in a shared module. 

