### PR TITLE
models: add missing issue event types

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -276,6 +276,8 @@ pub enum Event {
     RemovedFromMergeQueue,
     /// The issue or pull request was removed from a project board.
     RemovedFromProject,
+    /// Not documented in the Github issue events documentation.
+    RemovedFromProjectV2,
     /// The issue or pull request title was changed.
     Renamed,
     /// The issue or pull request was reopened.


### PR DESCRIPTION
This adds some issue event types encountered in the wild while trying to use [github-metadata-backup](https://github.com/0xB10C/github-metadata-backup/) on the [tock/tock](https://github.com/tock/tock) repository.
