### PR TITLE
feat: add list-artifacts-for-a-repository endpoint

### DIFF
--- a/src/api/actions.rs
+++ b/src/api/actions.rs
@@ -17,6 +17,95 @@ use crate::{params, FromResponse, Octocrab, Page};
 use http::request::Builder;
 use http::{header::HeaderMap, Method, StatusCode, Uri};
 
+pub struct ListRepositoryArtifacts<'octo> {
+    crab: &'octo Octocrab,
+    owner: String,
+    repo: String,
+    name: Option<String>,
+    per_page: Option<u8>,
+    page: Option<u32>,
+    etag: Option<EntityTag>,
+}
+
+impl<'octo> ListRepositoryArtifacts<'octo> {
+    pub(crate) fn new(crab: &'octo Octocrab, owner: String, repo: String) -> Self {
+        Self {
+            crab,
+            owner,
+            repo,
+            name: None,
+            per_page: None,
+            page: None,
+            etag: None,
+        }
+    }
+
+    /// Etag for this request.
+    pub fn etag(mut self, etag: Option<EntityTag>) -> Self {
+        self.etag = etag;
+        self
+    }
+
+    /// Filters artifacts by exact match on their name.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Results per page (max 100).
+    pub fn per_page(mut self, per_page: impl Into<u8>) -> Self {
+        self.per_page = Some(per_page.into());
+        self
+    }
+
+    /// Page number of the results to fetch.
+    pub fn page(mut self, page: impl Into<u32>) -> Self {
+        self.page = Some(page.into());
+        self
+    }
+
+    pub async fn send(self) -> crate::Result<Etagged<Page<WorkflowListArtifact>>> {
+        #[derive(serde::Serialize)]
+        struct Query<'a> {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            name: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            per_page: Option<u8>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            page: Option<u32>,
+        }
+
+        let route = format!(
+            "/repos/{owner}/{repo}/actions/artifacts",
+            owner = self.owner,
+            repo = self.repo,
+        );
+        let query = Query {
+            name: self.name.as_deref(),
+            per_page: self.per_page,
+            page: self.page,
+        };
+        let uri = self.crab.parameterized_uri(route, Some(&query))?;
+        let mut headers = HeaderMap::new();
+        if let Some(etag) = self.etag {
+            EntityTag::insert_if_none_match_header(&mut headers, etag)?;
+        }
+
+        let response = self.crab._get_with_headers(uri, Some(headers)).await?;
+        let etag = EntityTag::extract_from_response(&response);
+        if response.status() == StatusCode::NOT_MODIFIED {
+            Ok(Etagged { etag, value: None })
+        } else {
+            <Page<WorkflowListArtifact>>::from_response(crate::map_github_error(response).await?)
+                .await
+                .map(|page| Etagged {
+                    etag,
+                    value: Some(page),
+                })
+        }
+    }
+}
+
 pub struct ListWorkflowRunArtifacts<'octo> {
     crab: &'octo Octocrab,
     owner: String,
@@ -416,6 +505,33 @@ impl<'octo> ActionsHandler<'octo> {
         run_id: RunId,
     ) -> ListWorkflowRunArtifacts<'_> {
         ListWorkflowRunArtifacts::new(self.crab, owner.into(), repo.into(), run_id)
