### PR TITLE
feat: Implement Serialize for Page

### DIFF
--- a/src/page.rs
+++ b/src/page.rs
@@ -53,7 +53,7 @@ fn serialize_url<S>(uri: &Option<http::Uri>, serializer: S) -> Result<S::Ok, S::
 where
     S: Serializer,
 {
-    Option::<String>::serialize(&uri.as_ref().map(|uri| uri.to_string()), serializer)
+    Option::<String>::serialize(&uri.as_ref().map(Uri::to_string), serializer)
 }
 
 #[cfg(feature = "stream")]


### PR DESCRIPTION
Implements Serialize for page. Makes it a bit simpler to i.e. throw a Page into a tera template. I started out with adding deserialize as well (reworking FromResponse), but since that one is so specific to json I did not want to bother with getting it to work with the blanket implementation. It's probably possible with some effort.