### PR TITLE
docs: Modify `_put` method documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1543,7 +1543,7 @@ impl Octocrab {
         R::from_response(crate::map_github_error(response).await?).await
     }
 
-    /// Send a `PATCH` request with no additional post-processing.
+    /// Send a `PUT` request with no additional post-processing.
     pub async fn _put<B: Serialize + ?Sized>(
         &self,
         uri: impl TryInto<Uri>,


### PR DESCRIPTION
Fixed incorrect documentation for the `_put` method