### PR TITLE
fix(docs): Update and fix crate documentation for docs.rs, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,42 +25,53 @@ The semantic API provides strong typing around GitHub's API, a set of
 for GitHub apps.
 Currently, the following modules are available as of version `0.44`.
 
-- [`actions`] GitHub Actions.
-- [`apps`] GitHub Apps.
-- [`current`] Information about the current user.
-- [`gitignore`] Gitignore templates.
-- [`graphql`] GraphQL.
+- [`actions`] GitHub Actions
+- [`activity`] GitHub Activity
+- [`apps`] GitHub Apps
+- [`checks`] GitHub Checks
+- [`code_scannings`] Code Scanning
+- [`commits`] GitHub Commits
+- [`current`] Information about the current user
+- [`events`] GitHub Events
+- [`gists`] Gists
+- [`gitignore`] Gitignore templates
+- [`graphql`] GraphQL
 - [`issues`] Issues and related items, e.g. comments, labels, etc.
-- [`licenses`] License Metadata.
-- [`markdown`] Rendering Markdown with GitHub.
-- [`orgs`] GitHub Organisations.
-- [`pulls`] Pull Requests.
-- [`releases`] Releases.
-- [`repos`] Repositories.
-- [`search`] GitHub's search API.
-- [`teams`] Teams.
-- [`gists`] GitHub's gists API
-- [`users`] Users.
-- [`code_scannings`] Code scannings
+- [`licenses`] License Metadata
+- [`markdown`] Rendering Markdown with GitHub
+- [`orgs`] GitHub Organisations
+- [`projects`] GitHub Projects
+- [`pulls`] Pull Requests
+- [`ratelimit`] Rate Limiting
+- [`repos`] Repositories
+- [`search`] Using GitHub's search
+- [`teams`] Teams
+- [`users`] Users
 
 [`models`]: https://docs.rs/octocrab/latest/octocrab/models/index.html
 [`auth`]: https://docs.rs/octocrab/latest/octocrab/auth/index.html
-[`apps`]: https://docs.rs/octocrab/latest/octocrab/apps/index.html
 [`actions`]: https://docs.rs/octocrab/latest/octocrab/actions/struct.ActionsHandler.html
+[`activity`]: https://docs.rs/octocrab/latest/octocrab/activity/struct.ActivityHandler.html
+[`apps`]: https://docs.rs/octocrab/latest/octocrab/apps/struct.AppsHandler.html
+[`checks`]: https://docs.rs/octocrab/latest/octocrab/checks/struct.ChecksHandler.html
+[`code_scannings`]: https://docs.rs/octocrab/latest/octocrab/code_scannings/struct.CodeScanningsHandler.html
+[`commits`]: https://docs.rs/octocrab/latest/octocrab/commits/struct.CommitsHandler.html
 [`current`]: https://docs.rs/octocrab/latest/octocrab/current/struct.CurrentAuthHandler.html
+[`events`]: https://docs.rs/octocrab/latest/octocrab/events/struct.EventsHandler.html
+[`gists`]: https://docs.rs/octocrab/latest/octocrab/gists/struct.GistsHandler.html
 [`gitignore`]: https://docs.rs/octocrab/latest/octocrab/gitignore/struct.GitignoreHandler.html
 [`graphql`]: https://docs.rs/octocrab/latest/octocrab/struct.Octocrab.html#graphql-api
-[`markdown`]: https://docs.rs/octocrab/latest/octocrab/markdown/struct.MarkdownHandler.html
 [`issues`]: https://docs.rs/octocrab/latest/octocrab/issues/struct.IssueHandler.html
 [`licenses`]: https://docs.rs/octocrab/latest/octocrab/licenses/struct.LicenseHandler.html
-[`pulls`]: https://docs.rs/octocrab/latest/octocrab/pulls/struct.PullRequestHandler.html
+[`markdown`]: https://docs.rs/octocrab/latest/octocrab/markdown/struct.MarkdownHandler.html
 [`orgs`]: https://docs.rs/octocrab/latest/octocrab/orgs/struct.OrgHandler.html
+[`projects`]: https://docs.rs/octocrab/latest/octocrab/projects/struct.ProjectsHandler.html
+[`pulls`]: https://docs.rs/octocrab/latest/octocrab/pulls/struct.PullRequestHandler.html
+[`ratelimit`]: https://docs.rs/octocrab/latest/octocrab/ratelimit/struct.RateLimitHandler.html
 [`repos`]: https://docs.rs/octocrab/latest/octocrab/repos/struct.RepoHandler.html
