### PR TITLE
Send body for retried requests

### DIFF
--- a/src/service/middleware/retry.rs
+++ b/src/service/middleware/retry.rs
@@ -50,6 +50,8 @@ impl<B> Policy<Request<OctoBody>, Response<B>, Error> for RetryConfig {
         match self {
             RetryConfig::None => None,
             _ => {
+                let body = req.body().try_clone()?;
+
                 // `Request` can't be cloned
                 let mut new_req = Request::builder()
                     .uri(req.uri())
@@ -59,7 +61,6 @@ impl<B> Policy<Request<OctoBody>, Response<B>, Error> for RetryConfig {
                     new_req = new_req.header(name, value);
                 }
 
-                let body = req.body().clone();
                 let new_req = new_req.body(body).expect(
                     "This should never panic, as we are cloning a components from existing request",
                 );


### PR DESCRIPTION
Retried requests in octocrab did not re-send their body, which could result in an invalid request being retried (especially for non-GET requests). This PR fixes that by buffering the body of requests whose body is easily cloneable, and disabling retry for other requests.

I tried to do this without buffering the whole body upfront, but I didn't find a way to do it (https://github.com/hyperium/http-body/issues/158). Since we only store `Bytes`, which is refcounted, I don't think that buffering and copying the body should be such an issue.

Fixes: https://github.com/XAMPPRocky/octocrab/issues/835
