### PR TITLE
Codex/address wasm review followup

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,6 @@ jobs:
           rustup default stable
           rustup target add wasm32-unknown-unknown
           cargo build --target=wasm32-unknown-unknown --no-default-features -F jwt-rust-crypto
-          cargo build --target=wasm32-unknown-unknown --no-default-features -F jwt-rust-crypto,wasm-client
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,7 @@ jobs:
           rustup default stable
           rustup target add wasm32-unknown-unknown
           cargo build --target=wasm32-unknown-unknown --no-default-features -F jwt-rust-crypto
+          cargo build --target=wasm32-unknown-unknown --no-default-features -F jwt-rust-crypto,wasm-client
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ tracing = { version = "0.1.37", features = ["log"], optional = true }
 url = { version = "2.2.2", features = ["serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-reqwest = { version = "0.12.0", default-features = false, optional = true }
+reqwest = { version = "0.12.0", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.17.0", default-features = false, features = [
@@ -134,4 +134,3 @@ opentls = ["hyper-tls"]
 stream = ["futures-core", "futures-util"]
 timeout = ["hyper-timeout", "tokio", "tower/timeout"]
 default-client = ["hyper-util/client-legacy"]
-wasm-client = ["dep:reqwest"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,9 @@ tower-http = { version = "0.6.1", features = ["map-response-body", "trace"] }
 tracing = { version = "0.1.37", features = ["log"], optional = true }
 url = { version = "2.2.2", features = ["serde"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+reqwest = { version = "0.12.0", default-features = false, optional = true }
+
 [dev-dependencies]
 tokio = { version = "1.17.0", default-features = false, features = [
     "macros",
@@ -131,3 +134,4 @@ opentls = ["hyper-tls"]
 stream = ["futures-core", "futures-util"]
 timeout = ["hyper-timeout", "tokio", "tower/timeout"]
 default-client = ["hyper-util/client-legacy"]
+wasm-client = ["dep:reqwest"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,39 @@ Run this command in your terminal to add the latest version of `Octocrab`.
 cargo add octocrab
 ```
 
+### WebAssembly
+For `wasm32-unknown-unknown` browser targets, disable the default client and
+enable the `wasm-client` feature:
+
+```toml
+octocrab = { version = "0.50", default-features = false, features = [
+    "jwt-rust-crypto",
+    "wasm-client",
+] }
+```
+
+Then construct Octocrab with the browser-compatible service:
+
+```rust
+use std::sync::Arc;
+
+use http::{header::USER_AGENT, Uri};
+use octocrab::service::middleware::base_uri::BaseUriLayer;
+use octocrab::service::middleware::extra_headers::ExtraHeadersLayer;
+use octocrab::service::wasm::ReqwestService;
+use octocrab::{AuthState, OctocrabBuilder};
+
+let octocrab = OctocrabBuilder::new_empty()
+    .with_service(ReqwestService::new())
+    .with_layer(&BaseUriLayer::new(Uri::from_static("https://api.github.com")))
+    .with_layer(&ExtraHeadersLayer::new(Arc::new(vec![(
+        USER_AGENT,
+        "octocrab".parse().unwrap(),
+    )])))
+    .with_auth(AuthState::None)
+    .build()?;
+```
+
 ## Semantic API
 The semantic API provides strong typing around GitHub's API, a set of
 [`models`] that maps to GitHub's types, and [`auth`] functions that are useful

--- a/README.md
+++ b/README.md
@@ -19,13 +19,11 @@ cargo add octocrab
 ```
 
 ### WebAssembly
-For `wasm32-unknown-unknown` browser targets, disable the default client and
-enable the `wasm-client` feature:
+For `wasm32-unknown-unknown` browser targets, disable the default client:
 
 ```toml
 octocrab = { version = "0.50", default-features = false, features = [
     "jwt-rust-crypto",
-    "wasm-client",
 ] }
 ```
 

--- a/examples/wasm_client.rs
+++ b/examples/wasm_client.rs
@@ -1,32 +1,37 @@
-cfg_select! {
-    target_arch = "wasm32" => {
-        use std::sync::Arc;
+#[cfg(target_arch = "wasm32")]
+mod wasm_client {
+    use std::sync::Arc;
 
-        use http::{header::USER_AGENT, Uri};
-        use octocrab::service::middleware::base_uri::BaseUriLayer;
-        use octocrab::service::middleware::extra_headers::ExtraHeadersLayer;
-        use octocrab::service::wasm::ReqwestService;
-        use octocrab::{AuthState, Octocrab, OctocrabBuilder};
+    use http::{header::USER_AGENT, Uri};
+    use octocrab::service::middleware::base_uri::BaseUriLayer;
+    use octocrab::service::middleware::extra_headers::ExtraHeadersLayer;
+    use octocrab::service::wasm::ReqwestService;
+    use octocrab::{AuthState, Octocrab, OctocrabBuilder};
 
-        fn build_octocrab() -> octocrab::Result<Octocrab, std::convert::Infallible> {
-            OctocrabBuilder::new_empty()
-                .with_service(ReqwestService::new())
-                .with_layer(&BaseUriLayer::new(Uri::from_static(
-                    "https://api.github.com",
-                )))
-                .with_layer(&ExtraHeadersLayer::new(Arc::new(vec![(
-                    USER_AGENT,
-                    "octocrab".parse().unwrap(),
-                )])))
-                .with_auth(AuthState::None)
-                .build()
-        }
-
-        fn main() {
-            let _octocrab = build_octocrab().expect("build wasm client");
-        }
+    fn build_octocrab() -> octocrab::Result<Octocrab, std::convert::Infallible> {
+        OctocrabBuilder::new_empty()
+            .with_service(ReqwestService::new())
+            .with_layer(&BaseUriLayer::new(Uri::from_static(
+                "https://api.github.com",
+            )))
+            .with_layer(&ExtraHeadersLayer::new(Arc::new(vec![(
+                USER_AGENT,
+                "octocrab".parse().unwrap(),
+            )])))
+            .with_auth(AuthState::None)
+            .build()
     }
-    _ => {
-        fn main() {}
+
+    pub fn run() {
+        let _octocrab = build_octocrab().expect("build wasm client");
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    wasm_client::run();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
 }

--- a/examples/wasm_client.rs
+++ b/examples/wasm_client.rs
@@ -33,5 +33,4 @@ fn main() {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn main() {
-}
+fn main() {}

--- a/examples/wasm_client.rs
+++ b/examples/wasm_client.rs
@@ -1,5 +1,5 @@
-cfg_if::cfg_if! {
-    if #[cfg(target_arch = "wasm32")] {
+cfg_select! {
+    target_arch = "wasm32" => {
         use std::sync::Arc;
 
         use http::{header::USER_AGENT, Uri};
@@ -25,7 +25,8 @@ cfg_if::cfg_if! {
         fn main() {
             let _octocrab = build_octocrab().expect("build wasm client");
         }
-    } else {
+    }
+    _ => {
         fn main() {}
     }
 }

--- a/examples/wasm_client.rs
+++ b/examples/wasm_client.rs
@@ -1,0 +1,36 @@
+#[cfg(target_arch = "wasm32")]
+use std::sync::Arc;
+
+#[cfg(target_arch = "wasm32")]
+use http::{header::USER_AGENT, Uri};
+#[cfg(target_arch = "wasm32")]
+use octocrab::service::middleware::base_uri::BaseUriLayer;
+#[cfg(target_arch = "wasm32")]
+use octocrab::service::middleware::extra_headers::ExtraHeadersLayer;
+#[cfg(target_arch = "wasm32")]
+use octocrab::service::wasm::ReqwestService;
+#[cfg(target_arch = "wasm32")]
+use octocrab::{AuthState, Octocrab, OctocrabBuilder};
+
+#[cfg(target_arch = "wasm32")]
+fn build_octocrab() -> octocrab::Result<Octocrab, std::convert::Infallible> {
+    OctocrabBuilder::new_empty()
+        .with_service(ReqwestService::new())
+        .with_layer(&BaseUriLayer::new(Uri::from_static(
+            "https://api.github.com",
+        )))
+        .with_layer(&ExtraHeadersLayer::new(Arc::new(vec![(
+            USER_AGENT,
+            "octocrab".parse().unwrap(),
+        )])))
+        .with_auth(AuthState::None)
+        .build()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    let _octocrab = build_octocrab().expect("build wasm client");
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/examples/wasm_client.rs
+++ b/examples/wasm_client.rs
@@ -1,36 +1,31 @@
-#[cfg(target_arch = "wasm32")]
-use std::sync::Arc;
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+        use std::sync::Arc;
 
-#[cfg(target_arch = "wasm32")]
-use http::{header::USER_AGENT, Uri};
-#[cfg(target_arch = "wasm32")]
-use octocrab::service::middleware::base_uri::BaseUriLayer;
-#[cfg(target_arch = "wasm32")]
-use octocrab::service::middleware::extra_headers::ExtraHeadersLayer;
-#[cfg(target_arch = "wasm32")]
-use octocrab::service::wasm::ReqwestService;
-#[cfg(target_arch = "wasm32")]
-use octocrab::{AuthState, Octocrab, OctocrabBuilder};
+        use http::{header::USER_AGENT, Uri};
+        use octocrab::service::middleware::base_uri::BaseUriLayer;
+        use octocrab::service::middleware::extra_headers::ExtraHeadersLayer;
+        use octocrab::service::wasm::ReqwestService;
+        use octocrab::{AuthState, Octocrab, OctocrabBuilder};
 
-#[cfg(target_arch = "wasm32")]
-fn build_octocrab() -> octocrab::Result<Octocrab, std::convert::Infallible> {
-    OctocrabBuilder::new_empty()
-        .with_service(ReqwestService::new())
-        .with_layer(&BaseUriLayer::new(Uri::from_static(
-            "https://api.github.com",
-        )))
-        .with_layer(&ExtraHeadersLayer::new(Arc::new(vec![(
-            USER_AGENT,
-            "octocrab".parse().unwrap(),
-        )])))
-        .with_auth(AuthState::None)
-        .build()
+        fn build_octocrab() -> octocrab::Result<Octocrab, std::convert::Infallible> {
+            OctocrabBuilder::new_empty()
+                .with_service(ReqwestService::new())
+                .with_layer(&BaseUriLayer::new(Uri::from_static(
+                    "https://api.github.com",
+                )))
+                .with_layer(&ExtraHeadersLayer::new(Arc::new(vec![(
+                    USER_AGENT,
+                    "octocrab".parse().unwrap(),
+                )])))
+                .with_auth(AuthState::None)
+                .build()
+        }
+
+        fn main() {
+            let _octocrab = build_octocrab().expect("build wasm client");
+        }
+    } else {
+        fn main() {}
+    }
 }
-
-#[cfg(target_arch = "wasm32")]
-fn main() {
-    let _octocrab = build_octocrab().expect("build wasm client");
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,9 +332,9 @@ compile_error!("at least one of the features \"jwt-rust-crypto\" and feature \"j
 /// A convenience type with a default error type of [`Error`].
 pub type Result<T, E = error::Error> = std::result::Result<T, E>;
 
-#[cfg(feature = "default-client")]
+#[allow(dead_code)]
 const GITHUB_BASE_URI: &str = "https://api.github.com";
-#[cfg(feature = "default-client")]
+#[allow(dead_code)]
 const GITHUB_BASE_UPLOAD_URI: &str = "https://uploads.github.com";
 
 // This `include!` gives us pub const _SET_HEADERS_MAP: [(&str, &str)]
@@ -1207,9 +1207,11 @@ impl Octocrab {
     {
         OctocrabBuilder::new_empty().with_config(DefaultOctocrabBuilderConfig::default())
     }
+}
 
+#[cfg(not(target_arch = "wasm32"))]
+impl Octocrab {
     /// Creates a new `Octocrab`.
-    #[cfg(not(target_arch = "wasm32"))]
     fn new<S>(service: S, auth_state: AuthState) -> Self
     where
         S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>>
@@ -1226,25 +1228,7 @@ impl Octocrab {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
-    fn new<S>(service: S, auth_state: AuthState) -> Self
-    where
-        S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>> + 'static,
-        S::Future: 'static,
-        S::Error: Into<BoxError>,
-    {
-        let service = Rc::new(RefCell::new(UnsyncBoxService::new(
-            service.map_err(Into::into),
-        )));
-
-        Self {
-            client: service,
-            auth_state,
-        }
-    }
-
     /// Creates a new `Octocrab` with a custom executor
-    #[cfg(not(target_arch = "wasm32"))]
     fn new_with_executor<S>(service: S, auth_state: AuthState, executor: Executor) -> Self
     where
         S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>>
@@ -1264,9 +1248,28 @@ impl Octocrab {
             auth_state,
         }
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl Octocrab {
+    /// Creates a new `Octocrab`.
+    fn new<S>(service: S, auth_state: AuthState) -> Self
+    where
+        S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>> + 'static,
+        S::Future: 'static,
+        S::Error: Into<BoxError>,
+    {
+        let service = Rc::new(RefCell::new(UnsyncBoxService::new(
+            service.map_err(Into::into),
+        )));
+
+        Self {
+            client: service,
+            auth_state,
+        }
+    }
 
     /// Creates a new `Octocrab` with a custom executor.
-    #[cfg(target_arch = "wasm32")]
     fn new_with_executor<S>(service: S, auth_state: AuthState, _executor: Executor) -> Self
     where
         S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>> + 'static,
@@ -1275,7 +1278,9 @@ impl Octocrab {
     {
         Self::new(service, auth_state)
     }
+}
 
+impl Octocrab {
     /// Returns a new `Octocrab` based on the current builder but
     /// authorizing via a specific installation ID.
     /// Typically you will first construct an `Octocrab` using

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,15 +236,11 @@ use service::middleware::auth_header::AuthHeaderLayer;
 use service::middleware::cache::CacheStorage;
 #[cfg(feature = "default-client")]
 use service::middleware::cache::HttpCacheLayer;
-#[cfg(target_arch = "wasm32")]
-use std::cell::RefCell;
 use std::convert::{Infallible, TryInto};
 use std::future::Future;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::pin::Pin;
-#[cfg(target_arch = "wasm32")]
-use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::{fmt, usize};
@@ -262,10 +258,6 @@ use once_cell::sync::Lazy;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use snafu::*;
-#[cfg(target_arch = "wasm32")]
-use tower::util::UnsyncBoxService;
-#[cfg(not(target_arch = "wasm32"))]
-use tower::{buffer::Buffer, util::BoxService};
 use tower::{BoxError, Layer, Service, ServiceExt};
 
 use bytes::Bytes;
@@ -1161,15 +1153,23 @@ pub enum AuthState {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub type OctocrabService = Buffer<
+pub type OctocrabService = tower::buffer::Buffer<
     http::Request<OctoBody>,
-    <BoxService<http::Request<OctoBody>, http::Response<BoxBody<Bytes, Error>>, BoxError> as tower::Service<http::Request<OctoBody>>>::Future
+    <tower::util::BoxService<
+        http::Request<OctoBody>,
+        http::Response<BoxBody<Bytes, Error>>,
+        BoxError,
+    > as tower::Service<http::Request<OctoBody>>>::Future,
 >;
 
 #[cfg(target_arch = "wasm32")]
-pub type OctocrabService = Rc<
-    RefCell<
-        UnsyncBoxService<http::Request<OctoBody>, http::Response<BoxBody<Bytes, Error>>, BoxError>,
+pub type OctocrabService = std::rc::Rc<
+    std::cell::RefCell<
+        tower::util::UnsyncBoxService<
+            http::Request<OctoBody>,
+            http::Response<BoxBody<Bytes, Error>>,
+            BoxError,
+        >,
     >,
 >;
 
@@ -1220,7 +1220,10 @@ impl Octocrab {
         S::Future: Send + 'static,
         S::Error: Into<BoxError>,
     {
-        let service = Buffer::new(BoxService::new(service.map_err(Into::into)), 1024);
+        let service = tower::buffer::Buffer::new(
+            tower::util::BoxService::new(service.map_err(Into::into)),
+            1024,
+        );
 
         Self {
             client: service,
@@ -1238,7 +1241,10 @@ impl Octocrab {
         S::Error: Into<BoxError>,
     {
         // Use Buffer pair to return the background worker
-        let (service, worker) = Buffer::pair(BoxService::new(service.map_err(Into::into)), 1024);
+        let (service, worker) = tower::buffer::Buffer::pair(
+            tower::util::BoxService::new(service.map_err(Into::into)),
+            1024,
+        );
 
         // Execute the background worker with the custom executor
         executor(Box::pin(worker));
@@ -1259,9 +1265,9 @@ impl Octocrab {
         S::Future: 'static,
         S::Error: Into<BoxError>,
     {
-        let service = Rc::new(RefCell::new(UnsyncBoxService::new(
-            service.map_err(Into::into),
-        )));
+        let service = std::rc::Rc::new(std::cell::RefCell::new(
+            tower::util::UnsyncBoxService::new(service.map_err(Into::into)),
+        ));
 
         Self {
             client: service,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,31 +226,50 @@ use api::repos::RepoRef;
 use api::users::UserRef;
 pub use body::OctoBody;
 use chrono::{DateTime, Utc};
-use http::{HeaderMap, HeaderValue, Method, Uri};
+#[cfg(all(feature = "default-client", feature = "tracing"))]
+use http::HeaderMap;
+use http::{HeaderValue, Method, Uri};
 use http_body_util::combinators::BoxBody;
 use http_body_util::BodyExt;
+#[cfg(feature = "default-client")]
 use service::middleware::auth_header::AuthHeaderLayer;
-use service::middleware::cache::{CacheStorage, HttpCacheLayer};
+use service::middleware::cache::CacheStorage;
+#[cfg(feature = "default-client")]
+use service::middleware::cache::HttpCacheLayer;
+#[cfg(target_arch = "wasm32")]
+use std::cell::RefCell;
 use std::convert::{Infallible, TryInto};
 use std::future::Future;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::pin::Pin;
+#[cfg(target_arch = "wasm32")]
+use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::{fmt, usize};
+#[cfg(any(
+    feature = "timeout",
+    all(feature = "default-client", feature = "tracing")
+))]
 use web_time::Duration;
 
 use http::{header::HeaderName, StatusCode};
 use hyper::{Request, Response};
 
+#[cfg(feature = "default-client")]
 use once_cell::sync::Lazy;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use snafu::*;
-use tower::{buffer::Buffer, util::BoxService, BoxError, Layer, Service, ServiceExt};
+#[cfg(target_arch = "wasm32")]
+use tower::util::UnsyncBoxService;
+#[cfg(not(target_arch = "wasm32"))]
+use tower::{buffer::Buffer, util::BoxService};
+use tower::{BoxError, Layer, Service, ServiceExt};
 
 use bytes::Bytes;
+#[cfg(feature = "default-client")]
 use http::header::USER_AGENT;
 use http::request::Builder;
 #[cfg(feature = "opentls")]
@@ -265,18 +284,24 @@ use tower::retry::{Retry, RetryLayer};
 #[cfg(feature = "timeout")]
 use hyper_timeout::TimeoutConnector;
 
-use tower_http::{classify::ServerErrorsFailureClass, map_response_body::MapResponseBodyLayer};
+#[cfg(all(feature = "default-client", feature = "tracing"))]
+use tower_http::classify::ServerErrorsFailureClass;
+use tower_http::map_response_body::MapResponseBodyLayer;
 
 #[cfg(feature = "tracing")]
 use {tower_http::trace::TraceLayer, tracing::Span};
 
 use crate::api::codes_of_conduct;
+#[cfg(feature = "default-client")]
+use crate::error::HyperSnafu;
 use crate::error::{
-    HttpSnafu, HyperSnafu, InvalidUtf8Snafu, SerdeSnafu, SerdeUrlEncodedSnafu, ServiceSnafu,
-    UriParseError, UriParseSnafu, UriSnafu,
+    HttpSnafu, InvalidUtf8Snafu, SerdeSnafu, SerdeUrlEncodedSnafu, ServiceSnafu, UriParseError,
+    UriParseSnafu, UriSnafu,
 };
 
+#[cfg(feature = "default-client")]
 use crate::service::middleware::base_uri::BaseUriLayer;
+#[cfg(feature = "default-client")]
 use crate::service::middleware::extra_headers::ExtraHeadersLayer;
 
 #[cfg(feature = "retry")]
@@ -307,7 +332,9 @@ compile_error!("at least one of the features \"jwt-rust-crypto\" and feature \"j
 /// A convenience type with a default error type of [`Error`].
 pub type Result<T, E = error::Error> = std::result::Result<T, E>;
 
+#[cfg(feature = "default-client")]
 const GITHUB_BASE_URI: &str = "https://api.github.com";
+#[cfg(feature = "default-client")]
 const GITHUB_BASE_UPLOAD_URI: &str = "https://uploads.github.com";
 
 // This `include!` gives us pub const _SET_HEADERS_MAP: [(&str, &str)]
@@ -481,6 +508,7 @@ impl<Config, Auth> OctocrabBuilder<NoSvc, Config, Auth, NotLayerReady> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Svc, Config, Auth, B> OctocrabBuilder<Svc, Config, Auth, LayerReady>
 where
     Svc: Service<Request<OctoBody>, Response = Response<B>> + Send + 'static,
@@ -503,10 +531,65 @@ where
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+impl<Svc, Config, Auth, B> OctocrabBuilder<Svc, Config, Auth, LayerReady>
+where
+    Svc: Service<Request<OctoBody>, Response = Response<B>> + 'static,
+    Svc::Future: 'static,
+    Svc::Error: Into<BoxError>,
+    B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    B::Error: Into<BoxError>,
+{
+    pub fn with_executor(
+        self,
+        executor: Executor,
+    ) -> OctocrabBuilder<Svc, Config, Auth, LayerReady> {
+        OctocrabBuilder {
+            service: self.service,
+            auth: self.auth,
+            config: self.config,
+            _layer_ready: PhantomData,
+            executor: Some(executor),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 impl<Svc, Config, Auth, B> OctocrabBuilder<Svc, Config, Auth, LayerReady>
 where
     Svc: Service<Request<OctoBody>, Response = Response<B>> + Send + 'static,
     Svc::Future: Send + 'static,
+    Svc::Error: Into<BoxError>,
+    B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    B::Error: Into<BoxError>,
+{
+    /// Add a [`Layer`] to the current [`Service`] stack.
+    pub fn with_layer<L: Layer<Svc>>(
+        self,
+        layer: &L,
+    ) -> OctocrabBuilder<L::Service, Config, Auth, LayerReady> {
+        let Self {
+            service: stack,
+            auth,
+            config,
+            executor,
+            ..
+        } = self;
+        OctocrabBuilder {
+            service: layer.layer(stack),
+            auth,
+            config,
+            executor,
+            _layer_ready: PhantomData,
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<Svc, Config, Auth, B> OctocrabBuilder<Svc, Config, Auth, LayerReady>
+where
+    Svc: Service<Request<OctoBody>, Response = Response<B>> + 'static,
+    Svc::Future: 'static,
     Svc::Error: Into<BoxError>,
     B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
     B::Error: Into<BoxError>,
@@ -551,10 +634,37 @@ impl<Svc, Auth, LayerState> OctocrabBuilder<Svc, NoConfig, Auth, LayerState> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Svc, B, LayerState> OctocrabBuilder<Svc, NoConfig, AuthState, LayerState>
 where
     Svc: Service<Request<OctoBody>, Response = Response<B>> + Send + 'static,
     Svc::Future: Send + 'static,
+    Svc::Error: Into<BoxError>,
+    B: http_body::Body<Data = bytes::Bytes> + Send + Sync + 'static,
+    B::Error: Into<BoxError>,
+{
+    /// Build a [`Client`](OctocrabService) instance with the current [`Service`] stack.
+    pub fn build(self) -> Result<Octocrab, Infallible> {
+        // Transform response body to `BoxBody<Bytes, crate::Error>` and use type erased error to avoid type parameters.
+        let service = MapResponseBodyLayer::new(|b: B| {
+            b.map_err(|e| ServiceSnafu.into_error(e.into())).boxed()
+        })
+        .layer(self.service)
+        .map_err(|e| e.into());
+
+        if let Some(executor) = self.executor {
+            return Ok(Octocrab::new_with_executor(service, self.auth, executor));
+        }
+
+        Ok(Octocrab::new(service, self.auth))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<Svc, B, LayerState> OctocrabBuilder<Svc, NoConfig, AuthState, LayerState>
+where
+    Svc: Service<Request<OctoBody>, Response = Response<B>> + 'static,
+    Svc::Future: 'static,
     Svc::Error: Into<BoxError>,
     B: http_body::Body<Data = bytes::Bytes> + Send + Sync + 'static,
     B::Error: Into<BoxError>,
@@ -1050,9 +1160,17 @@ pub enum AuthState {
     },
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub type OctocrabService = Buffer<
     http::Request<OctoBody>,
     <BoxService<http::Request<OctoBody>, http::Response<BoxBody<Bytes, Error>>, BoxError> as tower::Service<http::Request<OctoBody>>>::Future
+>;
+
+#[cfg(target_arch = "wasm32")]
+pub type OctocrabService = Rc<
+    RefCell<
+        UnsyncBoxService<http::Request<OctoBody>, http::Response<BoxBody<Bytes, Error>>, BoxError>,
+    >,
 >;
 
 /// The GitHub API client.
@@ -1091,6 +1209,7 @@ impl Octocrab {
     }
 
     /// Creates a new `Octocrab`.
+    #[cfg(not(target_arch = "wasm32"))]
     fn new<S>(service: S, auth_state: AuthState) -> Self
     where
         S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>>
@@ -1107,7 +1226,25 @@ impl Octocrab {
         }
     }
 
+    #[cfg(target_arch = "wasm32")]
+    fn new<S>(service: S, auth_state: AuthState) -> Self
+    where
+        S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>> + 'static,
+        S::Future: 'static,
+        S::Error: Into<BoxError>,
+    {
+        let service = Rc::new(RefCell::new(UnsyncBoxService::new(
+            service.map_err(Into::into),
+        )));
+
+        Self {
+            client: service,
+            auth_state,
+        }
+    }
+
     /// Creates a new `Octocrab` with a custom executor
+    #[cfg(not(target_arch = "wasm32"))]
     fn new_with_executor<S>(service: S, auth_state: AuthState, executor: Executor) -> Self
     where
         S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>>
@@ -1126,6 +1263,17 @@ impl Octocrab {
             client: service,
             auth_state,
         }
+    }
+
+    /// Creates a new `Octocrab` with a custom executor.
+    #[cfg(target_arch = "wasm32")]
+    fn new_with_executor<S>(service: S, auth_state: AuthState, _executor: Executor) -> Self
+    where
+        S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>> + 'static,
+        S::Future: 'static,
+        S::Error: Into<BoxError>,
+    {
+        Self::new(service, auth_state)
     }
 
     /// Returns a new `Octocrab` based on the current builder but
@@ -1811,15 +1959,32 @@ impl Octocrab {
         &self,
         request: Request<OctoBody>,
     ) -> Result<http::Response<BoxBody<Bytes, crate::Error>>> {
-        let mut svc = self.client.clone();
-        let response: Response<BoxBody<Bytes, crate::Error>> = svc
-            .ready()
-            .await
-            .context(ServiceSnafu)?
-            .call(request)
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let mut svc = self.client.clone();
+            let response: Response<BoxBody<Bytes, crate::Error>> = svc
+                .ready()
+                .await
+                .context(ServiceSnafu)?
+                .call(request)
+                .await
+                .context(ServiceSnafu)?;
+            Ok(response)
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            futures::future::poll_fn(|cx| self.client.borrow_mut().poll_ready(cx))
+                .await
+                .context(ServiceSnafu)?;
+
+            let response: Response<BoxBody<Bytes, crate::Error>> = {
+                let mut svc = self.client.borrow_mut();
+                svc.call(request)
+            }
             .await
             .context(ServiceSnafu)?;
-        Ok(response)
+            Ok(response)
+        }
         //todo: attempt to downcast error to something more specific before returning. (Currently having trouble with this because I am not accustomed with snafu)
         // map_err(|err| {
         //     // Error decorating request

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,1 +1,5 @@
 pub mod middleware;
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-client"))]
+#[cfg_attr(docsrs, doc(cfg(all(target_arch = "wasm32", feature = "wasm-client"))))]
+pub mod wasm;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,5 +1,5 @@
 pub mod middleware;
 
-#[cfg(all(target_arch = "wasm32", feature = "wasm-client"))]
-#[cfg_attr(docsrs, doc(cfg(all(target_arch = "wasm32", feature = "wasm-client"))))]
+#[cfg(target_arch = "wasm32")]
+#[cfg_attr(docsrs, doc(cfg(target_arch = "wasm32")))]
 pub mod wasm;

--- a/src/service/wasm.rs
+++ b/src/service/wasm.rs
@@ -1,0 +1,67 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use http::{Request, Response};
+use http_body_util::{BodyExt, Full};
+use tower::{BoxError, Service};
+
+use crate::OctoBody;
+
+/// A browser-compatible HTTP service for Octocrab.
+///
+/// This service is intended for `wasm32-unknown-unknown` targets where the
+/// default hyper client is unavailable. It wraps `reqwest`'s browser client and
+/// returns collected response bodies that Octocrab can deserialize.
+#[derive(Clone, Debug, Default)]
+pub struct ReqwestService {
+    client: reqwest::Client,
+}
+
+impl ReqwestService {
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+        }
+    }
+
+    pub fn with_client(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+}
+
+impl Service<Request<OctoBody>> for ReqwestService {
+    type Response = Response<Full<Bytes>>;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: Request<OctoBody>) -> Self::Future {
+        let client = self.client.clone();
+
+        Box::pin(async move {
+            let (parts, body) = request.into_parts();
+            let body = body.collect().await?.to_bytes();
+
+            let response = client
+                .request(parts.method, parts.uri.to_string())
+                .headers(parts.headers)
+                .body(body)
+                .send()
+                .await?;
+
+            let status = response.status();
+            let headers = response.headers().clone();
+            let body = response.bytes().await?;
+
+            let mut builder = Response::builder().status(status);
+            *builder.headers_mut().expect("response builder is valid") = headers;
+
+            Ok(builder.body(Full::new(body))?)
+        })
+    }
+}


### PR DESCRIPTION
Quick update from the follow-up branch: I initially tried `cfg_select!` in response to the review suggestion, but CI caught that it is still unstable on stable Rust (`E0658`).

I updated the follow-up PR to use stable item-level `#[cfg]` gating for the wasm example instead, while keeping the import cleanup in `src/lib.rs`. The latest CI run on the follow-up branch is green across clippy, wasm-build, Ubuntu, macOS, and Windows: https://github.com/dairon2/octocrab/actions/runs/25689928898

Follow-up PR: https://github.com/VoltVoks/octocrab-bounty-work/pull/1
