### PR TITLE
cargo clippy

### DIFF
--- a/src/api/apps.rs
+++ b/src/api/apps.rs
@@ -62,7 +62,7 @@ impl<'octo> AppsRequestHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn installations(&self) -> installations::InstallationsRequestBuilder {
+    pub fn installations(&self) -> installations::InstallationsRequestBuilder<'_, '_> {
         installations::InstallationsRequestBuilder::new(self)
     }
 

--- a/src/api/gists.rs
+++ b/src/api/gists.rs
@@ -246,7 +246,10 @@ impl<'octo> GistsHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn list_commits(&self, gist_id: impl Into<String>) -> list_commits::ListCommitsBuilder {
+    pub fn list_commits(
+        &self,
+        gist_id: impl Into<String>,
+    ) -> list_commits::ListCommitsBuilder<'_, '_> {
         list_commits::ListCommitsBuilder::new(self, gist_id.into())
     }
 
@@ -353,7 +356,10 @@ impl<'octo> GistsHandler<'octo> {
     /// ```
     ///
     /// [docs]: https://docs.github.com/en/rest/gists/gists?apiVersion=2022-11-28#list-gist-forks
-    pub fn list_forks(&self, gist_id: impl Into<String>) -> list_forks::ListGistForksBuilder {
+    pub fn list_forks(
+        &self,
+        gist_id: impl Into<String>,
+    ) -> list_forks::ListGistForksBuilder<'_, '_> {
         list_forks::ListGistForksBuilder::new(self, gist_id.into())
     }
 

--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -281,7 +281,7 @@ impl IssueHandler<'_> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn list_assignees(&self) -> ListAssigneesBuilder {
+    pub fn list_assignees(&self) -> ListAssigneesBuilder<'_, '_> {
         ListAssigneesBuilder::new(self)
     }
 }
@@ -469,7 +469,7 @@ impl IssueHandler<'_> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn list_labels_for_issue(&self, number: u64) -> ListLabelsForIssueBuilder {
+    pub fn list_labels_for_issue(&self, number: u64) -> ListLabelsForIssueBuilder<'_, '_> {
         ListLabelsForIssueBuilder::new(self, number)
     }
 
@@ -487,7 +487,7 @@ impl IssueHandler<'_> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn list_labels_for_repo(&self) -> ListLabelsForRepoBuilder {
+    pub fn list_labels_for_repo(&self) -> ListLabelsForRepoBuilder<'_, '_> {
         ListLabelsForRepoBuilder::new(self)
     }
 }

--- a/src/api/orgs.rs
+++ b/src/api/orgs.rs
@@ -137,7 +137,7 @@ impl<'octo> OrgHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn list_repos(&self) -> list_repos::ListReposBuilder {
+    pub fn list_repos(&self) -> list_repos::ListReposBuilder<'_, '_> {
         list_repos::ListReposBuilder::new(self)
     }
 
@@ -222,7 +222,7 @@ impl<'octo> OrgHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn list_members(&self) -> list_members::ListOrgMembersBuilder {
+    pub fn list_members(&self) -> list_members::ListOrgMembersBuilder<'_, '_> {
         list_members::ListOrgMembersBuilder::new(self)
     }
 

--- a/src/api/projects.rs
+++ b/src/api/projects.rs
@@ -90,7 +90,7 @@ impl<'octo> ProjectHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn delete_project(&self, project_id: impl Into<u32>) -> DeleteProjectBuilder {
+    pub fn delete_project(&self, project_id: impl Into<u32>) -> DeleteProjectBuilder<'_, '_> {
         DeleteProjectBuilder::new(self, project_id.into())
     }
 
@@ -113,7 +113,10 @@ impl<'octo> ProjectHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn create_user_project(&self, username: impl Into<String>) -> CreateUserProjectBuilder {
+    pub fn create_user_project(
+        &self,
+        username: impl Into<String>,
+    ) -> CreateUserProjectBuilder<'_, '_> {
         CreateUserProjectBuilder::new(self, username.into())
     }
 
