### PR TITLE
feat: add missing `waiting` status to Workflow status enum

### DIFF
--- a/src/models/workflows.rs
+++ b/src/models/workflows.rs
@@ -120,6 +120,7 @@ pub enum Status {
     InProgress,
     Completed,
     Failed,
+    Waiting,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Adds support for `waiting` status for workflow jobs.

From the OpenAPI definition:
```json
"status": {
  "description": "The phase of the lifecycle that the job is currently in.",
  "type": "string",
  "enum": [
    "queued",
    "in_progress",
    "completed",
    "waiting",
    "requested",
    "pending"
  ]
},
```

### References
- https://docs.github.com/en/rest/actions/workflow-jobs?apiVersion=2026-03-10#get-a-job-for-a-workflow-run
- https://github.com/github/rest-api-description