### PR TITLE
Expose `digest` field in the `Asset` model

### DIFF
--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -341,6 +341,7 @@ pub struct Asset {
     pub state: String,
     pub content_type: String,
     pub size: i64,
+    pub digest: Option<String>,
     pub download_count: i64,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,


### PR DESCRIPTION
GitHub releases now have automatically generated checksums in every asset. This PR exposes the `digest` field of the get release asset response.