@@ -134,7 +137,10 @@ impl<'octo> ProjectHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn list_user_projects(&self, username: impl Into<String>) -> ListUserProjectsBuilder {
+    pub fn list_user_projects(
+        &self,
+        username: impl Into<String>,
+    ) -> ListUserProjectsBuilder<'_, '_> {
         ListUserProjectsBuilder::new(self, username.into())
     }
 

--- a/src/api/pulls.rs
+++ b/src/api/pulls.rs
@@ -256,7 +256,7 @@ impl<'octo> PullRequestHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn list(&self) -> list::ListPullRequestsBuilder {
+    pub fn list(&self) -> list::ListPullRequestsBuilder<'_, '_> {
         list::ListPullRequestsBuilder::new(self)
     }
 
@@ -373,7 +373,7 @@ impl<'octo> PullRequestHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn list_comments(&self, pr: Option<u64>) -> comment::ListCommentsBuilder {
+    pub fn list_comments(&self, pr: Option<u64>) -> comment::ListCommentsBuilder<'_, '_> {
         comment::ListCommentsBuilder::new(self, pr)
     }
 
@@ -391,7 +391,7 @@ impl<'octo> PullRequestHandler<'octo> {
     ///     comment
     ///  }
     /// ```
-    pub fn comment(&self, comment_id: CommentId) -> comment::CommentBuilder {
+    pub fn comment(&self, comment_id: CommentId) -> comment::CommentBuilder<'_, '_> {
         comment::CommentBuilder::new(self, comment_id)
     }
 
@@ -409,7 +409,7 @@ impl<'octo> PullRequestHandler<'octo> {
         note = "specific PR builder transitioned to pr_review_actions, pr_commits, reply_to_comment"
     )]
     //FIXME: remove?
-    pub fn pull_number(&self, pull_nr: u64) -> SpecificPullRequestBuilder {
+    pub fn pull_number(&self, pull_nr: u64) -> SpecificPullRequestBuilder<'_, '_> {
         SpecificPullRequestBuilder::new(self, pull_nr)
     }
 
@@ -499,7 +499,7 @@ impl<'octo> PullRequestHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn merge(&self, pr: u64) -> merge::MergePullRequestsBuilder {
+    pub fn merge(&self, pr: u64) -> merge::MergePullRequestsBuilder<'_, '_> {
         merge::MergePullRequestsBuilder::new(self, pr)
     }
 }

--- a/src/api/pulls/specific_pr.rs
+++ b/src/api/pulls/specific_pr.rs
@@ -97,7 +97,7 @@ impl<'octo, 'b> SpecificPullRequestBuilder<'octo, 'b> {
     ///     Ok(())
     ///   }
     /// ```
-    pub fn comment(&self, comment_id: CommentId) -> SpecificPullRequestCommentBuilder {
+    pub fn comment(&self, comment_id: CommentId) -> SpecificPullRequestCommentBuilder<'_, '_> {
         SpecificPullRequestCommentBuilder::new(self.handler, self.pr_number, comment_id)
     }
 }

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -524,7 +524,11 @@ impl<'octo> RepoHandler<'octo> {
     }
 
     /// Create a status for a specified commit in the specified repository.
-    pub fn create_status(&self, sha: String, state: models::StatusState) -> CreateStatusBuilder {
+    pub fn create_status(
+        &self,
+        sha: String,
+        state: models::StatusState,
+    ) -> CreateStatusBuilder<'_, '_> {
         CreateStatusBuilder::new(self, sha, state)
     }
 

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -86,7 +86,7 @@ impl<'octo> TeamHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn create(&self, name: impl Into<String>) -> CreateTeamBuilder {
+    pub fn create(&self, name: impl Into<String>) -> CreateTeamBuilder<'_, '_, '_, '_> {
         CreateTeamBuilder::new(self, name.into())
     }
 
@@ -106,7 +106,11 @@ impl<'octo> TeamHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn edit(&self, team_slug: impl Into<String>, name: impl Into<String>) -> EditTeamBuilder {
+    pub fn edit(
+        &self,
+        team_slug: impl Into<String>,
+        name: impl Into<String>,
+    ) -> EditTeamBuilder<'_, '_> {
         EditTeamBuilder::new(self, team_slug.into(), name.into())
     }
 
@@ -146,13 +150,13 @@ impl<'octo> TeamHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn list_children(&self, team_slug: impl Into<String>) -> ListChildTeamsBuilder {
+    pub fn list_children(&self, team_slug: impl Into<String>) -> ListChildTeamsBuilder<'_, '_> {
         ListChildTeamsBuilder::new(self, team_slug.into())
     }
 
     /// Creates a new `TeamRepoHandler` for the specified team,
     /// that allows you to manage this team's repositories.
-    pub fn repos(&self, team_slug: impl Into<String>) -> TeamRepoHandler {
+    pub fn repos(&self, team_slug: impl Into<String>) -> TeamRepoHandler<'_> {
         TeamRepoHandler::new(self.crab, self.owner.clone(), team_slug.into())
     }
 
@@ -170,7 +174,7 @@ impl<'octo> TeamHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn members(&self, team_slug: impl Into<String>) -> ListTeamMembersBuilder {
+    pub fn members(&self, team_slug: impl Into<String>) -> ListTeamMembersBuilder<'_, '_> {
         ListTeamMembersBuilder::new(self, team_slug.into())
     }
 
@@ -188,7 +192,7 @@ impl<'octo> TeamHandler<'octo> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn invitations(&self, team_slug: impl Into<String>) -> ListTeamInvitationsBuilder {
+    pub fn invitations(&self, team_slug: impl Into<String>) -> ListTeamInvitationsBuilder<'_, '_> {
         ListTeamInvitationsBuilder::new(self, team_slug.into())
     }
 }

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -62,12 +62,12 @@ impl<'octo> UserHandler<'octo> {
     }
 
     /// List this users that follow this user
-    pub fn followers(&self) -> ListUserFollowerBuilder {
+    pub fn followers(&self) -> ListUserFollowerBuilder<'_, '_> {
         ListUserFollowerBuilder::new(self)
     }
 
     /// List this user is following
-    pub fn following(&self) -> ListUserFollowingBuilder {
+    pub fn following(&self) -> ListUserFollowingBuilder<'_, '_> {
         ListUserFollowingBuilder::new(self)
     }
 
@@ -77,7 +77,7 @@ impl<'octo> UserHandler<'octo> {
 
     /// API for listing blocked users
     /// you must pass authentication information with your requests
-    pub fn blocks(&self) -> BlockedUsersBuilder {
+    pub fn blocks(&self) -> BlockedUsersBuilder<'_, '_> {
         BlockedUsersBuilder::new(self)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1153,29 +1153,29 @@ impl Octocrab {
 impl Octocrab {
     /// Creates a new [`actions::ActionsHandler`] for accessing information from
     /// GitHub Actions.
-    pub fn actions(&self) -> actions::ActionsHandler {
+    pub fn actions(&self) -> actions::ActionsHandler<'_> {
         actions::ActionsHandler::new(self)
     }
 
     /// Creates a [`current::CurrentAuthHandler`] that allows you to access
     /// information about the current authenticated user.
-    pub fn current(&self) -> current::CurrentAuthHandler {
+    pub fn current(&self) -> current::CurrentAuthHandler<'_> {
         current::CurrentAuthHandler::new(self)
     }
 
     /// Creates a [`activity::ActivityHandler`] for the current authenticated user.
-    pub fn activity(&self) -> activity::ActivityHandler {
+    pub fn activity(&self) -> activity::ActivityHandler<'_> {
         activity::ActivityHandler::new(self)
     }
 
     /// Creates a new [`apps::AppsRequestHandler`] for the currently authenticated app.
-    pub fn apps(&self) -> apps::AppsRequestHandler {
+    pub fn apps(&self) -> apps::AppsRequestHandler<'_> {
         apps::AppsRequestHandler::new(self)
     }
 
     /// Creates a [`gitignore::GitignoreHandler`] for accessing information
     /// about `gitignore`.
-    pub fn gitignore(&self) -> gitignore::GitignoreHandler {
+    pub fn gitignore(&self) -> gitignore::GitignoreHandler<'_> {
         gitignore::GitignoreHandler::new(self)
     }
 
@@ -1185,13 +1185,13 @@ impl Octocrab {
         &self,
         owner: impl Into<String>,
         repo: impl Into<String>,
-    ) -> issues::IssueHandler {
+    ) -> issues::IssueHandler<'_> {
         issues::IssueHandler::new(self, RepoRef::ByOwnerAndName(owner.into(), repo.into()))
     }
 
     /// Creates a [`issues::IssueHandler`] for the repo specified at repository ID,
     /// that allows you to access GitHub's issues API.
-    pub fn issues_by_id(&self, id: impl Into<RepositoryId>) -> issues::IssueHandler {
+    pub fn issues_by_id(&self, id: impl Into<RepositoryId>) -> issues::IssueHandler<'_> {
         issues::IssueHandler::new(self, RepoRef::ById(id.into()))
     }
 
@@ -1201,7 +1201,7 @@ impl Octocrab {
         &self,
         owner: impl Into<String>,
         repo: impl Into<String>,
-    ) -> code_scannings::CodeScanningHandler {
+    ) -> code_scannings::CodeScanningHandler<'_> {
         code_scannings::CodeScanningHandler::new(self, owner.into(), Option::from(repo.into()))
     }
 
@@ -1210,7 +1210,7 @@ impl Octocrab {
     pub fn code_scannings_organisation(
         &self,
         owner: impl Into<String>,
-    ) -> code_scannings::CodeScanningHandler {
+    ) -> code_scannings::CodeScanningHandler<'_> {
         code_scannings::CodeScanningHandler::new(self, owner.into(), None)
     }
 
@@ -1219,23 +1219,23 @@ impl Octocrab {
         &self,
         owner: impl Into<String>,
         repo: impl Into<String>,
-    ) -> commits::CommitHandler {
+    ) -> commits::CommitHandler<'_> {
         commits::CommitHandler::new(self, owner.into(), repo.into())
     }
 
     /// Creates a [`licenses::LicenseHandler`].
-    pub fn licenses(&self) -> licenses::LicenseHandler {
+    pub fn licenses(&self) -> licenses::LicenseHandler<'_> {
         licenses::LicenseHandler::new(self)
     }
 
     /// Creates a [`markdown::MarkdownHandler`].
-    pub fn markdown(&self) -> markdown::MarkdownHandler {
+    pub fn markdown(&self) -> markdown::MarkdownHandler<'_> {
         markdown::MarkdownHandler::new(self)
     }
 
     /// Creates an [`orgs::OrgHandler`] for the specified organization,
     /// that allows you to access GitHub's organization API.
-    pub fn orgs(&self, owner: impl Into<String>) -> orgs::OrgHandler {
+    pub fn orgs(&self, owner: impl Into<String>) -> orgs::OrgHandler<'_> {
         orgs::OrgHandler::new(self, owner.into())
     }
 
@@ -1245,47 +1245,51 @@ impl Octocrab {
         &self,
         owner: impl Into<String>,
         repo: impl Into<String>,
-    ) -> pulls::PullRequestHandler {
+    ) -> pulls::PullRequestHandler<'_> {
         pulls::PullRequestHandler::new(self, owner.into(), repo.into())
     }
 
     /// Creates a [`repos::RepoHandler`] for the repo specified at `owner/repo`,
     /// that allows you to access GitHub's repository API.
-    pub fn repos(&self, owner: impl Into<String>, repo: impl Into<String>) -> repos::RepoHandler {
+    pub fn repos(
+        &self,
+        owner: impl Into<String>,
+        repo: impl Into<String>,
+    ) -> repos::RepoHandler<'_> {
         repos::RepoHandler::new(self, RepoRef::ByOwnerAndName(owner.into(), repo.into()))
     }
 
     /// Creates a [`repos::RepoHandler`] for the repo specified at repository ID,
     /// that allows you to access GitHub's repository API.
-    pub fn repos_by_id(&self, id: impl Into<RepositoryId>) -> repos::RepoHandler {
+    pub fn repos_by_id(&self, id: impl Into<RepositoryId>) -> repos::RepoHandler<'_> {
         repos::RepoHandler::new(self, RepoRef::ById(id.into()))
     }
 
     /// Creates a [`projects::ProjectHandler`] that allows you to access GitHub's
     /// projects API (classic).
-    pub fn projects(&self) -> projects::ProjectHandler {
+    pub fn projects(&self) -> projects::ProjectHandler<'_> {
         projects::ProjectHandler::new(self)
     }
 
     /// Creates a [`search::SearchHandler`] that allows you to construct general queries
     /// to GitHub's API.
-    pub fn search(&self) -> search::SearchHandler {
+    pub fn search(&self) -> search::SearchHandler<'_> {
         search::SearchHandler::new(self)
     }
 
     /// Creates a [`teams::TeamHandler`] for the specified organization that allows
     /// you to access GitHub's teams API.
-    pub fn teams(&self, owner: impl Into<String>) -> teams::TeamHandler {
+    pub fn teams(&self, owner: impl Into<String>) -> teams::TeamHandler<'_> {
         teams::TeamHandler::new(self, owner.into())
     }
 
     /// Creates a [`users::UserHandler`] for the specified user using the user name
-    pub fn users(&self, user: impl Into<String>) -> users::UserHandler {
+    pub fn users(&self, user: impl Into<String>) -> users::UserHandler<'_> {
         users::UserHandler::new(self, UserRef::ByString(user.into()))
     }
 
     /// Creates a [`users::UserHandler`] for the specified user using the user ID
-    pub fn users_by_id(&self, user: impl Into<UserId>) -> users::UserHandler {
+    pub fn users_by_id(&self, user: impl Into<UserId>) -> users::UserHandler<'_> {
         users::UserHandler::new(self, UserRef::ById(user.into()))
     }
 
@@ -1295,19 +1299,19 @@ impl Octocrab {
         &self,
         owner: impl Into<String>,
         repo: impl Into<String>,
-    ) -> workflows::WorkflowsHandler {
+    ) -> workflows::WorkflowsHandler<'_> {
         workflows::WorkflowsHandler::new(self, owner.into(), repo.into())
     }
 
     /// Creates an [`events::EventsBuilder`] that allows you to access
     /// GitHub's events API.
-    pub fn events(&self) -> events::EventsBuilder {
+    pub fn events(&self) -> events::EventsBuilder<'_> {
         events::EventsBuilder::new(self)
     }
 
     /// Creates a [`gists::GistsHandler`] that allows you to access
     /// GitHub's Gists API.
-    pub fn gists(&self) -> gists::GistsHandler {
+    pub fn gists(&self) -> gists::GistsHandler<'_> {
         gists::GistsHandler::new(self)
     }
 
@@ -1316,17 +1320,17 @@ impl Octocrab {
         &self,
         owner: impl Into<String>,
         repo: impl Into<String>,
-    ) -> checks::ChecksHandler {
+    ) -> checks::ChecksHandler<'_> {
         checks::ChecksHandler::new(self, owner.into(), repo.into())
     }
 
     /// Creates a [`ratelimit::RateLimitHandler`] that returns the API rate limit.
-    pub fn ratelimit(&self) -> ratelimit::RateLimitHandler {
+    pub fn ratelimit(&self) -> ratelimit::RateLimitHandler<'_> {
         ratelimit::RateLimitHandler::new(self)
     }
 
     /// Creates a [`hooks::HooksHandler`] that returns the API hooks
-    pub fn hooks(&self, owner: impl Into<String>) -> hooks::HooksHandler {
+    pub fn hooks(&self, owner: impl Into<String>) -> hooks::HooksHandler<'_> {
         hooks::HooksHandler::new(self, owner.into())
     }
 }


### PR DESCRIPTION
just to fix the clippy warnings https://github.com/XAMPPRocky/octocrab/actions/runs/17897120458/job/50885202928#step:4:382:

```
    Checking octocrab v0.45.0 (/home/runner/work/octocrab/octocrab)
warning: hiding a lifetime that's elided elsewhere is confusing
    --> src/lib.rs:1156:20
     |
1156 |     pub fn actions(&self) -> actions::ActionsHandler {
     |                    ^^^^^     ----------------------- the same lifetime is hidden here
     |                    |
     |                    the lifetime is elided here
     |
     = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
     = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default

...