### PR TITLE
Use `Option<AuthorAssociation>` over `String` in `Issue` struct

### DIFF
--- a/src/models/issues.rs
+++ b/src/models/issues.rs
@@ -25,7 +25,8 @@ pub struct Issue {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub assignee: Option<Author>,
     pub assignees: Vec<Author>,
-    pub author_association: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_association: Option<AuthorAssociation>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub milestone: Option<Milestone>,
     pub locked: bool,


### PR DESCRIPTION
This is more type-safe. Also, according to the response schema (https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue), the field is not required. Only the following are required:

```
  "required": [
    "assignee",
    "closed_at",
    "comments",
    "comments_url",
    "events_url",
    "html_url",
    "id",
    "node_id",
    "labels",
    "labels_url",
    "milestone",
    "number",
    "repository_url",
    "state",
    "locked",
    "title",
    "url",
    "user",
    "created_at",
    "updated_at"
  ]
```

So, make it optional as well.