### PR TITLE
fix: Octocrab doesn't compile with Yew (for me)

### DIFF
--- a/src/from_response.rs
+++ b/src/from_response.rs
@@ -4,14 +4,16 @@ use http_body_util::BodyExt;
 use snafu::ResultExt;
 
 /// A trait for mapping from a `http::Response` to an another type.
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait FromResponse: Sized {
     async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
     where
         B: Body<Data = Bytes, Error = crate::Error> + Send;
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<T: serde::de::DeserializeOwned> FromResponse for T {
     async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
     where

--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -259,7 +259,8 @@ impl Content {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl crate::FromResponse for ContentItems {
     async fn from_response<B>(response: Response<B>) -> crate::Result<Self>
     where

--- a/src/page.rs
+++ b/src/page.rs
@@ -177,7 +177,8 @@ impl<'iter, T> IntoIterator for &'iter Page<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<T: serde::de::DeserializeOwned> crate::FromResponse for Page<T> {
     async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
     where


### PR DESCRIPTION
Fixes #224

Compiles cleanly. The changes are:

**`src/from_response.rs`** (lines 7-8, 15-16): Replaced both `#[async_trait::async_trait]` attributes on the `FromResponse` trait definition and its blanket impl with conditional `cfg_attr` pairs — using the standard `async_trait` on non-wasm32 and `async_trait(?Send)` on wasm32.

**`src/page.rs`** (line 180-181): Same change for `Page<T>`'s `FromResponse` impl.

**`src/models/repos.rs`** (line 262-263): Same change for `ContentItems`'s `FromResponse` impl.

**Root cause**: `async_trait` by default generates futures with a `+ Send` bound. On `wasm32-unknown-unknown` (used by Yew/Trunk), many types backed by JavaScript objects (e.g. `reqwest::Response` in the older version, or any JS-bridged type) are not `Send`. The `?Send` variant relaxes this requirement so futures don't need to be `Send`, which is correct for the single-threaded WASM runtime.