### PR TITLE
Add 'dowload' and 'download_zip' functions to client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1752,6 +1752,10 @@ impl Octocrab {
         }
     }
 
+    /// Download a file from the given URL with the given content type
+    ///
+    /// This is a convenience method that sets the `Accept` header to the given
+    /// content type and downloads the file into a `Vec<u8>`.
     pub async fn download(
         &self,
         uri: impl TryInto<Uri>,
@@ -1776,7 +1780,7 @@ impl Octocrab {
         Ok(bytes.to_vec())
     }
 
-    /// Download a zip file from the given URL
+    /// Download a zip file from the given URL into a `Vec<u8>`.
     pub async fn download_zip(&self, uri: impl TryInto<Uri>) -> crate::Result<Vec<u8>> {
         self.download(uri, "application/zip").await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1751,6 +1751,35 @@ impl Octocrab {
             Ok(response)
         }
     }
+
+    pub async fn download(
+        &self,
+        uri: impl TryInto<Uri>,
+        content_type: impl TryInto<http::HeaderValue>,
+    ) -> crate::Result<Vec<u8>> {
+        let uri = uri
+            .try_into()
+            .map_err(|_| UriParseError {})
+            .context(UriParseSnafu)?;
+        let content_type = content_type
+            .try_into()
+            .map_err(|_| UriParseError {})
+            .context(UriParseSnafu)?;
+
+        let mut request = Builder::new().method(Method::GET).uri(uri);
+        request = request.header(http::header::ACCEPT, content_type);
+
+        let request = self.build_request(request, None::<&()>)?;
+        let response = self.execute(request).await?;
+
+        let bytes = response.into_body().collect().await?.to_bytes();
+        Ok(bytes.to_vec())
+    }
+
+    /// Download a zip file from the given URL
+    pub async fn download_zip(&self, uri: impl TryInto<Uri>) -> crate::Result<Vec<u8>> {
+        self.download(uri, "application/zip").await
+    }
 }
 
 /// # Utility Methods


### PR DESCRIPTION
I've added two functions to help with downloading arbatrary files from GitHub.

- `download`: which you can pass in a URI and content-type header
- `download_zip`: which you can pass in a URI and it will download the zip file

Let me know if you want the names chanaged as `download` might not be the best name for the first function.