### PR TITLE
fix: insert auth headers for api.github.com

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1720,8 +1720,8 @@ impl Octocrab {
                         .headers
                         .insert(http::header::AUTHORIZATION, auth_header);
                 }
-                Some(authority) => {
-                    tracing::warn!("Not inserting auth header: authority = {}", authority);
+                Some(_) => {
+                    // Don't insert auth header.
                 }
             }
         }


### PR DESCRIPTION
`into_stream()` for pagination is currently broken. Consider the following case:

```rust
        let stream_client = client.clone();
        let stream = client
            .pulls(&owner, &repo)
            .list_files(issue_number)
            .await?
            .into_stream(&stream_client);

        pin!(stream);

        let mut objects = Vec::new();
        while let Some(diff) = stream.try_next().await? {
            tracing::info("{}", &diff.filename);
        }
```

When more than 30 files are modified in a pull request, [the Github API will return a response with a `link` header](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers) containing a link to the next page of results.

Octocrab correctly resolves the `next` URL from this header when it exhausts the first page of results, and so try_next() will make another API call to Github of the form `https://api.github.com/repositories/{repo_id}/issues?page=2`.

However, because the authority of this URL is `api.github.com` and not `None`,[ Octocrab will not include auth headers with that request,](https://github.com/XAMPPRocky/octocrab/blame/ce8c885dc2701c891ce868c846fa25d32fd44ba2/src/lib.rs#L1710) and the request will fail.

This pull request alters this behaviour to include auth headers if the URL authority is `None` or `"api.github.com"`.

Fixes: 
https://github.com/XAMPPRocky/octocrab/issues/576
https://github.com/XAMPPRocky/octocrab/issues/738