### PR TITLE
examples/graphql_issues.rs: Update schema URL

### DIFF
--- a/examples/graphql_issues.rs
+++ b/examples/graphql_issues.rs
@@ -1,7 +1,7 @@
 //! Run this to update `github_schema.graphql`:
 //!
 //! ```sh
-//! curl -L https://docs.github.com/public/schema.docs.graphql -o examples/github_schema.graphql
+//! curl -L https://docs.github.com/public/fpt/schema.docs.graphql -o examples/github_schema.graphql
 //! ```
 use graphql_client::GraphQLQuery;
 


### PR DESCRIPTION
The current link is 404:ed.

    $ curl --head -L https://docs.github.com/public/schema.docs.graphql
    HTTP/2 404
    content-length: 9

    $ curl --head -L https://docs.github.com/public/fpt/schema.docs.graphql
    HTTP/2 200
    content-length: 1262568