### PR TITLE
fix!: make CommitAuthor email nullable

### DIFF
--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -287,12 +287,12 @@ impl<'octo> RepoHandler<'octo> {
     ///     .branch("master")
     ///     .commiter(CommitAuthor {
     ///         name: "Octocat".to_string(),
-    ///         email: "octocat@github.com".to_string(),
+    ///         email: Some("octocat@github.com".to_string()),
     ///         date: None,
     ///     })
     ///     .author(CommitAuthor {
     ///         name: "Ferris".to_string(),
-    ///         email: "ferris@rust-lang.org".to_string(),
+    ///         email: Some("ferris@rust-lang.org".to_string()),
     ///         date: None,
     ///     })
     ///     .send()
@@ -344,12 +344,12 @@ impl<'octo> RepoHandler<'octo> {
     ///     .branch("master")
     ///     .commiter(CommitAuthor {
     ///         name: "Octocat".to_string(),
-    ///         email: "octocat@github.com".to_string(),
+    ///         email: Some("octocat@github.com".to_string()),
     ///         date: None,
     ///     })
     ///     .author(CommitAuthor {
     ///         name: "Ferris".to_string(),
-    ///         email: "ferris@rust-lang.org".to_string(),
+    ///         email: Some("ferris@rust-lang.org".to_string()),
     ///         date: None,
     ///     })
     ///     .send()
@@ -391,12 +391,12 @@ impl<'octo> RepoHandler<'octo> {
     ///     .branch("master")
     ///     .commiter(CommitAuthor {
     ///         name: "Octocat".to_string(),
-    ///         email: "octocat@github.com".to_string(),
+    ///         email: Some("octocat@github.com".to_string()),
     ///         date: None,
     ///     })
     ///     .author(CommitAuthor {
     ///         name: "Ferris".to_string(),
-    ///         email: "ferris@rust-lang.org".to_string(),
+    ///         email: Some("ferris@rust-lang.org".to_string()),
     ///         date: None,
     ///     })
     ///     .send()
@@ -775,7 +775,7 @@ impl<'octo> RepoHandler<'octo> {
     ///     .signature("signature")
     ///     .author(CommitAuthor{
     ///             name: "name".to_owned(),
-    ///             email: "email".to_owned(),
+    ///             email: Some("email".to_owned()),
     ///             date: None
     ///         })
     ///     .send()

--- a/src/api/repos/file.rs
+++ b/src/api/repos/file.rs
@@ -221,12 +221,12 @@ mod tests {
             .branch("not-master")
             .commiter(CommitAuthor {
                 name: "Octocat".to_string(),
-                email: "octocat@github.com".to_string(),
+                email: Some("octocat@github.com".to_string()),
                 date: None,
             })
             .author(CommitAuthor {
                 name: "Ferris".to_string(),
-                email: "ferris@rust-lang.org".to_string(),
+                email: Some("ferris@rust-lang.org".to_string()),
                 date: None,
             });
 
@@ -260,12 +260,12 @@ mod tests {
             .branch("not-master")
             .commiter(CommitAuthor {
                 name: "Octocat".to_string(),
-                email: "octocat@github.com".to_string(),
+                email: Some("octocat@github.com".to_string()),
                 date: None,
             })
             .author(CommitAuthor {
                 name: "Ferris".to_string(),
-                email: "ferris@rust-lang.org".to_string(),
+                email: Some("ferris@rust-lang.org".to_string()),
                 date: None,
             });
 

--- a/src/models/events/payload/push.rs
+++ b/src/models/events/payload/push.rs
@@ -45,7 +45,7 @@ mod test {
                     commit.author,
                     CommitAuthor {
                         name: "readme-bot".to_string(),
-                        email: "readme-bot@example.com".to_string(),
+                        email: Some("readme-bot@example.com".to_string()),
                         date: None,
                     }
                 );

--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -158,7 +158,8 @@ pub struct GitUserTime {
 #[serde(rename_all = "snake_case")]
 pub struct CommitAuthor {
     pub name: String,
-    pub email: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<DateTime<Utc>>,
 }


### PR DESCRIPTION
### TL;DR issue
Currently JSON parsing breaks when handling Push Webhook events where the pusher is a bot without an email.

### Description
Currently, the Push webhook uses the `GitUserTime` (which internally use the flatten `CommitAuthor`) as the `Pusher`, which assumes that email is always present. After considering adding a new struct to represent the `Pusher`, I noticed that in the documentation it mentions that the email can be null for all the `Commiter`, `Pusher` and `Author`.

This was noticed while handling Push webhook events from [GitHub Merge Queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue), where the pusher is:
```json
"pusher": {
  "name": "github-merge-queue[bot]",
  "email": null
}
```

But also investigated and this seems to be the case for bots in general. As PRs where the pushes are done by [Renovate](https://docs.renovatebot.com/) also have the pusher as:
```json
"pusher": {
  "name": "renovate[bot]",
  "email": null
}
```

So, because of that, the suggestion here is to do the change directly on the `CommitAuthor`. This approach is a breaking change for the current API. Another solution if we want to avoid it being breaking would be to have a different type for the `Pusher` where the email is nullable/optional.

### Screenshots
<img width="678" height="953" alt="Screenshot 2025-09-18 at 11 06 48" src="https://github.com/user-attachments/assets/55186c85-ab44-49d3-bbaf-048553a77b75" />
<img width="753" height="445" alt="Screenshot 2025-09-18 at 09 50 51" src="https://github.com/user-attachments/assets/74a61203-3ef7-4d31-9d24-e671efb2c550" />


### References
- https://docs.github.com/en/webhooks/webhook-events-and-payloads#push