### PR TITLE
chore: add `changes` field to `PullRequestWebhookEventPayload`

### DIFF
--- a/src/models/webhook_events/payload/pull_request.rs
+++ b/src/models/webhook_events/payload/pull_request.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::models::{pulls::PullRequest, teams::RequestedTeam, Author, Label, Milestone};
 
+use super::OldValue;
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct PullRequestWebhookEventPayload {
@@ -15,6 +17,7 @@ pub struct PullRequestWebhookEventPayload {
     pub label: Option<Label>,
     pub after: Option<String>,
     pub before: Option<String>,
+    pub changes: Option<PullRequestWebhookEventChanges>,
     pub requested_reviewer: Option<Author>,
     pub requested_team: Option<RequestedTeam>,
 }
@@ -44,4 +47,21 @@ pub enum PullRequestWebhookEventAction {
     Unassigned,
     Unlabeled,
     Unlocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PullRequestWebhookEventChanges {
+    base: Option<PullRequestWebhookEventBase>,
+    body: Option<OldValue<String>>,
+    title: Option<OldValue<String>>
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PullRequestWebhookEventBase {
+    #[serde(rename(deserialize = "ref"))]
+    #[serde(rename(serialize = "ref"))]
+    pub ref_: OldValue<String>,
+    pub sha: OldValue<String>,
 }

--- a/src/models/webhook_events/payload/pull_request.rs
+++ b/src/models/webhook_events/payload/pull_request.rs
@@ -54,7 +54,7 @@ pub enum PullRequestWebhookEventAction {
 pub struct PullRequestWebhookEventChanges {
     base: Option<PullRequestWebhookEventBase>,
     body: Option<OldValue<String>>,
-    title: Option<OldValue<String>>
+    title: Option<OldValue<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
The `PullRequestWebhookEventPayload` is missing `changes` field, if `PullRequestWebhookEventPayload.action == "edited"`.

Reference: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#pull_request