### PR TITLE
cargo clippy --fix

### DIFF
--- a/examples/create_org_secret.rs
+++ b/examples/create_org_secret.rs
@@ -36,7 +36,7 @@ async fn main() -> octocrab::Result<()> {
         )
         .await?;
 
-    println!("{:?}", result);
+    println!("{result:?}");
 
     Ok(())
 }

--- a/examples/create_repo_secret.rs
+++ b/examples/create_repo_secret.rs
@@ -31,7 +31,7 @@ async fn main() -> octocrab::Result<()> {
         )
         .await?;
 
-    println!("{:?}", result);
+    println!("{result:?}");
 
     Ok(())
 }

--- a/examples/get_code_scanning_alerts.rs
+++ b/examples/get_code_scanning_alerts.rs
@@ -41,14 +41,14 @@ async fn main() {
         .send()
         .await
         .unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
     // Get a single Code Scanning alert
     let single_alert = octocrab
         .code_scannings(OWNER.to_owned(), REPO.to_owned())
         .get(1)
         .await
         .unwrap();
-    println!("{:?}", single_alert);
+    println!("{single_alert:?}");
     // Update (Open) a Code Scanning alert
     let updated_alert = octocrab
         .code_scannings(OWNER.to_owned(), REPO.to_owned())
@@ -57,5 +57,5 @@ async fn main() {
         .send()
         .await
         .unwrap();
-    println!("{:?}", updated_alert);
+    println!("{updated_alert:?}");
 }

--- a/examples/get_dependabot_alerts.rs
+++ b/examples/get_dependabot_alerts.rs
@@ -42,7 +42,7 @@ async fn main() {
         .get_alerts()
         .await
         .unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
     // Get a single Dependabot alert
     let single_alert = octocrab
         .repos(OWNER, REPO)
@@ -50,7 +50,7 @@ async fn main() {
         .get_alert(5)
         .await
         .unwrap();
-    println!("{:?}", single_alert);
+    println!("{single_alert:?}");
     // Update (dismiss) a Dependabot alert
     let updated_alert = octocrab
         .repos(OWNER, REPO)
@@ -65,5 +65,5 @@ async fn main() {
         )
         .await
         .unwrap();
-    println!("{:?}", updated_alert);
+    println!("{updated_alert:?}");
 }

--- a/examples/get_secret_scanning_alerts.rs
+++ b/examples/get_secret_scanning_alerts.rs
@@ -42,7 +42,7 @@ async fn main() {
         .get_alerts()
         .await
         .unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
     // Get a single Secret Scanning alert
     let single_alert = octocrab
         .repos(OWNER, REPO)
@@ -50,7 +50,7 @@ async fn main() {
         .get_alert(5)
         .await
         .unwrap();
-    println!("{:?}", single_alert);
+    println!("{single_alert:?}");
     // Update (dismiss) a Secret Scanning alert
     let updated_alert = octocrab
         .repos(OWNER, REPO)
@@ -65,7 +65,7 @@ async fn main() {
         )
         .await
         .unwrap();
-    println!("{:?}", updated_alert);
+    println!("{updated_alert:?}");
 
     // Get alert locations
     let alert_location = octocrab
@@ -74,5 +74,5 @@ async fn main() {
         .get_alert_locations(5)
         .await
         .unwrap();
-    println!("{:?}", alert_location);
+    println!("{alert_location:?}");
 }

--- a/examples/star_unstar_a_gist.rs
+++ b/examples/star_unstar_a_gist.rs
@@ -17,12 +17,12 @@ fn parse_argv_or_exit() -> ProgramArguments {
             false
         } else {
             eprintln!("error: Need (--star | --unstar) as first argument.");
-            eprintln!("{}", USAGE);
+            eprintln!("{USAGE}");
             std::process::exit(1);
         }
     } else {
         eprintln!("error: Need (--star | --unstar) as first argument.");
-        eprintln!("{}", USAGE);
+        eprintln!("{USAGE}");
         std::process::exit(1);
     };
 
@@ -30,7 +30,7 @@ fn parse_argv_or_exit() -> ProgramArguments {
         gist_id
     } else {
         eprintln!("error: Need GIST_ID as second argument.");
-        eprintln!("{}", USAGE);
+        eprintln!("{USAGE}");
         std::process::exit(1);
     };
     ProgramArguments { gist_id, star }

--- a/src/api/commits/associated_pull_requests.rs
+++ b/src/api/commits/associated_pull_requests.rs
@@ -13,8 +13,8 @@ pub enum PullRequestTarget {
 impl Display for PullRequestTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Branch(branch) => write!(f, "{}", branch),
-            Self::Sha(commit) => write!(f, "{}", commit),
+            Self::Branch(branch) => write!(f, "{branch}"),
+            Self::Sha(commit) => write!(f, "{commit}"),
         }
     }
 }

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -59,8 +59,8 @@ pub(crate) enum RepoRef {
 impl std::fmt::Display for RepoRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RepoRef::ByOwnerAndName(owner, name) => write!(f, "repos/{}/{}", owner, name),
-            RepoRef::ById(id) => write!(f, "repositories/{}", id),
+            RepoRef::ByOwnerAndName(owner, name) => write!(f, "repos/{owner}/{name}"),
+            RepoRef::ById(id) => write!(f, "repositories/{id}"),
         }
     }
 }

