### PR TITLE
docs: document wasm feature for Yew builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
       - run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-          cargo build --target=wasm32-unknown-unknown --no-default-features -F jwt-rust-crypto
+          cargo build --target=wasm32-unknown-unknown --no-default-features -F wasm
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ features = [
     "stream",
     "timeout",
     "tracing",
+    "wasm",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -131,3 +132,4 @@ opentls = ["hyper-tls"]
 stream = ["futures-core", "futures-util"]
 timeout = ["hyper-timeout", "tokio", "tower/timeout"]
 default-client = ["hyper-util/client-legacy"]
+wasm = ["jwt-rust-crypto"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ Run this command in your terminal to add the latest version of `Octocrab`.
 cargo add octocrab
 ```
 
+### WebAssembly / Yew
+
+For `wasm32-unknown-unknown` targets, such as browser apps built with Yew,
+disable Octocrab's default native-client features and enable the `wasm` feature:
+
+```toml
+octocrab = { version = "0.50", default-features = false, features = ["wasm"] }
+```
+
+The default feature set includes native HTTP client support (`tokio`/`mio` and
+TLS connectors) that is not available on `wasm32-unknown-unknown`. Use a custom
+service with `OctocrabBuilder::with_service` when making requests from wasm.
+
 ## Semantic API
 The semantic API provides strong typing around GitHub's API, a set of
 [`models`] that maps to GitHub's types, and [`auth`] functions that are useful


### PR DESCRIPTION
## Summary
- Add a `wasm` feature alias for the minimal feature set that compiles on `wasm32-unknown-unknown`.
- Document the Yew/WebAssembly dependency configuration in the README.
- Update the wasm CI job to use the new feature alias.

## Validation
- `cargo check --target wasm32-unknown-unknown --no-default-features --features wasm`
- `cargo check`
- `git diff --check`

Fixes #224
