### PR TITLE
fix(emails): `visibility` can be `null`

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1106,7 +1106,7 @@ pub struct UserEmailInfo {
     pub email: String,
     pub primary: bool,
     pub verified: bool,
-    pub visibility: EmailVisibilityState,
+    pub visibility: Option<EmailVisibilityState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/resources/user_emails.json
+++ b/tests/resources/user_emails.json
@@ -4,5 +4,11 @@
     "primary": true,
     "verified": true,
     "visibility": "private"
+  },
+  {
+    "email": "octocat1@github.com",
+    "primary": true,
+    "verified": true,
+    "visibility": null
   }
 ]

--- a/tests/user_emails_tests.rs
+++ b/tests/user_emails_tests.rs
@@ -54,7 +54,7 @@ async fn should_respond_to_primary_email_visibility() {
     );
     let response = result.unwrap();
     let visibility = response.first().unwrap().visibility;
-    assert_eq!(visibility, EmailVisibilityState::Private);
+    assert_eq!(visibility, Some(EmailVisibilityState::Private));
 }
 
 #[tokio::test]
@@ -78,7 +78,10 @@ async fn should_respond_to_email_list() {
     );
     let response = result.unwrap();
     let visibility = response.items.first().unwrap().visibility;
-    assert_eq!(visibility, EmailVisibilityState::Private);
+    assert_eq!(visibility, Some(EmailVisibilityState::Private));
+
+    let visibility = response.items[1].visibility;
+    assert_eq!(visibility, None);
 }
 
 #[tokio::test]
@@ -102,7 +105,7 @@ async fn should_respond_to_public_email_list() {
     );
     let response = result.unwrap();
     let visibility = response.items.first().unwrap().visibility;
-    assert_eq!(visibility, EmailVisibilityState::Private);
+    assert_eq!(visibility, Some(EmailVisibilityState::Private));
 }
 
 #[tokio::test]


### PR DESCRIPTION
According to the [`/user/emails` schema](https://docs.github.com/en/rest/users/emails?apiVersion=2022-11-28#list-email-addresses-for-the-authenticated-user), the `visibility` field in the response can be `null`. The `UserEmailInfo` made it mandatory, causing deserialization failures during requests against real GitHub APIs like this:

```
invalid type: null, expected string or map
```