### PR TITLE
feat: fetch repository permission for a contributor

### DIFF
--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -33,6 +33,7 @@ use crate::models::interaction_limits::{
     InteractionLimit, InteractionLimitExpiry, InteractionLimitType,
 };
 use crate::models::{repos, RepositoryId};
+use crate::repos::collaborators::GetCollaboratorPermissionBuilder;
 use crate::repos::file::GetReadmeBuilder;
 use crate::{models, params, Octocrab, Result};
 pub use branches::ListBranchesBuilder;
@@ -473,6 +474,20 @@ impl<'octo> RepoHandler<'octo> {
     /// ```
     pub fn list_collaborators(&self) -> ListCollaboratorsBuilder<'_, '_> {
         ListCollaboratorsBuilder::new(self)
+    }
+
+    /// Checks the repository permission and role of a collaborator.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let permission = octocrab::instance().repos("owner", "repo").get_contributor_permission("username").send().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_contributor_permission(
+        &self,
+        username: impl Into<String>,
+    ) -> GetCollaboratorPermissionBuilder<'_, '_> {
+        GetCollaboratorPermissionBuilder::new(self, username)
     }
 
     /// List contributors from a repository.

--- a/src/api/repos/collaborators.rs
+++ b/src/api/repos/collaborators.rs
@@ -49,3 +49,30 @@ impl<'octo, 'r> ListCollaboratorsBuilder<'octo, 'r> {
         self.handler.crab.get(route, Some(&self)).await
     }
 }
+
+#[derive(serde::Serialize)]
+pub struct GetCollaboratorPermissionBuilder<'octo, 'r> {
+    #[serde(skip)]
+    handler: &'r RepoHandler<'octo>,
+    /// The handle for the GitHub user account.
+    #[serde(skip)]
+    username: String,
+}
+
+impl<'octo, 'r> GetCollaboratorPermissionBuilder<'octo, 'r> {
+    pub fn new(handler: &'r RepoHandler<'octo>, username: impl Into<String>) -> Self {
+        Self {
+            handler,
+            username: username.into(),
+        }
+    }
+
+    /// Sends the actual request.
+    pub async fn send(self) -> crate::Result<crate::models::repos::RepoPermission> {
+        let route = format!(
+            "/{}/collaborators/{}/permission",
+            self.handler.repo, self.username
+        );
+        self.handler.crab.get(route, Some(&self)).await
+    }
+}

--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::error::SerdeSnafu;
+use crate::{error::SerdeSnafu, params::teams::Permission};
 use bytes::Bytes;
 use http_body::Body;
 use http_body_util::BodyExt;
@@ -397,6 +397,17 @@ pub struct MergeCommit {
     pub node_id: String,
     pub html_url: String,
     pub comments_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RepoPermission {
+    /// Provides the legacy base roles of admin, write, read, and none, where the
+    /// maintain role is mapped to write and the triage role is mapped to read.
+    pub permission: Permission,
+    /// Provides the name of the assigned role, including custom roles.
+    pub role_name: String,
+    pub user: Collaborator,
 }
 
 /// A HashMap of languages and the number of bytes of code written in that language.

--- a/src/params.rs
+++ b/src/params.rs
@@ -565,7 +565,7 @@ pub mod teams {
         Closed,
     }
 
-    #[derive(Debug, Clone, Copy, serde::Serialize)]
+    #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
     #[serde(rename_all = "snake_case")]
     #[non_exhaustive]
     pub enum Permission {


### PR DESCRIPTION
### Description
This PR introduces the functionality of fetching a contributor permission on a repository.

```rust
octocrab::instance()
  .repos("owner", "repo")
  .get_contributor_permission("username")
  .send()
  .await?;
```

If merged, this should mark the `/repos/{owner}/{repo}/collaborators/{username}/permission` from https://github.com/XAMPPRocky/octocrab/issues/542.

### References
- https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#get-repository-permissions-for-a-user