### PR TITLE
feat: provide expiration-aware installation token APIs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,8 @@ pub enum Error {
     },
     #[snafu(display("Installation Error: Github App authorization is required to target an installation.\n\nFound at {}", backtrace))]
     Installation { backtrace: Backtrace },
+    #[snafu(display("Error getting installation access token: octocrab instance is not an installation.\n\nFound at {}", backtrace))]
+    InstallationTokenInvalidAuth { backtrace: Backtrace },
     InvalidHeaderValue {
         source: http::header::InvalidHeaderValue,
         backtrace: Backtrace,


### PR DESCRIPTION
As noted in the docs for `installation_and_token`, some consumers may need a token for their own use outside of calling REST APIs via octocrab, such as performing git operations like cloning via HTTPS.

If that consumer can be active for more than an hour, it needs to consider the possibility that the token may expire. There are no good APIs within octocrab for this currently. The only real method for getting a token is `installation_and_token`, which acquires a fresh token each time it is called.

Provide APIs to acquire an access token, optionally with a given expiration buffer. Internally, these APIs take care of either returning the cached token or acquiring a new one. A consumer can simply call `installation_token` or `installation_token_with_buffer` each time it needs a token and be guaranteed to have a valid token.

Fixes #836.