### PR TITLE
fix: Commit search endpoint uses wrong type for deserialization

### DIFF
--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -50,7 +50,7 @@ impl<'octo> SearchHandler<'octo> {
     pub fn commits<'query>(
         self,
         query: &'query (impl AsRef<str> + ?Sized),
-    ) -> QueryHandler<'octo, 'query, models::repos::Commit> {
+    ) -> QueryHandler<'octo, 'query, models::commits::Commit> {
         QueryHandler::new(self.crab, "commits", query.as_ref())
     }
 


### PR DESCRIPTION
In `models::repo::Commit`, `author` which is of type `CommitAuthor` (https://github.com/XAMPPRocky/octocrab/blob/main/src/models/repos.rs#L160) has a non-optional name field. But this was causing crashes for me with the error `Serde error: missing field 'name'` as Github does not return the author name here (`name` is also not present in the example response in the Github docs for this endpoint either: https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-commits). `models::commits::Commit` works for me locally.