+    }
+
+    /// Lists all artifacts for a repository. Anyone with read access to the
+    /// repository can use this endpoint. OAuth app tokens and personal access
+    /// tokens (classic) need the `repo` scope to use this endpoint with a
+    /// private repository.
+    ///
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// let artifacts = octocrab::instance()
+    ///     .actions()
+    ///     .list_repository_artifacts("owner", "repo")
+    ///     // optional
+    ///     .name("my-artifact")
+    ///     .per_page(30)
+    ///     .page(1u32)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list_repository_artifacts(
+        &self,
+        owner: impl Into<String>,
+        repo: impl Into<String>,
+    ) -> ListRepositoryArtifacts<'_> {
+        ListRepositoryArtifacts::new(self.crab, owner.into(), repo.into())
     }
 
     /// Dispatch a workflow run. You must authenticate using an

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1561,7 +1561,7 @@ impl Octocrab {
 
     /// Convenience method to accept any &str, and attempt to convert it to a Uri.
     /// the method also attempts to serialize any parameters into a query string, and append it to the uri.
-    fn parameterized_uri<A, P>(&self, uri: A, parameters: Option<&P>) -> Result<Uri>
+    pub(crate) fn parameterized_uri<A, P>(&self, uri: A, parameters: Option<&P>) -> Result<Uri>
     where
         A: AsRef<str>,
         P: Serialize + ?Sized,

--- a/src/models/workflows.rs
+++ b/src/models/workflows.rs
@@ -150,6 +150,18 @@ pub struct WorkflowListArtifact {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_run: Option<ArtifactWorkflowRun>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ArtifactWorkflowRun {
+    pub id: crate::models::RunId,
+    pub repository_id: crate::models::RepositoryId,
+    pub head_repository_id: crate::models::RepositoryId,
+    pub head_branch: String,
+    pub head_sha: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]

--- a/tests/actions_list_repository_artifacts_test.rs
+++ b/tests/actions_list_repository_artifacts_test.rs
@@ -1,0 +1,129 @@
+// Tests for calls to the actions "list artifacts for a repository" API:
+// - /repos/{owner}/{repo}/actions/artifacts
+mod mock_error;
+
+use mock_error::setup_error_handler;
+use octocrab::{models::workflows::WorkflowListArtifact, Octocrab, Page};
+use serde::{Deserialize, Serialize};
+use wiremock::{
+    matchers::{method, path, query_param},
+    Mock, MockServer, ResponseTemplate,
+};
+
+const OWNER: &str = "owner";
+const REPO: &str = "repo";
+
+#[derive(Clone, Serialize, Deserialize)]
+struct FakePage {
+    total_count: u64,
+    artifacts: Vec<WorkflowListArtifact>,
+}
+
+async fn setup_api(template: ResponseTemplate) -> MockServer {
+    let mock_server = MockServer::start().await;
+    let uri = format!("/repos/{OWNER}/{REPO}/actions/artifacts");
+
+    Mock::given(method("GET"))
+        .and(path(&uri))
+        .respond_with(template)
+        .mount(&mock_server)
+        .await;
+
+    setup_error_handler(&mock_server, &format!("GET on {uri} was not received")).await;
+    mock_server
+}
+
+fn setup_octocrab(uri: &str) -> Octocrab {
+    Octocrab::builder().base_uri(uri).unwrap().build().unwrap()
+}
+
+#[tokio::test]
+async fn should_return_page_with_repository_artifacts() {
+    let expected: FakePage =
+        serde_json::from_str(include_str!("resources/repository_artifacts.json")).unwrap();
+    let template = ResponseTemplate::new(200).set_body_json(expected.clone());
+    let mock_server = setup_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client
+        .actions()
+        .list_repository_artifacts(OWNER, REPO)
+        .send()
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+    let etagged = result.unwrap();
+    let Page {
+        total_count, items, ..
+    } = etagged.value.expect("expected a page, got None");
+    assert_eq!(total_count.unwrap(), expected.total_count);
+    assert_eq!(items, expected.artifacts);
+
+    let first = &items[0];
+    let workflow_run = first
+        .workflow_run
+        .as_ref()
+        .expect("expected workflow_run on the first artifact");
+    assert_eq!(workflow_run.head_branch, "main");
+}
+
+#[tokio::test]
+async fn should_forward_query_parameters() {
+    let mock_server = MockServer::start().await;
+    let uri = format!("/repos/{OWNER}/{REPO}/actions/artifacts");
+    let expected: FakePage =
+        serde_json::from_str(include_str!("resources/repository_artifacts.json")).unwrap();
+
+    Mock::given(method("GET"))
+        .and(path(&uri))
+        .and(query_param("name", "my-artifact"))
+        .and(query_param("per_page", "10"))
+        .and(query_param("page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(expected))
+        .mount(&mock_server)
+        .await;
+    setup_error_handler(
+        &mock_server,
+        &format!("GET on {uri} with expected query parameters was not received"),
+    )
+    .await;
+
+    let client = setup_octocrab(&mock_server.uri());
+    let result = client
+        .actions()
+        .list_repository_artifacts(OWNER, REPO)
+        .name("my-artifact")
+        .per_page(10u8)
+        .page(2u32)
+        .send()
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn should_be_err_with_500() {
+    let template = ResponseTemplate::new(500);
+    let mock_server = setup_api(template).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client
+        .actions()
+        .list_repository_artifacts(OWNER, REPO)
+        .send()
+        .await;
+
+    assert!(
+        result.is_err(),
+        "expected error result, got success: {:#?}",
+        result
+    );
+}

--- a/tests/resources/repository_artifacts.json
+++ b/tests/resources/repository_artifacts.json
@@ -1,0 +1,43 @@
+{
+  "total_count": 2,
+  "artifacts": [
+    {
+      "id": 11,
+      "node_id": "MDg6QXJ0aWZhY3QxMQ==",
+      "name": "Rails",
+      "size_in_bytes": 556,
+      "url": "https://api.github.com/repos/octo-org/octo-docs/actions/artifacts/11",
+      "archive_download_url": "https://api.github.com/repos/octo-org/octo-docs/actions/artifacts/11/zip",
+      "expired": false,
+      "created_at": "2020-01-10T14:59:22Z",
+      "updated_at": "2020-01-21T14:59:22Z",
+      "expires_at": "2020-03-21T14:59:22Z",
+      "workflow_run": {
+        "id": 2332938,
+        "repository_id": 1296269,
+        "head_repository_id": 1296269,
+        "head_branch": "main",
+        "head_sha": "328faa0536e6fef19753d9d91dc96a9931694ce3"
+      }
+    },
+    {
+      "id": 13,
+      "node_id": "MDg6QXJ0aWZhY3QxMw==",
+      "name": "Test output",
+      "size_in_bytes": 453,
+      "url": "https://api.github.com/repos/octo-org/octo-docs/actions/artifacts/13",
+      "archive_download_url": "https://api.github.com/repos/octo-org/octo-docs/actions/artifacts/13/zip",
+      "expired": false,
+      "created_at": "2020-01-10T14:59:22Z",
+      "updated_at": "2020-01-21T14:59:22Z",
+      "expires_at": "2020-03-21T14:59:22Z",
+      "workflow_run": {
+        "id": 2332942,
+        "repository_id": 1296269,
+        "head_repository_id": 1296269,
+        "head_branch": "main",
+        "head_sha": "178f4f6090b3fccad4a65b3e83d076a622d59652"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds ActionsHandler::list_repository_artifacts, exposing GET /repos/{owner}/{repo}/actions/artifacts with optional name, per_page, page, and ETag support.

WorkflowListArtifact gains an optional workflow_run field, populated by the repository-scoped endpoint via the new ArtifactWorkflowRun struct.

This implements https://docs.github.com/en/rest/actions/artifacts?apiVersion=2026-03-10#list-artifacts-for-a-repository

I used claude to create the PR - I couldn't find a AI policy for the repo, apologies if there is a human-only policy here. I have reviewed the entire branch and it looks reasonable to me, but its my first PR to octocrab, so I'm not aware of your conventions yet..