### PR TITLE
feat: redb cache backend [cache-redb 3/3]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ request-headers = ["X-GitHub-Api-Version: 2022-11-28"]
 # This list should include all features EXCEPT jwt-aws-lc-rs.
 # When adding new features, remember to add them here too.
 features = [
+    "cache-redb",
     "default-client",
     "follow-redirect",
     "jwt-rust-crypto",
@@ -73,6 +74,8 @@ hyper-tls = { version = "0.6.0", optional = true }
 hyper-util = { version = "0.1.3", features = ["http1"] }
 percent-encoding = "2.2.0"
 pin-project = "1.0.12"
+postcard = { version = "1.1.3", features = ["alloc"], optional = true }
+redb = { version = "4.1.0", optional = true }
 rustls = { version = "0.23", optional = true, default-features = false }
 secrecy = "0.10.3"
 serde = { version = "1.0.126", features = ["derive"] }
@@ -103,6 +106,7 @@ crypto_box = { version = "0.8.2", features = ["seal"] }
 base64 = "0.22.0"
 pretty_assertions = "1.4.0"
 graphql_client = "0.14.0"
+tempfile = "3.27.0"
 
 [build-dependencies]
 cargo_metadata = "0.23.0"
@@ -132,3 +136,8 @@ opentls = ["hyper-tls"]
 stream = ["futures-core", "futures-util"]
 timeout = ["hyper-timeout", "tokio", "tower/timeout"]
 default-client = ["hyper-util/client-legacy"]
+cache-redb = ["redb", "postcard"]
+
+[[test]]
+name = "cache_redb_test"
+required-features = ["cache-redb"]

--- a/src/service/middleware/cache.rs
+++ b/src/service/middleware/cache.rs
@@ -1,4 +1,6 @@
 pub mod mem;
+#[cfg(feature = "cache-redb")]
+pub mod redb;
 
 use std::{
     future::Future,

--- a/src/service/middleware/cache/redb.rs
+++ b/src/service/middleware/cache/redb.rs
@@ -1,0 +1,311 @@
+use std::sync::Arc;
+
+use super::{CacheKey, CacheStorage, CacheWriter, CachedResponse};
+use http::HeaderMap;
+use redb::{Database, ReadableDatabase as _, TableDefinition};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "tracing")]
+use tracing::instrument;
+
+/// A file-based cache backend using [redb](https://crates.io/crates/redb).
+///
+/// Note, this cache does not implement any eviction policy. Users should be
+/// aware that the cache will grow indefinitely unless the database file is
+/// deleted or truncated.
+#[derive(Debug)]
+pub struct ReDBCache {
+    db: Arc<Database>,
+}
+
+impl ReDBCache {
+    pub fn new<D: Into<Arc<Database>>>(db: D) -> Self {
+        Self { db: db.into() }
+    }
+}
+
+// Wrapper around `http::Uri` to implement `serde::Serialize`,
+// `serde::Deserialize`, `redb::Value` and `redb::Key`.
+#[derive(Debug)]
+enum Uri<'a> {
+    Owned(http::Uri),
+    Ref(&'a http::Uri),
+}
+
+impl Serialize for Uri<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Uri::Owned(uri) => http_serde::uri::serialize(uri, serializer),
+            Uri::Ref(uri) => http_serde::uri::serialize(uri, serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Uri<'_> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let uri = http_serde::uri::deserialize(deserializer)?;
+        Ok(Uri::Owned(uri))
+    }
+}
+
+impl redb::Value for Uri<'_> {
+    type SelfType<'a>
+        = Uri<'a>
+    where
+        Self: 'a;
+
+    type AsBytes<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        postcard::from_bytes(data).expect("Failed to deserialize CacheKey from bytes")
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'b,
+    {
+        postcard::to_allocvec(value).expect("Failed to serialize CacheKey")
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("octocrab::UriWrapper")
+    }
+}
+
+impl redb::Key for Uri<'_> {
+    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+        data1.cmp(data2)
+    }
+}
+
+const TABLE_CACHE_KEYS: TableDefinition<Uri, CacheKey> =
+    TableDefinition::new("octocrab_cache_keys");
+
+const TABLE_CACHE_RESPONSES: TableDefinition<Uri, CachedResponse> =
+    TableDefinition::new("octocrab_cache_responses");
+
+impl redb::Value for CacheKey {
+    type SelfType<'a> = CacheKey;
+
+    type AsBytes<'a> = Vec<u8>;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        postcard::from_bytes(data).expect("Failed to deserialize CacheKey from bytes")
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'b,
+    {
+        postcard::to_allocvec(value).expect("Failed to serialize CacheKey")
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("octocrab::CacheKey")
+    }
+}
+
+impl redb::Value for CachedResponse {
+    type SelfType<'a> = CachedResponse;
+
+    type AsBytes<'a> = Vec<u8>;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        postcard::from_bytes(data).expect("Failed to deserialize CachedResponse from bytes")
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'b,
+    {
+        postcard::to_allocvec(value).expect("Failed to serialize CachedResponse")
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("octocrab::CachedResponse")
+    }
+}
+
+#[derive(Debug)]
+struct RedbWriter {
+    db: Arc<Database>,
+    uri: Uri<'static>,
+    key: CacheKey,
+    response: CachedResponse,
+}
+
+impl CacheStorage for ReDBCache {
+    #[cfg_attr(feature = "tracing", instrument)]
+    fn try_hit(&self, uri: &http::Uri) -> Option<CacheKey> {
+        let txn = match self.db.begin_read() {
+            Ok(txn) => txn,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                tracing::error!("Failed to begin read transaction: {e}");
+                return None;
+            }
+        };
+
+        let table = match txn.open_table(TABLE_CACHE_KEYS) {
+            Ok(table) => table,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                tracing::error!("Failed to open cache keys table: {e}");
+                return None;
+            }
+        };
+
+        let cache_key = match table.get(Uri::Ref(uri)) {
+            Ok(value) => value,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                tracing::error!("Failed to read from cache keys table: {e}");
+                return None;
+            }
+        };
+
+        cache_key.map(|g| g.value())
+    }
+
+    #[cfg_attr(feature = "tracing", instrument)]
+    fn load(&self, uri: &http::Uri) -> Option<CachedResponse> {
+        let txn = match self.db.begin_read() {
+            Ok(txn) => txn,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                tracing::error!("Failed to begin read transaction: {e}");
+                return None;
+            }
+        };
+
+        let table = match txn.open_table(TABLE_CACHE_RESPONSES) {
+            Ok(table) => table,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                tracing::error!("Failed to open cache responses table: {e}");
+                return None;
+            }
+        };
+
+        let response = match table.get(Uri::Ref(uri)) {
+            Ok(value) => value,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                tracing::error!("Failed to read from cache responses table: {e}");
+                return None;
+            }
+        };
+
+        response.map(|g| g.value())
+    }
+
+    fn writer(&self, uri: &http::Uri, key: CacheKey, headers: HeaderMap) -> Box<dyn CacheWriter> {
+        Box::new(RedbWriter {
+            db: self.db.clone(),
+            uri: Uri::Owned(uri.clone()),
+            key,
+            response: CachedResponse {
+                body: Vec::new(),
+                headers,
+            },
+        })
+    }
+}
+
+impl CacheWriter for RedbWriter {
+    fn write_body(&mut self, data: &[u8]) {
+        self.response.body.extend_from_slice(data);
+    }
+}
+
+impl Drop for RedbWriter {
+    #[cfg_attr(feature = "tracing", instrument)]
+    fn drop(&mut self) {
+        // The whole response was received, hence the writer is dropped. We need
+        // to add the response body to the cache.
+
+        let txn = match self.db.begin_write() {
+            Ok(txn) => txn,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                tracing::error!("Failed to begin cache write transaction: {e}");
+                return;
+            }
+        };
+
+        {
+            let mut table = match txn.open_table(TABLE_CACHE_KEYS) {
+                Ok(table) => table,
+                Err(e) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!("Failed to open cache keys table: {e}");
+                    return;
+                }
+            };
+
+            if let Err(e) = table.insert(&self.uri, &self.key) {
+                #[cfg(feature = "tracing")]
+                tracing::error!("Failed to write to cache keys table: {e}");
+                return;
+            }
+
+            drop(table);
+        }
+
+        {
+            let mut table = match txn.open_table(TABLE_CACHE_RESPONSES) {
+                Ok(table) => table,
+                Err(e) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!("Failed to open cache responses table: {e}");
+                    return;
+                }
+            };
+
+            if let Err(e) = table.insert(&self.uri, &self.response) {
+                #[cfg(feature = "tracing")]
+                tracing::error!("Failed to write to cache responses table: {e}");
+                return;
+            }
+
+            drop(table);
+        }
+
+        match txn.commit() {
+            Ok(_) => (),
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                tracing::error!("Failed to commit cache write transaction: {e}");
+            }
+        }
+    }
+}