-[`releases`]: https://docs.rs/octocrab/latest/octocrab/repos/struct.ReleasesHandler.html
 [`search`]: https://docs.rs/octocrab/latest/octocrab/search/struct.SearchHandler.html
 [`teams`]: https://docs.rs/octocrab/latest/octocrab/teams/struct.TeamHandler.html
-[`gists`]: https://docs.rs/octocrab/latest/octocrab/gists/struct.GistsHandler.html
-[`users`]: https://docs.rs/octocrab/latest/octocrab/gists/struct.UsersHandler.html
+[`users`]: https://docs.rs/octocrab/latest/octocrab/users/struct.UsersHandler.html
 
 #### Getting a Pull Request
 ```rust
@@ -190,4 +201,33 @@ octocrab::initialise(octocrab::Octocrab::builder());
 let octocrab = octocrab::instance();
 ```
 
+## GitHub Webhook Support
 
+`octocrab` provides [deserializable datatypes](https://docs.rs/octocrab/latest/octocrab/models/webhook_events/index.html)
+for the payloads received by a GitHub application [responding to
+webhooks](https://docs.github.com/en/apps/creating-github-apps/writing-code-for-a-github-app/building-a-github-app-that-responds-to-webhook-events).
+This allows you to write a typesafe application using Rust with
+pattern-matching/enum-dispatch to respond to events.
+
+**Note**: Webhook support in `octocrab` is still beta, not all known webhook events are
+strongly typed.
+
+```rust
+use http::request::Request;
+use tracing::{warn, info};
+use octocrab::models::webhook_events::*;
+
+let request_from_github = Request::post("https://my-webhook-url.com").body(vec![0_u8]).unwrap();
+// request_from_github is the HTTP request your webhook handler received
+let (parts, body) = request_from_github.into_parts();
+let header = parts.headers.get("X-GitHub-Event").unwrap().to_str().unwrap();
+
+let event = WebhookEvent::try_from_header_and_body(header, &body).unwrap();
+// Now you can match on event type and call any specific handling logic
+match event.kind {
+    WebhookEventType::Ping => info!("Received a ping"),
+    WebhookEventType::PullRequest => info!("Received a pull request event"),
+    // ...
+    _ => warn!("Ignored event"),
+};
+```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cargo add octocrab
 The semantic API provides strong typing around GitHub's API, a set of
 [`models`] that maps to GitHub's types, and [`auth`] functions that are useful
 for GitHub apps.
-Currently, the following modules are available as of version `0.17`.
+Currently, the following modules are available as of version `0.44`.
 
 - [`actions`] GitHub Actions.
 - [`apps`] GitHub Apps.

--- a/src/api/checks.rs
+++ b/src/api/checks.rs
@@ -449,7 +449,7 @@ impl<'octo> ChecksHandler<'octo> {
     }
 
     ///Lists check suites for a commit ref.
-    ///See https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#list-check-suites-for-a-git-reference
+    ///See <https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#list-check-suites-for-a-git-reference>
     ///```no_run
     /// use octocrab::models::checks::ListCheckSuites;
     /// use octocrab::params::repos::Commitish;
@@ -527,7 +527,7 @@ impl<'octo> ChecksHandler<'octo> {
     }
 
     /// Changes the default automatic flow when creating check suites. By default, a check suite is automatically created each time code is pushed to a repository. When you disable the automatic creation of check suites, you can manually Create a check suite. You must have admin permissions in the repository to set preferences for check suites.
-    /// see https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#update-repository-preferences-for-check-suites
+    /// see <https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#update-repository-preferences-for-check-suites>
     /// ```no_run
     /// use octocrab::models::{AppId, checks::AutoTriggerCheck};
     /// use octocrab::models::checks::CheckSuitePreferences;
@@ -551,7 +551,7 @@ impl<'octo> ChecksHandler<'octo> {
     }
 
     /// Gets a single check suite using its id.
-    /// See https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#get-a-check-suite
+    /// See <https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#get-a-check-suite>
     /// ```no_run
     /// use octocrab::models::checks::CheckSuite;
     /// use octocrab::models::CheckSuiteId;
@@ -569,7 +569,7 @@ impl<'octo> ChecksHandler<'octo> {
     }
 
     ///Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository.
-    ///See https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#rerequest-a-check-suite
+    ///See <https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#rerequest-a-check-suite>
     ///```no_run
     /// use octocrab::models::CheckSuiteId;
     ///  async fn run() -> octocrab::Result<()> {
@@ -589,7 +589,7 @@ impl<'octo> ChecksHandler<'octo> {
     }
 
     ///Triggers GitHub to rerequest an existing check run, without pushing new code to a repository.
-    ///See https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#rerequest-a-check-run
+    ///See <https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#rerequest-a-check-run>
     ///```no_run
     /// use octocrab::models::CheckRunId;
     ///  async fn run() -> octocrab::Result<()> {
@@ -609,7 +609,7 @@ impl<'octo> ChecksHandler<'octo> {
     }
 
     ///Lists annotations for a check run using the annotation id.
-    ///See https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-run-annotations
+    ///See <https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-run-annotations>
     ///```no_run
     /// use octocrab::models::CheckRunId;
     /// use octocrab::params::checks::CheckRunAnnotation;
@@ -686,7 +686,7 @@ impl<'octo, 'r> CheckSuitePreferencesBuilder<'octo, 'r> {
     }
 
     /// Sends the actual request of [`ChecksHandler.update_preferences()`]
-    /// see https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#update-repository-preferences-for-check-suites
+    /// see <https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#update-repository-preferences-for-check-suites>
     ///
     /// [`ChecksHandler.update_preferences()`]: ChecksHandler#method.update_preferences()
     pub async fn send(self) -> Result<CheckSuitePreferences> {
@@ -715,7 +715,7 @@ impl<'octo, 'r> GetCheckSuiteBuilder<'octo, 'r> {
     }
 
     /// Sends the actual request of [`ChecksHandler.get_check_suite()`]
-    /// see https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#get-a-check-suite
+    /// see <https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#get-a-check-suite>
     ///
     /// [`ChecksHandler.get_check_suite()`]: ChecksHandler#method.get_check_suite()
     pub async fn send(self) -> Result<CheckSuite> {
@@ -745,7 +745,7 @@ impl<'octo, 'r> crate::checks::RerequestCheckSuiteBuilder<'octo, 'r> {
     }
 
     /// Sends the actual request of [`ChecksHandler.rerequest_check_suite()`]
-    /// see https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#rerequest-a-check-suite
+    /// see <https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#rerequest-a-check-suite>
     ///
     /// [`ChecksHandler.rerequest_check_suite()`]: ChecksHandler#method.rerequest_check_suite()
     pub async fn send(self) -> Result<()> {
@@ -780,7 +780,7 @@ impl<'octo, 'r> crate::checks::RerequestCheckRunBuilder<'octo, 'r> {
     }
 
     /// Sends the actual request of [`ChecksHandler.rerequest_check_run()`]
-    /// see https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#rerequest-a-check-run
+    /// see <https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#rerequest-a-check-run>
     ///
     /// [`ChecksHandler.rerequest_check_run()`]: ChecksHandler#method.rerequest_check_run()
     pub async fn send(self) -> Result<()> {
@@ -819,7 +819,7 @@ impl<'octo, 'r> crate::checks::CheckRunAnnotationsBuilder<'octo, 'r> {
     }
 
     /// Sends the actual request of [`ChecksHandler.list_annotations()`]
-    /// see https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-run-annotations
+    /// see <https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-run-annotations>
     ///
     /// [`ChecksHandler.list_annotations()`]: ChecksHandler#method.list_annotations()
     pub async fn send(self) -> Result<Vec<CheckRunAnnotation>> {

--- a/src/api/checks.rs
+++ b/src/api/checks.rs
@@ -372,7 +372,7 @@ impl<'octo, 'r> crate::checks::ListCheckSuitesForGitRefBuilder<'octo, 'r> {
     }
 
     /// Send the actual request to /repos/{owner}/{repo}/commits/{ref}/check-suites
-    /// See https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#list-check-suites-for-a-git-reference
+    /// See <https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#list-check-suites-for-a-git-reference>
     pub async fn send(self) -> Result<models::checks::ListCheckSuites> {
         let route = format!(
             "/repos/{owner}/{repo}/commits/{ref}/check-suites",
@@ -507,7 +507,7 @@ impl<'octo> ChecksHandler<'octo> {
         UpdateCheckRunBuilder::new(self, check_run_id)
     }
 
-    /// Creates a check suite manually. see https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#create-a-check-suite
+    /// Creates a check suite manually. see <https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#create-a-check-suite>
     /// ```no_run
     /// use octocrab::models::checks::CheckSuite;
     ///  async fn run() -> octocrab::Result<CheckSuite> {

--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -129,7 +129,7 @@ impl<'octo> IssueHandler<'octo> {
 
     /// Users with push access can lock an issue or pull request's conversation.
     ///
-    /// See also: https://docs.github.com/en/rest/issues/issues#lock-an-issue
+    /// See also: <https://docs.github.com/en/rest/issues/issues#lock-an-issue>
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
     /// use octocrab::params;
@@ -170,7 +170,7 @@ impl<'octo> IssueHandler<'octo> {
 
     /// Users with push access can unlock an issue or pull request's conversation.
     ///
-    /// See also: https://docs.github.com/en/rest/issues/issues#unlock-an-issue
+    /// See also: <https://docs.github.com/en/rest/issues/issues#unlock-an-issue>
     /// ```no_run
     /// # async fn run() -> octocrab::Result<()> {
     /// assert!(octocrab::instance().issues("owner", "repo").unlock(404).await?);

--- a/src/api/orgs.rs
+++ b/src/api/orgs.rs
@@ -228,6 +228,11 @@ impl<'octo> OrgHandler<'octo> {
 
     /// Handle secrets on the organizaton
     /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let octocrab = octocrab::instance();
+    /// let secrets = octocrab.orgs("org").secrets();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn secrets(&self) -> secrets::OrgSecretsHandler<'_> {
         secrets::OrgSecretsHandler::new(self)

--- a/src/api/orgs/secrets.rs
+++ b/src/api/orgs/secrets.rs
@@ -5,7 +5,7 @@ use crate::models::orgs::secrets::{CreateOrganizationSecret, CreateOrganizationS
 
 /// A client to GitHub's organization API.
 ///
-/// Created with [`Octocrab::orgs`].
+/// Created with [`crate::Octocrab::orgs`].
 pub struct OrgSecretsHandler<'octo> {
     org: &'octo OrgHandler<'octo>,
 }

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -763,7 +763,7 @@ impl<'octo> RepoHandler<'octo> {
     }
 
     /// Creates a new Git commit object.
-    /// See https://docs.github.com/en/rest/git/commits?apiVersion=2022-11-28#create-a-commit
+    /// See <https://docs.github.com/en/rest/git/commits?apiVersion=2022-11-28#create-a-commit>
     /// ```no_run
     /// # use octocrab::models::commits::GitCommitObject;
     /// use octocrab::models::repos::CommitAuthor;

--- a/src/api/repos/dependabot.rs
+++ b/src/api/repos/dependabot.rs
@@ -2,7 +2,7 @@ use super::RepoHandler;
 
 /// A client to GitHub's repository dependabot API.
 ///
-/// Created with [`Octocrab::repos`].
+/// Created with [`RepoHandler`].
 pub struct RepoDependabotAlertsHandler<'octo> {
     handler: &'octo RepoHandler<'octo>,
     params: Params,

--- a/src/api/repos/dependabot.rs
+++ b/src/api/repos/dependabot.rs
@@ -2,7 +2,7 @@ use super::RepoHandler;
 
 /// A client to GitHub's repository dependabot API.
 ///
-/// Created with [`RepoHandler`].
+/// Created with [`Octocrab::repos`](crate::Octocrab::repos).
 pub struct RepoDependabotAlertsHandler<'octo> {
     handler: &'octo RepoHandler<'octo>,
     params: Params,

--- a/src/api/repos/releases.rs
+++ b/src/api/repos/releases.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 
 /// Handler for GitHub's releases API.
 ///
-/// Created with [`RepoHandler::releases`].
+/// Created with [`Octocrab::repos`](crate::Octocrab::repos).
 pub struct ReleasesHandler<'octo, 'r> {
     handler: &'r RepoHandler<'octo>,
 }

--- a/src/api/repos/secret_scanning_alerts.rs
+++ b/src/api/repos/secret_scanning_alerts.rs
@@ -2,7 +2,7 @@ use super::RepoHandler;
 
 /// A client to GitHub's repository Secret Scanning API.
 ///
-/// Created with [`Octocrab::repos`].
+/// Created with [`RepoHandler`].
 pub struct RepoSecretScanningAlertsHandler<'octo> {
     handler: &'octo RepoHandler<'octo>,
     params: Params,

--- a/src/api/repos/secret_scanning_alerts.rs
+++ b/src/api/repos/secret_scanning_alerts.rs
@@ -2,7 +2,7 @@ use super::RepoHandler;
 
 /// A client to GitHub's repository Secret Scanning API.
 ///
-/// Created with [`RepoHandler`].
+/// Created with [`Octocrab::repos`](crate::Octocrab::repos).
 pub struct RepoSecretScanningAlertsHandler<'octo> {
     handler: &'octo RepoHandler<'octo>,
     params: Params,

--- a/src/api/repos/secrets.rs
+++ b/src/api/repos/secrets.rs
@@ -5,7 +5,7 @@ use crate::models::repos::secrets::{CreateRepositorySecret, CreateRepositorySecr
 
 /// A client to GitHub's repository secrets API.
 ///
-/// Created with [`Octocrab::repos`].
+/// Created with [`RepoHandler`].
 pub struct RepoSecretsHandler<'octo> {
     handler: &'octo RepoHandler<'octo>,
 }

--- a/src/api/repos/status.rs
+++ b/src/api/repos/status.rs
@@ -48,7 +48,7 @@ impl<'octo, 'r> CreateStatusBuilder<'octo, 'r> {
 
     /// The target URL to associate with this status. This URL will be linked from the GitHub UI to allow users to easily see the source of the status.  
     /// For example, if your continuous integration system is posting build status, you would want to provide the deep link for the build output for this specific SHA:
-    /// http://ci.example.com/user/repo/build/sha
+    /// <http://ci.example.com/user/repo/build/sha>
     pub fn target(mut self, target: String) -> Self {
         self.target_url = Some(target);
         self

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -40,6 +40,9 @@ impl std::fmt::Display for UserRef {
     }
 }
 
+/// Handler for GitHub's users API.
+///
+/// Created with [`Octocrab::users`].
 pub struct UserHandler<'octo> {
     crab: &'octo Octocrab,
     user: UserRef,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -57,7 +57,7 @@ impl Default for Auth {
 
 /// Create a JSON Web Token that can be used to authenticate an a GitHub application.
 ///
-/// See: https://docs.github.com/en/developers/apps/getting-started-with-apps/setting-up-your-development-environment-to-create-a-github-app#authenticating-as-a-github-app
+/// See: <https://docs.github.com/en/developers/apps/getting-started-with-apps/setting-up-your-development-environment-to-create-a-github-app#authenticating-as-a-github-app>
 pub fn create_jwt(
     github_app_id: AppId,
     key: &EncodingKey,
@@ -132,7 +132,7 @@ impl From<OAuthWire> for OAuth {
 impl crate::Octocrab {
     /// Authenticate with Github's device flow. This starts the process to obtain a new `OAuth`.
     ///
-    /// See https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#device-flow for details.
+    /// See <https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#device-flow> for details.
     ///
     /// Note: To authenticate against public Github, the `Octocrab` that calls this method
     /// *must* be constructed with `base_uri: "https://github.com"` and extra header
@@ -179,7 +179,7 @@ impl crate::Octocrab {
 
 /// The device codes as returned from step 1 of Github's device flow.
 ///
-/// See https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#response-parameters
+/// See <https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#response-parameters>
 #[derive(Deserialize, Clone)]
 #[non_exhaustive]
 pub struct DeviceCodes {
@@ -188,13 +188,13 @@ pub struct DeviceCodes {
     /// The user verification code is displayed on the device so the user can enter the
     /// code in a browser. This code is 8 characters with a hyphen in the middle.
     pub user_code: String,
-    /// The verification URL where users need to enter the user_code: https://github.com/login/device.
+    /// The verification URL where users need to enter the user_code: <https://github.com/login/device>
     pub verification_uri: String,
     /// The number of seconds before the device_code and user_code expire. The default is
     /// 900 seconds or 15 minutes.
     pub expires_in: u64,
     /// The minimum number of seconds that must pass before you can make a new access
-    /// token request (POST https://github.com/login/oauth/access_token) to complete the
+    /// token request (POST <https://github.com/login/oauth/access_token>) to complete the
     /// device authorization. For example, if the interval is 5, then you cannot make a
     /// new request until 5 seconds pass. If you make more than one request over 5
     /// seconds, then you will hit the rate limit and receive a slow_down error.
@@ -280,14 +280,14 @@ enum TokenResponse {
 pub enum Continue {
     /// When you receive the slow_down error, 5 extra seconds are added to the minimum
     /// interval or timeframe required between your requests using POST
-    /// https://github.com/login/oauth/access_token. For example, if the starting interval
+    /// <https://github.com/login/oauth/access_token>. For example, if the starting interval
     /// required at least 5 seconds between requests and you get a slow_down error response,
     /// you must now wait a minimum of 10 seconds before making a new request for an OAuth
     /// access token. The error response includes the new interval that you must use.
     SlowDown,
     /// This error occurs when the authorization request is pending and the user hasn't
     /// entered the user code yet. The app is expected to keep polling the POST
-    /// https://github.com/login/oauth/access_token request without exceeding the
+    /// <https://github.com/login/oauth/access_token> request without exceeding the
     /// interval, which requires a minimum number of seconds between each request.
     AuthorizationPending,
 }
@@ -296,7 +296,7 @@ pub enum Continue {
 struct PollForDevice<'a> {
     /// Required. The client ID you received from GitHub for your OAuth App.
     client_id: &'a str,
-    /// Required. The device verification code you received from the POST https://github.com/login/device/code request.
+    /// Required. The device verification code you received from the POST <https://github.com/login/device/code> request.
     device_code: &'a str,
     /// Required. The grant type must be urn:ietf:params:oauth:grant-type:device_code.
     grant_type: &'static str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,7 @@ where
     B: http_body::Body<Data = bytes::Bytes> + Send + Sync + 'static,
     B::Error: Into<BoxError>,
 {
-    /// Build a [`Client`] instance with the current [`Service`] stack.
+    /// Build a [`Client`](OctocrabService) instance with the current [`Service`] stack.
     pub fn build(self) -> Result<Octocrab, Infallible> {
         // Transform response body to `BoxBody<Bytes, crate::Error>` and use type erased error to avoid type parameters.
         let service = MapResponseBodyLayer::new(|b: B| {
@@ -688,7 +688,7 @@ impl OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>
         connector
     }
 
-    /// Build a [`Client`] instance with the current [`Service`] stack.
+    /// Build a [`Client`](hyper_util::client::legacy::Client) instance with the current [`Service`] stack.
     #[cfg(feature = "default-client")]
     #[cfg_attr(docsrs, doc(cfg(feature = "default-client")))]
     pub fn build(self) -> Result<Octocrab> {
@@ -1119,7 +1119,7 @@ impl Octocrab {
     /// https git requests to e.g. clone repositories that the installation
     /// has access to.
     ///
-    /// See also https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#http-based-git-access-by-an-installation
+    /// See also <https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#http-based-git-access-by-an-installation>
     pub async fn installation_and_token(
         &self,
         id: InstallationId,
@@ -1132,7 +1132,7 @@ impl Octocrab {
     /// Returns a new `Octocrab` based on the current builder but
     /// authorizing via an access token.
     ///
-    /// See also https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app
+    /// See also <https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app>
     pub fn user_access_token<S: Into<SecretString>>(&self, token: S) -> Result<Self> {
         Ok(Octocrab {
             client: self.client.clone(),
@@ -1189,7 +1189,7 @@ impl Octocrab {
         issues::IssueHandler::new(self, RepoRef::ById(id.into()))
     }
 
-    /// Creates a [`code_scanning::CodeSCanningHandler`] for the repo specified at `owner/repo`,
+    /// Creates a [`code_scannings::CodeScanningHandler`] for the repo specified at `owner/repo`,
     /// that allows you to access GitHub's Code scanning API.
     pub fn code_scannings(
         &self,
@@ -1199,7 +1199,7 @@ impl Octocrab {
         code_scannings::CodeScanningHandler::new(self, owner.into(), Option::from(repo.into()))
     }
 
-    /// Creates a [`code_scanning::CodeSCanningHandler`] for the org specified at `owner`,
+    /// Creates a [`code_scannings::CodeScanningHandler`] for the org specified at `owner`,
     /// that allows you to access GitHub's Code scanning API.
     pub fn code_scannings_organisation(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 //! - [`activity`] GitHub Activity
 //! - [`apps`] GitHub Apps
 //! - [`checks`] GitHub Checks
+//! - [`code_scannings`] Code Scanning
 //! - [`commits`] GitHub Commits
 //! - [`current`] Information about the current user.
 //! - [`events`] GitHub Events
@@ -32,7 +33,6 @@
 //! - [`search`] Using GitHub's search.
 //! - [`teams`] Teams
 //! - [`users`] Users
-//! - [`code_scannings`] Code Scanning
 //!
 //! #### Getting a Pull Request
 //! ```no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,14 @@
 //! set of [`models`] that maps to GitHub's types. Currently the following
 //! modules are available.
 //!
-//! - [`activity`] GitHub Activity
 //! - [`actions`] GitHub Actions
+//! - [`activity`] GitHub Activity
 //! - [`apps`] GitHub Apps
+//! - [`checks`] GitHub Checks
+//! - [`commits`] GitHub Commits
 //! - [`current`] Information about the current user.
+//! - [`events`] GitHub Events
+//! - [`gists`] Gists
 //! - [`gitignore`] Gitignore templates
 //! - [`Octocrab::graphql`] GraphQL.
 //! - [`issues`] Issues and related items, e.g. comments, labels, etc.
@@ -21,12 +25,14 @@
 //! - [`orgs`] GitHub Organisations
 //! - [`projects`] GitHub Projects
 //! - [`pulls`] Pull Requests
+//! - [`ratelimit`] Rate Limiting
 //! - [`repos`] Repositories
-//! - [`repos::forks`] Repositories
-//! - [`repos::releases`] Repositories
+//! - [`repos::forks`] Repository forks
+//! - [`repos::releases`] Repository releases
 //! - [`search`] Using GitHub's search.
 //! - [`teams`] Teams
 //! - [`users`] Users
+//! - [`code_scannings`] Code Scanning
 //!
 //! #### Getting a Pull Request
 //! ```no_run
@@ -130,6 +136,21 @@
 //!
 //! You can also easily access new properties that aren't available in the
 //! current models using `serde`.
+//!
+//! ```no_run
+//! #[derive(Deserialize)]
+//! struct RepositoryWithVisibility {
+//!     #[serde(flatten)]
+//!     inner: octocrab::models::Repository,
+//!     visibility: String,
+//! }
+//!
+//! let my_repo = octocrab::instance()
+//!     .get::<RepositoryWithVisibility>("https://api.github.com/repos/XAMPPRocky/octocrab", None::<&()>)
+//!     .await?;
+//! ```
+//!
+//!
 //!
 //! ## Static API
 //! `octocrab` also provides a statically reference count version of its API,
@@ -251,14 +272,14 @@ use crate::service::middleware::extra_headers::ExtraHeadersLayer;
 #[cfg(feature = "retry")]
 use crate::service::middleware::retry::RetryConfig;
 
-use crate::api::{code_scannings, users};
 use auth::{AppAuth, Auth};
 use models::{AppId, InstallationId, InstallationToken, RepositoryId, UserId};
 
 pub use self::{
     api::{
-        actions, activity, apps, checks, commits, current, events, gists, gitignore, hooks, issues,
-        licenses, markdown, orgs, projects, pulls, ratelimit, repos, search, teams, workflows,
+        actions, activity, apps, checks, code_scannings, commits, current, events, gists,
+        gitignore, hooks, issues, licenses, markdown, orgs, projects, pulls, ratelimit, repos,
+        search, teams, users, workflows,
     },
     error::{Error, GitHubError},
     from_response::FromResponse,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,8 @@
 //! current models using `serde`.
 //!
 //! ```no_run
+//! use serde::Deserialize;
+//!
 //! #[derive(Deserialize)]
 //! struct RepositoryWithVisibility {
 //!     #[serde(flatten)]
@@ -145,9 +147,13 @@
 //!     visibility: String,
 //! }
 //!
+//!
+//! # async fn run() -> octocrab::Result<()> {
 //! let my_repo = octocrab::instance()
-//!     .get::<RepositoryWithVisibility>("https://api.github.com/repos/XAMPPRocky/octocrab", None::<&()>)
+//!     .get::<RepositoryWithVisibility, _, _>("https://api.github.com/repos/XAMPPRocky/octocrab", None::<&()>)
 //!     .await?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //!

--- a/src/models.rs
+++ b/src/models.rs
@@ -176,7 +176,7 @@ pub struct Contents {
 }
 
 /// Issue events are triggered by activity in issues and pull requests.
-/// https://docs.github.com/en/webhooks-and-events/events/issue-event-types
+/// <https://docs.github.com/en/webhooks-and-events/events/issue-event-types>
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]

--- a/src/models/events/payload.rs
+++ b/src/models/events/payload.rs
@@ -75,7 +75,7 @@ pub struct WrappedEventPayload {
 ///
 /// Different event types have different payloads. Any event type not specifically part
 /// of this enum will be captured in the variant `UnknownEvent` with a value of
-/// [`serde_json::Value`](serde_json::Value).
+/// [`serde_json::Value`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 #[serde(untagged)]

--- a/src/models/events/payload/installation.rs
+++ b/src/models/events/payload/installation.rs
@@ -17,7 +17,7 @@ pub struct InstallationEventPayload {
     pub enterprise: Option<serde_json::Value>,
     /// An array of repositories that the installation can access
     pub repositories: Vec<InstallationEventRepository>,
-    /// The initiator of the request, mainly for the [`created`](InstallationAction::Created) action
+    /// The initiator of the request, mainly for the [`created`](crate::models::events::payload::InstallationEventAction::Created) action
     pub requester: Option<Author>,
 }
 

--- a/src/models/events/payload/installation_repositories.rs
+++ b/src/models/events/payload/installation_repositories.rs
@@ -21,7 +21,7 @@ pub struct InstallationRepositoriesEventPayload {
     pub repositories_removed: Vec<InstallationEventRepository>,
     /// Describe whether all repositories have been selected or there's a selection involved
     pub repository_selection: InstallationRepositoriesEventSelection,
-    /// The initiator of the request, mainly for the [`created`](InstallationAction::Created) action
+    /// The initiator of the request, mainly for the [`created`](crate::models::events::payload::InstallationEventAction::Created) action
     pub requester: Option<Author>,
 }
 

--- a/src/models/webhook_events.rs
+++ b/src/models/webhook_events.rs
@@ -8,7 +8,7 @@
 //! time of writing, the header is named
 //! [`X-GitHub-Event`](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#delivery-headers))
 //! and then pass the value, along with the payload, to [`WebhookEvent::try_from_header_and_body`]
-//! which will validate the payload and return a valid [`WebhookEvent`](WebhookEvent).
+//! which will validate the payload and return a valid [`WebhookEvent`].
 //!
 //! ```
 //! use octocrab::models::{AppId, webhook_events::{WebhookEvent, WebhookEventPayload, WebhookEventType}};
@@ -170,7 +170,7 @@ pub enum WebhookEventType {
     ///
     /// **Note:** The API only looks for pushes in the repository where the check run was created.
     /// Pushes to a branch in a forked repository are not detected and return an empty pull_requests
-    /// array and a null value for head_branch in the [payload](CheckRunWebhookEventPayload).
+    /// array and a null value for head_branch in the [payload](WebhookEventPayload::CheckRun).
     CheckRun,
     /// This event occurs when there is activity relating to a check suite. For information about
     /// check suites, see "Getting started with the Checks
@@ -718,7 +718,7 @@ pub enum WebhookEventType {
     WorkflowRun,
     /// A webhook event that is currently unsupported by octocrab.
     ///
-    /// When a [`WebhookEvent`](WebhookEvent) has this [kind](WebhookEvent::kind), then the
+    /// When a [`WebhookEvent`] has this [kind](WebhookEvent::kind), then the
     /// [specific](WebhookEvent::specific) payload will only be a generic `serde_json::Value`.
     #[serde(untagged)]
     Unknown(String),

--- a/src/params.rs
+++ b/src/params.rs
@@ -83,7 +83,7 @@ pub mod apps {
 
     use crate::models::RepositoryId;
 
-    /// https://docs.github.com/en/rest/reference/apps#create-an-installation-access-token-for-an-app
+    /// <https://docs.github.com/en/rest/reference/apps#create-an-installation-access-token-for-an-app>
     #[derive(Debug, Clone, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize, Default)]
     #[serde(rename_all = "snake_case")]
     #[non_exhaustive]
@@ -593,7 +593,7 @@ pub mod users {
     pub mod repos {
         /// What ownership type to filter a user repository list by.
         ///
-        /// See https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repositories-for-a-user
+        /// See <https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repositories-for-a-user>
         #[derive(Debug, Clone, Copy, serde::Serialize)]
         #[serde(rename_all = "snake_case")]
         #[non_exhaustive]


### PR DESCRIPTION
I went ahead and revamped the documentation, since a few modules were not being exported properly (like `users`) and other parts of the docs had broken links or weren't up to date with the latest features.

Closes #759, and almost all the warnings generated by `cargo docs`.

To test the resulting output, you can run `RUSTDOCFLAGS="--cfg docsrs" rustup run nightly cargo doc --all-features --no-deps --open`.

Thanks for creating Octocrab. Looking forward to upstreaming some more improvements in the future, like getting the API abstractions up to parity with Github.

As an aside, if you are open to a new source of funding for your open source work, we'd love to chat. Please feel free to reach out to me directly through twitter or my email on my website.