### PR TITLE
refactor: serde support for Cache structs [cache-redb 1/3]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ hyper-rustls = { version = "0.27.0", optional = true, default-features = false, 
     "native-tokio",
     "tls12",
 ] }
+http-serde = "2.1.1"
 hyper-timeout = { version = "0.5.1", optional = true }
 hyper-tls = { version = "0.6.0", optional = true }
 hyper-util = { version = "0.1.3", features = ["http1"] }

--- a/src/service/middleware/cache.rs
+++ b/src/service/middleware/cache.rs
@@ -12,12 +12,13 @@ use http::{header, request::Request, HeaderMap, HeaderValue, Response, StatusCod
 use http_body::{Body, Frame, SizeHint};
 use http_body_util::{combinators::BoxBody, BodyExt, Full};
 use pin_project::pin_project;
+use serde::{Deserialize, Serialize};
 use tower::{Layer, Service};
 
 // Implementation based on the documentation at:
 // https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#use-conditional-requests-if-appropriate
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 /// Cache key identification returned by the GitHub API.
 pub enum CacheKey {
@@ -25,10 +26,11 @@ pub enum CacheKey {
     LastModified(String),
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 /// Cache entry containing the response data as well as response headers.
 pub struct CachedResponse {
     pub body: Vec<u8>,
+    #[serde(with = "http_serde::header_map")]
     pub headers: HeaderMap,
 }
 


### PR DESCRIPTION
This commit adds serde Serialize/Deserialize to the CacheKey and CachedResponse structs.

This is preparatory work for adding support for adding an ReDB implementation for the CacheStorage trait, submitted in a separate PR.

This code was written by a human (me) using only "Autocomplete" AI tooling. I provide it to the octocrab project under the terms of the Apache and MIT licenses.