### PR TITLE
models: Add enum `EventInstallation::id()` helper

### DIFF
--- a/src/models/webhook_events.rs
+++ b/src/models/webhook_events.rs
@@ -962,6 +962,15 @@ pub enum EventInstallation {
     Minimal(Box<EventInstallationId>),
 }
 
+impl EventInstallation {
+    pub fn id(&self) -> InstallationId {
+        match self {
+            EventInstallation::Full(installation) => installation.id,
+            EventInstallation::Minimal(installation) => installation.id,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EventInstallationId {
     pub id: InstallationId,


### PR DESCRIPTION
The only common field for both `EventInstallation::Full` and `EventInstallation::Minimal` is the `id`` field. Let's add a helper to make life easier for e.g. implementors of GitHub Apps that trigger on webhook events.