--- a/src/api/repos/releases.rs
+++ b/src/api/repos/releases.rs
@@ -715,7 +715,7 @@ impl<'octo, 'repos, 'handler, 'name, 'label>
             self.name
         );
         if let Some(label) = self.label {
-            base_uri = format!("{}&label={}", base_uri, label);
+            base_uri = format!("{base_uri}&label={label}");
         }
 
         let url: Uri = base_uri

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -33,9 +33,9 @@ pub(crate) enum UserRef {
 impl std::fmt::Display for UserRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UserRef::ByString(str) => write!(f, "users/{}", str),
+            UserRef::ByString(str) => write!(f, "users/{str}"),
 
-            UserRef::ById(id) => write!(f, "user/{}", id),
+            UserRef::ById(id) => write!(f, "user/{id}"),
         }
     }
 }
@@ -97,7 +97,7 @@ impl<'octo> UserHandler<'octo> {
     ///    Ok(is_blocked)
     ///  }
     pub async fn is_blocked(&self, username: &str) -> crate::Result<bool> {
-        let route = format!("/user/blocks/{}", username);
+        let route = format!("/user/blocks/{username}");
         let response = self.crab._get(route).await?;
         Ok(response.status() == 204)
     }
@@ -117,7 +117,7 @@ impl<'octo> UserHandler<'octo> {
     ///    .await
     ///  }
     pub async fn block_user(&self, username: &str) -> crate::Result<()> {
-        let route = format!("/user/blocks/{}", username);
+        let route = format!("/user/blocks/{username}");
         /* '204 not found' is returned if user blocked */
         let result: crate::Result<()> = self.crab.put(route, None::<&()>).await;
         match result {
@@ -149,7 +149,7 @@ impl<'octo> UserHandler<'octo> {
     ///    .await
     ///  }
     pub async fn unblock_user(&self, username: &str) -> crate::Result<()> {
-        let route = format!("/user/blocks/{}", username);
+        let route = format!("/user/blocks/{username}");
 
         self.crab.delete(route, None::<&()>).await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1704,8 +1704,7 @@ impl Octocrab {
                 let mut buf = b"Basic ".to_vec();
                 {
                     let mut encoder = EncoderWriter::new(&mut buf, &BASE64_STANDARD);
-                    write!(encoder, "{}:{}", username, password)
-                        .expect("writing to a Vec never fails");
+                    write!(encoder, "{username}:{password}").expect("writing to a Vec never fails");
                 }
                 Some(HeaderValue::from_bytes(&buf).expect("base64 is always valid HeaderValue"))
             }

--- a/src/page.rs
+++ b/src/page.rs
@@ -277,8 +277,7 @@ fn get_links(headers: &http::header::HeaderMap) -> crate::Result<HeaderLinks> {
                             "next" => next = Some(Uri::from_str(url).context(UriSnafu)?),
                             "last" => last = Some(Uri::from_str(url).context(UriSnafu)?),
                             other => eprint!(
-                                "INFO: Received unexpected 'rel' attribute in 'Link' header: \"{}\"",
-                                other
+                                "INFO: Received unexpected 'rel' attribute in 'Link' header: \"{other}\""
                             ),
                         }
                     }

--- a/tests/code_scanning_alert_update_test.rs
+++ b/tests/code_scanning_alert_update_test.rs
@@ -19,9 +19,7 @@ async fn setup_issue_check_assignee_api(template: ResponseTemplate) -> MockServe
 
     Mock::given(method("PATCH"))
         .and(path(format!(
-            "/repos/{owner}/{repo}/code-scanning/alerts/{number}",
-            owner = owner,
-            repo = repo
+            "/repos/{owner}/{repo}/code-scanning/alerts/{number}"
         )))
         .respond_with(template.clone())
         .mount(&mock_server)

--- a/tests/code_scanning_alerts_list_test.rs
+++ b/tests/code_scanning_alerts_list_test.rs
@@ -17,38 +17,24 @@ async fn setup_codescanning_list_api(template: ResponseTemplate, is_org: bool) -
 
     if is_org {
         Mock::given(method("GET"))
-            .and(path(format!(
-                "/orgs/{owner}/code-scanning/alerts",
-                owner = OWNER
-            )))
+            .and(path(format!("/orgs/{OWNER}/code-scanning/alerts")))
             .respond_with(template.clone())
             .mount(&mock_server)
             .await;
         setup_error_handler(
             &mock_server,
-            &format!(
-                "GET on /org/{owner}/code-scanning/alerts was not received",
-                owner = OWNER
-            ),
+            &format!("GET on /org/{OWNER}/code-scanning/alerts was not received"),
         )
         .await;
     } else {
         Mock::given(method("GET"))
-            .and(path(format!(
-                "/repos/{owner}/{repo}/code-scanning/alerts",
-                owner = OWNER,
-                repo = REPO
-            )))
+            .and(path(format!("/repos/{OWNER}/{REPO}/code-scanning/alerts")))
             .respond_with(template.clone())
             .mount(&mock_server)
             .await;
         setup_error_handler(
             &mock_server,
-            &format!(
-                "GET on /repos/{owner}/{repo}/code-scanning/alerts was not received",
-                owner = OWNER,
-                repo = REPO
-            ),
+            &format!("GET on /repos/{OWNER}/{REPO}/code-scanning/alerts was not received"),
         )
         .await;
     }

--- a/tests/code_scanning_analysis_test.rs
+++ b/tests/code_scanning_analysis_test.rs
@@ -19,9 +19,7 @@ async fn setup_issue_check_assignee_api(template: ResponseTemplate) -> MockServe
 
     Mock::given(method("GET"))
         .and(path(format!(
-            "/repos/{owner}/{repo}/code-scanning/alerts/{number}",
-            owner = owner,
-            repo = repo
+            "/repos/{owner}/{repo}/code-scanning/alerts/{number}"
         )))
         .respond_with(template.clone())
         .mount(&mock_server)

--- a/tests/dependabot_alerts_test.rs
+++ b/tests/dependabot_alerts_test.rs
@@ -16,21 +16,13 @@ async fn setup_dependabot_api(template: ResponseTemplate) -> MockServer {
     let mock_server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path(format!(
-            "/repos/{owner}/{repo}/dependabot/alerts",
-            owner = OWNER,
-            repo = REPO
-        )))
+        .and(path(format!("/repos/{OWNER}/{REPO}/dependabot/alerts")))
         .respond_with(template.clone())
         .mount(&mock_server)
         .await;
     setup_error_handler(
         &mock_server,
-        &format!(
-            "GET on /repos/{owner}/{repo}/dependabot/alerts was not received",
-            owner = OWNER,
-            repo = REPO
-        ),
+        &format!("GET on /repos/{OWNER}/{REPO}/dependabot/alerts was not received"),
     )
     .await;
 

--- a/tests/repos_commit_test.rs
+++ b/tests/repos_commit_test.rs
@@ -64,7 +64,7 @@ async fn should_return_list_of_commits() {
     );
 
     result.iter().for_each(|commit| {
-        println!("Commit = {:#?}", commit);
+        println!("Commit = {commit:#?}");
         assert!(
             commit.sha == "24606b5f326a1356f031dd06431cfb0beddd475f",
             "expected '24606b5f326a1356f031dd06431cfb0beddd475f' value, got {:#?}",

--- a/tests/secrets_alerts_test.rs
+++ b/tests/secrets_alerts_test.rs
@@ -19,20 +19,14 @@ async fn setup_secrets_api(template: ResponseTemplate) -> MockServer {
 
     Mock::given(method("GET"))
         .and(path(format!(
-            "/repos/{owner}/{repo}/secret-scanning/alerts",
-            owner = OWNER,
-            repo = REPO
+            "/repos/{OWNER}/{REPO}/secret-scanning/alerts"
         )))
         .respond_with(template.clone())
         .mount(&mock_server)
         .await;
     setup_error_handler(
         &mock_server,
-        &format!(
-            "GET on /repos/{owner}/{repo}/secret-scanning/alerts was not received",
-            owner = OWNER,
-            repo = REPO
-        ),
+        &format!("GET on /repos/{OWNER}/{REPO}/secret-scanning/alerts was not received"),
     )
     .await;
 
@@ -44,9 +38,7 @@ async fn setup_secrets_locations_api(template: ResponseTemplate) -> MockServer {
 
     Mock::given(method("GET"))
         .and(path(format!(
-            "/repos/{owner}/{repo}/secret-scanning/alerts/5/locations",
-            owner = OWNER,
-            repo = REPO
+            "/repos/{OWNER}/{REPO}/secret-scanning/alerts/5/locations"
         )))
         .respond_with(template.clone())
         .mount(&mock_server)
@@ -54,9 +46,7 @@ async fn setup_secrets_locations_api(template: ResponseTemplate) -> MockServer {
     setup_error_handler(
         &mock_server,
         &format!(
-            "GET on /repos/{owner}/{repo}/secret-scanning/alerts/{ALERT_NUMBER}/locations was not received",
-            owner = OWNER,
-            repo = REPO
+            "GET on /repos/{OWNER}/{REPO}/secret-scanning/alerts/{ALERT_NUMBER}/locations was not received"
         ),
     )
     .await;

--- a/tests/user_blocks_tests.rs
+++ b/tests/user_blocks_tests.rs
@@ -79,7 +79,7 @@ async fn should_check_if_user_blocked() {
     let template = ResponseTemplate::new(200);
     let mock_server = setup_blocks_mock(
         "GET",
-        format!("/user/blocks/{}", NOT_BLOCKED).as_str(),
+        format!("/user/blocks/{NOT_BLOCKED}").as_str(),
         template,
     )
     .await;
@@ -94,7 +94,7 @@ async fn should_respond_user_blocked() {
     let template = ResponseTemplate::new(204);
     let mock_server = setup_blocks_mock(
         "PUT",
-        format!("/user/blocks/{}", NOT_BLOCKED).as_str(),
+        format!("/user/blocks/{NOT_BLOCKED}").as_str(),
         template,
     )
     .await;
@@ -109,7 +109,7 @@ async fn should_respond_user_unblocked() {
     let template = ResponseTemplate::new(200);
     let mock_server = setup_blocks_mock(
         "DELETE",
-        format!("/user/blocks/{}", NOT_BLOCKED).as_str(),
+        format!("/user/blocks/{NOT_BLOCKED}").as_str(),
         template,
     )
     .await;


### PR DESCRIPTION
Looking a the CI output (https://github.com/XAMPPRocky/octocrab/pull/781/checks#step:4:630) , there are some new clippy fixes available:

```
warning: `octocrab` (example "create_org_secret") generated 1 warning (run `cargo clippy --fix --example "create_org_secret"` to apply 1 suggestion)
warning: variables can be used directly in the `format!` string
  --> tests/code_scanning_alert_update_test.rs:21:19
   |
21 |           .and(path(format!(
   |  ___________________^
22 | |             "/repos/{owner}/{repo}/code-scanning/alerts/{number}",
23 | |             owner = owner,
24 | |             repo = repo
25 | |         )))
   | |_________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
   = note: `#[warn(clippy::uninlined_format_args)]` on by default
