### PR TITLE
fix: resolve WASM Send trait violation in FromResponse (#224)

### DIFF
--- a/src/from_response.rs
+++ b/src/from_response.rs
@@ -3,23 +3,52 @@ use http_body::Body;
 use http_body_util::BodyExt;
 use snafu::ResultExt;
 
-/// A trait for mapping from a `http::Response` to an another type.
-#[async_trait::async_trait]
-pub trait FromResponse: Sized {
-    async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
-    where
-        B: Body<Data = Bytes, Error = crate::Error> + Send;
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+        /// A trait for mapping from a `http::Response` to an another type.
+        #[async_trait::async_trait(?Send)]
+        pub trait FromResponse: Sized {
+            async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
+            where
+                B: Body<Data = Bytes, Error = crate::Error>;
+        }
+    } else {
+        /// A trait for mapping from a `http::Response` to an another type.
+        #[async_trait::async_trait]
+        pub trait FromResponse: Sized {
+            async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
+            where
+                B: Body<Data = Bytes, Error = crate::Error> + Send;
+        }
+    }
 }
 
-#[async_trait::async_trait]
-impl<T: serde::de::DeserializeOwned> FromResponse for T {
-    async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
-    where
-        B: Body<Data = Bytes, Error = crate::Error> + Send,
-    {
-        let (_, body) = response.into_parts();
-        let body = body.collect().await?.to_bytes();
-        let de = &mut serde_json::Deserializer::from_slice(&body);
-        return serde_path_to_error::deserialize(de).context(crate::error::JsonSnafu);
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+        #[async_trait::async_trait(?Send)]
+        impl<T: serde::de::DeserializeOwned> FromResponse for T {
+            async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
+            where
+                B: Body<Data = Bytes, Error = crate::Error>,
+            {
+                let (_, body) = response.into_parts();
+                let body = body.collect().await?.to_bytes();
+                let de = &mut serde_json::Deserializer::from_slice(&body);
+                return serde_path_to_error::deserialize(de).context(crate::error::JsonSnafu);
+            }
+        }
+    } else {
+        #[async_trait::async_trait]
+        impl<T: serde::de::DeserializeOwned> FromResponse for T {
+            async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
+            where
+                B: Body<Data = Bytes, Error = crate::Error> + Send,
+            {
+                let (_, body) = response.into_parts();
+                let body = body.collect().await?.to_bytes();
+                let de = &mut serde_json::Deserializer::from_slice(&body);
+                return serde_path_to_error::deserialize(de).context(crate::error::JsonSnafu);
+            }
+        }
     }
 }

--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -259,24 +259,50 @@ impl Content {
     }
 }
 
-#[async_trait::async_trait]
-impl crate::FromResponse for ContentItems {
-    async fn from_response<B>(response: Response<B>) -> crate::Result<Self>
-    where
-        B: Body<Data = Bytes, Error = crate::Error> + Send,
-    {
-        let json: serde_json::Value =
-            serde_json::from_slice(response.into_body().collect().await?.to_bytes().as_ref())
-                .context(SerdeSnafu)?;
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+        #[async_trait::async_trait(?Send)]
+        impl crate::FromResponse for ContentItems {
+            async fn from_response<B>(response: Response<B>) -> crate::Result<Self>
+            where
+                B: Body<Data = Bytes, Error = crate::Error>,
+            {
+                let json: serde_json::Value =
+                    serde_json::from_slice(response.into_body().collect().await?.to_bytes().as_ref())
+                        .context(SerdeSnafu)?;
 
-        if json.is_array() {
-            Ok(ContentItems {
-                items: serde_json::from_value(json).context(crate::error::SerdeSnafu)?,
-            })
-        } else {
-            let items = vec![serde_json::from_value(json).context(crate::error::SerdeSnafu)?];
+                if json.is_array() {
+                    Ok(ContentItems {
+                        items: serde_json::from_value(json).context(crate::error::SerdeSnafu)?,
+                    })
+                } else {
+                    let items = vec![serde_json::from_value(json).context(crate::error::SerdeSnafu)?];
 
-            Ok(ContentItems { items })
+                    Ok(ContentItems { items })
+                }
+            }
+        }
+    } else {
+        #[async_trait::async_trait]
+        impl crate::FromResponse for ContentItems {
+            async fn from_response<B>(response: Response<B>) -> crate::Result<Self>
+            where
+                B: Body<Data = Bytes, Error = crate::Error> + Send,
+            {
+                let json: serde_json::Value =
+                    serde_json::from_slice(response.into_body().collect().await?.to_bytes().as_ref())
+                        .context(SerdeSnafu)?;
+
+                if json.is_array() {
+                    Ok(ContentItems {
+                        items: serde_json::from_value(json).context(crate::error::SerdeSnafu)?,
+                    })
+                } else {
+                    let items = vec![serde_json::from_value(json).context(crate::error::SerdeSnafu)?];
+
+                    Ok(ContentItems { items })
+                }
+            }
         }
     }
 }

--- a/src/page.rs
+++ b/src/page.rs
@@ -177,63 +177,128 @@ impl<'iter, T> IntoIterator for &'iter Page<T> {
     }
 }
 
