### PR TITLE
models: Add optional `name` field to `Author` struct

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -422,6 +422,7 @@ pub struct Author {
     pub received_events_url: Url,
     pub r#type: String,
     pub site_admin: bool,
+    pub name: Option<String>,
     pub patch_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,


### PR DESCRIPTION
The optional field `name` was missing as I mentioned in #770.
This has now been added, not all fields are added, think about `company`, `location`, and others as [listed here](https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-the-authenticated-user).

I will leave it up to you if you find it valuable to have them added :)

I ran the tests, everything passed, as far as I saw, nothing should be broken from just this... Please let me know if I missed that lol