### PR TITLE
Bump jsonwebtoken to v10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ either = "1.8.0"
 futures = { version = "0.3.15" }
 futures-core = { version = "0.3.15", optional = true }
 futures-util = { version = "0.3.15", optional = true }
+getrandom = { version = "0.2.15", features = ["js"] }
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 http = "1.0.0"
 http-body = "1.0.0"


### PR DESCRIPTION
This PR bumps the major version of jsonwebtoken from v9 to v10.

The [changelog](https://github.com/Keats/jsonwebtoken/blob/master/CHANGELOG.md#1000-2025-09-29)  notes `now using traits for crypto backends, you have to choose between aws_lc_rs and rust_crypto` as the breaking change responsible for the major version bump.

`jsonwebtoken::EncodingKey` is one of the parameters to `create_jwt` in [auth.rs](auth.rs). A [search](https://github.com/search?q=octocrab+create_jwt+-path%3Aexample&type=code) shows the impact should be limited, at least for visible repositories. Only one active repo uses it and they use an old version of the crate.

NOTE: Looks like wasm compilation failed initially. Related to https://github.com/Keats/jsonwebtoken/issues/450. I was able to address this by enabling the `js` feature on `getrandom`, which isa transitive dependency of jsonwebtoken's crypto functionanlity: `getrandom = { version = "0.2.15", features = ["js"] }`