-#[async_trait::async_trait]
-impl<T: serde::de::DeserializeOwned> crate::FromResponse for Page<T> {
-    async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
-    where
-        B: Body<Data = Bytes, Error = crate::Error> + Send,
-    {
-        let HeaderLinks {
-            first,
-            prev,
-            next,
-            last,
-        } = get_links(response.headers())?;
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+        #[async_trait::async_trait(?Send)]
+        impl<T: serde::de::DeserializeOwned> crate::FromResponse for Page<T> {
+            async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
+            where
+                B: Body<Data = Bytes, Error = crate::Error>,
+            {
+                let HeaderLinks {
+                    first,
+                    prev,
+                    next,
+                    last,
+                } = get_links(response.headers())?;
 
-        let json: serde_json::Value =
-            serde_json::from_slice(response.into_body().collect().await?.to_bytes().as_ref())
-                .context(SerdeSnafu)?;
+                let json: serde_json::Value =
+                    serde_json::from_slice(response.into_body().collect().await?.to_bytes().as_ref())
+                        .context(SerdeSnafu)?;
 
-        if json.is_array() {
-            Ok(Self {
-                items: serde_json::from_value(json).context(crate::error::SerdeSnafu)?,
-                incomplete_results: None,
-                total_count: None,
-                next,
-                prev,
-                first,
-                last,
-            })
-        } else {
-            let attr = vec![
-                "items",
-                "workflows",
-                "workflow_runs",
-                "jobs",
-                "artifacts",
-                "repositories",
-                "installations",
-                "runners",
-            ]
-            .into_iter()
-            .find(|v| json.get(v).is_some())
-            .ok_or(Box::from(
-                "error decoding pagination result, top-level attribute unknown",
-            ))
-            .context(crate::error::OtherSnafu)?;
+                if json.is_array() {
+                    Ok(Self {
+                        items: serde_json::from_value(json).context(crate::error::SerdeSnafu)?,
+                        incomplete_results: None,
+                        total_count: None,
+                        next,
+                        prev,
+                        first,
+                        last,
+                    })
+                } else {
+                    let attr = vec![
+                        "items",
+                        "workflows",
+                        "workflow_runs",
+                        "jobs",
+                        "artifacts",
+                        "repositories",
+                        "installations",
+                        "runners",
+                    ]
+                    .into_iter()
+                    .find(|v| json.get(v).is_some())
+                    .ok_or(Box::from(
+                        "error decoding pagination result, top-level attribute unknown",
+                    ))
+                    .context(crate::error::OtherSnafu)?;
 
-            Ok(Self {
-                items: serde_json::from_value(json.get(attr).cloned().unwrap())
-                    .context(crate::error::SerdeSnafu)?,
-                incomplete_results: json
-                    .get("incomplete_results")
-                    .and_then(serde_json::Value::as_bool),
-                total_count: json.get("total_count").and_then(serde_json::Value::as_u64),
-                next,
-                prev,
-                first,
-                last,
-            })
+                    Ok(Self {
+                        items: serde_json::from_value(json.get(attr).cloned().unwrap())
+                            .context(crate::error::SerdeSnafu)?,
+                        incomplete_results: json
+                            .get("incomplete_results")
+                            .and_then(serde_json::Value::as_bool),
+                        total_count: json.get("total_count").and_then(serde_json::Value::as_u64),
+                        next,
+                        prev,
+                        first,
+                        last,
+                    })
+                }
+            }
+        }
+    } else {
+        #[async_trait::async_trait]
+        impl<T: serde::de::DeserializeOwned> crate::FromResponse for Page<T> {
+            async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
+            where
+                B: Body<Data = Bytes, Error = crate::Error> + Send,
+            {
+                let HeaderLinks {
+                    first,
+                    prev,
+                    next,
+                    last,
+                } = get_links(response.headers())?;
+
+                let json: serde_json::Value =
+                    serde_json::from_slice(response.into_body().collect().await?.to_bytes().as_ref())
+                        .context(SerdeSnafu)?;
+
+                if json.is_array() {
+                    Ok(Self {
+                        items: serde_json::from_value(json).context(crate::error::SerdeSnafu)?,
+                        incomplete_results: None,
+                        total_count: None,
+                        next,
+                        prev,
+                        first,
+                        last,
+                    })
+                } else {
+                    let attr = vec![
+                        "items",
+                        "workflows",
+                        "workflow_runs",
+                        "jobs",
+                        "artifacts",
+                        "repositories",
+                        "installations",
+                        "runners",
+                    ]
+                    .into_iter()
+                    .find(|v| json.get(v).is_some())
+                    .ok_or(Box::from(
+                        "error decoding pagination result, top-level attribute unknown",
+                    ))
+                    .context(crate::error::OtherSnafu)?;
+
+                    Ok(Self {
+                        items: serde_json::from_value(json.get(attr).cloned().unwrap())
+                            .context(crate::error::SerdeSnafu)?,
+                        incomplete_results: json
+                            .get("incomplete_results")
+                            .and_then(serde_json::Value::as_bool),
+                        total_count: json.get("total_count").and_then(serde_json::Value::as_u64),
+                        next,
+                        prev,
+                        first,
+                        last,
+                    })
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes the compilation error on WASM where futures returned by sync_trait are not Send because the underlying body type B (often from eqwest on WASM) does not implement Send.

The fix uses cfg_if to:
1. Use #[async_trait(?Send)] on WASM targets.
2. Remove the B: Send bound in the where clause on WASM targets.

This allows octocrab to be used in WASM environments like Yew or other browser-based async runtimes without violating trait bounds.