### PR TITLE
`octocrab::Error`: don't include unconditional backtrace in Display impl

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("HTTP Error: {}\n\nFound at {}", source, backtrace))]
+    #[snafu(display("HTTP Error: {}", source))]
     Http {
         source: http::Error,
         backtrace: Backtrace,
@@ -59,35 +59,35 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Service Error: {}\n\nFound at {}", source, backtrace))]
+    #[snafu(display("Service Error: {}", source))]
     Service {
         source: BoxError,
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Hyper Error: {}\n\nFound at {}", source, backtrace))]
+    #[snafu(display("Hyper Error: {}", source))]
     Hyper {
         source: hyper::Error,
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Serde Url Encode Error: {}\nFound at {}", source, backtrace))]
+    #[snafu(display("Serde Url Encode Error: {}", source))]
     SerdeUrlEncoded {
         source: serde_urlencoded::ser::Error,
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Serde Error: {}\nFound at {}", source, backtrace))]
+    #[snafu(display("Serde Error: {}", source))]
     Serde {
         source: serde_json::Error,
         backtrace: Backtrace,
     },
-    #[snafu(display("JSON Error in {}: {}\nFound at {}", source.path(), source.inner(), backtrace))]
+    #[snafu(display("JSON Error in {}: {}", source.path(), source.inner()))]
     Json {
         source: serde_path_to_error::Error<serde_json::Error>,
         backtrace: Backtrace,
     },
-    #[snafu(display("JWT Error in {}\nFound at {}", source, backtrace))]
+    #[snafu(display("JWT Error in {}", source))]
     JWT {
         source: jsonwebtoken::errors::Error,
         backtrace: Backtrace,


### PR DESCRIPTION
Users of this crate cannot currently get an error description without the backtrace included. This may be undesirable for a number of reasons, and is inconsistent with the examples in the `snafu` crate (whose Display implementations generally do not include a backtrace). Users who want a backtrace to be printed can still do so for an octocrab Error `e` by writing:

    snafu::ErrorCompat::backtrace(&e)

This was requested as part of a pull request to a project using this crate: https://github.com/0xB10C/github-metadata-backup/pull/11#discussion_r2509355952
