### PR TITLE
Implement structured GraphQL response and error handling

### DIFF
--- a/examples/graphql_issues.rs
+++ b/examples/graphql_issues.rs
@@ -4,6 +4,7 @@
 //! curl -L https://docs.github.com/public/fpt/schema.docs.graphql -o examples/github_schema.graphql
 //! ```
 use graphql_client::GraphQLQuery;
+use octocrab::GraphqlResponse;
 
 #[allow(clippy::upper_case_acronyms)]
 type URI = String;
@@ -37,26 +38,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             break;
         }
 
-        let response: octocrab::Result<graphql_client::Response<issues_query::ResponseData>> =
-            octocrab
-                .graphql(&IssuesQuery::build_query(variables.clone()))
-                .await;
+        let response: octocrab::Result<GraphqlResponse<issues_query::ResponseData>> = octocrab
+            .graphql(&IssuesQuery::build_query(variables.clone()))
+            .await;
 
         match response {
-            Ok(response) => {
+            Ok(GraphqlResponse::Ok(response)) => {
                 println!("Page {page}:");
-                let issues = &response
-                    .data
-                    .as_ref()
-                    .unwrap()
-                    .repository
-                    .as_ref()
-                    .unwrap()
-                    .issues;
+                let issues = &response.data.repository.as_ref().unwrap().issues;
                 print_issues(issues);
                 if !update_page_info(&mut variables, issues) {
                     break;
                 }
+            }
+            Ok(GraphqlResponse::Err(response)) => {
+                println!("{response:#?}");
+                break;
             }
             Err(error) => {
                 println!("{error:#?}");

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ use std::fmt::{Display, Formatter};
 use std::string::FromUtf8Error;
 use tower::BoxError;
 
+use crate::GraphqlError;
+
 //This is workaround until I figure out how to get TryInto errors to work
 #[derive(Debug)]
 pub struct UriParseError;
@@ -94,6 +96,11 @@ pub enum Error {
         source: jsonwebtoken::errors::Error,
         backtrace: Backtrace,
     },
+    #[snafu(display("GraphQL Error: {}\nFound at {}", source, backtrace))]
+    Graphql {
+        source: GraphqlErrors,
+        backtrace: Backtrace,
+    },
     Other {
         source: Box<dyn std::error::Error + Send + Sync>,
         backtrace: Backtrace,
@@ -130,3 +137,35 @@ impl fmt::Display for GitHubError {
 }
 
 impl std::error::Error for GitHubError {}
+
+#[derive(Debug)]
+pub struct GraphqlErrors(pub Vec<GraphqlError>);
+
+impl From<Vec<GraphqlError>> for GraphqlErrors {
+    fn from(errors: Vec<GraphqlError>) -> Self {
+        Self(errors)
+    }
+}
+
+impl fmt::Display for GraphqlErrors {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} GraphQL Error", self.0.len())?;
+        for (i, error) in self.0.iter().enumerate() {
+            write!(f, "\n{}: {}", i + 1, error.message)?;
+
+            if let Some(path) = &error.path {
+                write!(f, " (path: {:?})", path)?;
+            }
+
+            if let Some(locs) = &error.locations {
+                for loc in locs {
+                    write!(f, "\n at line {}, column {}", loc.line, loc.column)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl std::error::Error for GraphqlErrors {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,13 +232,13 @@ use http_body_util::BodyExt;
 use service::middleware::auth_header::AuthHeaderLayer;
 use service::middleware::cache::{CacheStorage, HttpCacheLayer};
 use std::convert::{Infallible, TryInto};
-use std::fmt;
 use std::future::Future;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
+use std::{fmt, usize};
 use web_time::Duration;
 
 use http::{header::HeaderName, StatusCode};
@@ -1422,19 +1422,82 @@ impl Octocrab {
     /// from JSON.
     /// ```no_run
     ///# async fn run() -> octocrab::Result<()> {
-    /// let response: serde_json::Value = octocrab::instance()
+    /// let response: octocrab::GraphqlResponse<serde_json::Value> = octocrab::instance()
     ///     .graphql(&serde_json::json!({ "query": "{ viewer { login }}" }))
     ///     .await?;
     ///# Ok(())
     ///# }
     /// ```
-    pub async fn graphql<R: crate::FromResponse>(
+    pub async fn graphql<R: serde::de::DeserializeOwned>(
         &self,
         payload: &(impl serde::Serialize + ?Sized),
     ) -> crate::Result<R> {
-        self.post("/graphql", Some(&serde_json::json!(payload)))
-            .await
+        let response: GraphqlResponse<R> = self
+            .post("/graphql", Some(&serde_json::json!(payload)))
+            .await?;
+
+        match response {
+            GraphqlResponse::Ok(res) => Ok(res.data),
+            GraphqlResponse::Err(errors) => Err(error::Error::Graphql {
+                source: errors.errors.into(),
+                backtrace: Backtrace::capture(),
+            }),
+        }
     }
+}
+
+/// GraphQL Response.
+/// GraphQL can return a response with `data` or `errors`, or both in the case of a partial success.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum GraphqlResponse<T> {
+    /// A response containing errors.
+    Err(GraphqlErrorResponse<T>),
+    /// A response representing a complete success with no errors.
+    Ok(GraphqlOkResponse<T>),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GraphqlOkResponse<T> {
+    pub data: T,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GraphqlErrorResponse<T> {
+    /// GraphQL returns `data` even in the case of a partial success.
+    pub data: Option<T>,
+    /// A list of errors encountered during the request.
+    pub errors: Vec<GraphqlError>,
+}
+
+/// An individual GraphQL error.
+/// Following the [GraphQL October 2021 Spec](https://spec.graphql.org/October2021/#sec-Errors).
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GraphqlError {
+    /// A description of the error intended for the developer as a guide to understand and correct the error.
+    pub message: String,
+    /// A particular point of reference in the GraphQL query where the error occurred.
+    /// This may be `None` if the error cannot be associated with a particular point
+    pub locations: Option<Vec<GraphqlErrorLocation>>,
+    /// The path to the specific field that caused the error.
+    /// This may be `None` if the error is not associated with a specific field
+    pub path: Option<Vec<GraphqlPathSegment>>,
+    /// Additional error metadata provided by the server.
+    pub extensions: Option<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GraphqlErrorLocation {
+    pub line: u32,
+    pub column: u32,
+}
+
+/// A path can consist of field names (Strings) and list indices (usize).
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum GraphqlPathSegment {
+    Path(String),
+    Position(usize),
 }
 
 /// # HTTP Methods


### PR DESCRIPTION
This PR extends Octocrab's GraphQL support with structured responses and error handling. It follows the [GraphQL September 2025 Spec](https://spec.graphql.org/September2025/#sec-Errors) to ensure compatibility and provides detailed error metadata.

Closes #78 