### PR TITLE
fix: incorrect path for followers and followees

### DIFF
--- a/src/api/users/follow.rs
+++ b/src/api/users/follow.rs
@@ -38,7 +38,7 @@ impl<'octo, 'b> ListUserFollowerBuilder<'octo, 'b> {
     /// Sends the actual request.
     pub async fn send(self) -> crate::Result<Page<crate::models::Follower>> {
         // build the route to get this users followers
-        let route = format!("/users/{}/followers", self.handler.user);
+        let route = format!("/{}/followers", self.handler.user);
         self.handler.crab.get(route, Some(&self)).await
     }
 }
@@ -80,7 +80,7 @@ impl<'octo, 'b> ListUserFollowingBuilder<'octo, 'b> {
     /// Sends the actual request.
     pub async fn send(self) -> crate::Result<Page<crate::models::Followee>> {
         // build the route to get this users followers
-        let route = format!("/users/{}/following", self.handler.user);
+        let route = format!("/{}/following", self.handler.user);
         self.handler.crab.get(route, Some(&self)).await
     }
 }


### PR DESCRIPTION
```rust
async fn followers() -> Vec<Follower> {
    let octo = octocrab::instance();
    octo.users(USER)
        .followers()
        .send()
        .await
        .unwrap()
        .into_stream(&octo)
        .try_collect::<Vec<Follower>>()
        .await
        .unwrap()
}
```
This results in a 404 error because the path being called is `/users/users/<username>/followers`. This PR removes the extra `/users` part. Same for following.