### PR TITLE
Expose OctoBody

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ pub mod service;
 
 use api::repos::RepoRef;
 use api::users::UserRef;
-use body::OctoBody;
+pub use body::OctoBody;
 use chrono::{DateTime, Utc};
 use http::{HeaderMap, HeaderValue, Method, Uri};
 use http_body_util::combinators::BoxBody;


### PR DESCRIPTION
In #869, OctoBody was used in a public trait, but is not itself visible. It's marked pub, so I'm assuming that re-exporting it is okay.