--- a/tests/cache_redb_test.rs
+++ b/tests/cache_redb_test.rs
@@ -1,0 +1,44 @@
+// Tests for caching behavior using ReDBCache
+mod cache_test_helpers;
+
+use cache_test_helpers::etag_update_cache_impl;
+use cache_test_helpers::should_cache_impl;
+use octocrab::service::middleware::cache::redb::ReDBCache;
+
+fn setup_cache_mem() -> ReDBCache {
+    let backend = redb::backends::InMemoryBackend::new();
+    let db = redb::Builder::new()
+        .create_with_backend(backend)
+        .expect("Failed to create ReDB database");
+    ReDBCache::new(db)
+}
+
+fn setup_cache_file() -> ReDBCache {
+    let file = tempfile::tempfile().expect("Failed to create temporary file");
+    let backend =
+        redb::backends::FileBackend::new(file).expect("Failed to create ReDB file backend");
+    let db = redb::Builder::new()
+        .create_with_backend(backend)
+        .expect("Failed to create ReDB database");
+    ReDBCache::new(db)
+}
+
+#[tokio::test]
+async fn should_cache_redb_mem_backend() {
+    should_cache_impl(setup_cache_mem()).await;
+}
+
+#[tokio::test]
+async fn etag_update_cache_redb_mem_backend() {
+    etag_update_cache_impl(setup_cache_mem()).await;
+}
+
+#[tokio::test]
+async fn should_cache_redb_file_backend() {
+    should_cache_impl(setup_cache_file()).await;
+}
+
+#[tokio::test]
+async fn etag_update_cache_redb_file_backend() {
+    etag_update_cache_impl(setup_cache_file()).await;
+}


### PR DESCRIPTION
This commit adds an implementation of the CacheStorage trait backed by
ReDB, "a simple, portable, high-performance, ACID, embedded key-value
store" written in pure Rust.

Data stored in the ReDB database is (de)serialized using Postcard, "a
#![no_std] focused serializer and deserializer for Serde". Postcard
stores data in a binary format and is generally more resource
efficient than json or other text based formats.

The ReDB implementation is gated by the `cache-redb` feature, to avoid
introducing the redb/postcard dependencies for all users.

When the `tracing` feature is enabled, the CacheStorage functions are
annotated with `tracing::instrument`, and any errors reading from /
writing to ReDB are logged with `tracing::error!()` macro.

This code was written by a human (me) using only "Autocomplete" AI
tooling. I provide it to the octocrab project under the terms of the
Apache and MIT licenses.