### PR TITLE
Use PUT not PATCH for pull request reviews

### DIFF
--- a/src/api/pulls/specific_pr/pr_reviews/specific_review.rs
+++ b/src/api/pulls/specific_pr/pr_reviews/specific_review.rs
@@ -79,7 +79,7 @@ impl<'octo, 'b> SpecificReviewBuilder<'octo, 'b> {
             pull_number = self.pr_number,
             review_id = self.review_id
         );
-        self.handler.crab.patch(route, Some(&body.into())).await
+        self.handler.crab.put(route, Some(&body.into())).await
     }
 
     ///Deletes a pull request review that has not been submitted. Submitted reviews cannot be deleted.

--- a/tests/pull_request_review_operations_test.rs
+++ b/tests/pull_request_review_operations_test.rs
@@ -40,7 +40,7 @@ async fn should_work_with_specific_review() {
         .respond_with(template.clone())
         .mount(&mock_server)
         .await;
-    Mock::given(method("PATCH"))
+    Mock::given(method("PUT"))
         .and(path(format!(
             "/repos/{OWNER}/{REPO}/pulls/{PULL_NUMBER}/reviews/{REVIEW_ID}"
         )))


### PR DESCRIPTION
I was getting 404s when trying to update the body of a pull request review. Looks like https://docs.github.com/en/rest/pulls/reviews?apiVersion=2026-03-10#update-a-review-for-a-pull-request says it's a PUT not PATCH.