### PR TITLE
Support wasm futures without Send service bounds

### DIFF
--- a/src/from_response.rs
+++ b/src/from_response.rs
@@ -4,18 +4,38 @@ use http_body_util::BodyExt;
 use snafu::ResultExt;
 
 /// A trait for mapping from a `http::Response` to an another type.
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait FromResponse: Sized {
+    #[cfg(not(target_arch = "wasm32"))]
     async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
     where
         B: Body<Data = Bytes, Error = crate::Error> + Send;
+
+    #[cfg(target_arch = "wasm32")]
+    async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
+    where
+        B: Body<Data = Bytes, Error = crate::Error>;
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<T: serde::de::DeserializeOwned> FromResponse for T {
+    #[cfg(not(target_arch = "wasm32"))]
     async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
     where
         B: Body<Data = Bytes, Error = crate::Error> + Send,
+    {
+        let (_, body) = response.into_parts();
+        let body = body.collect().await?.to_bytes();
+        let de = &mut serde_json::Deserializer::from_slice(&body);
+        return serde_path_to_error::deserialize(de).context(crate::error::JsonSnafu);
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
+    where
+        B: Body<Data = Bytes, Error = crate::Error>,
     {
         let (_, body) = response.into_parts();
         let body = body.collect().await?.to_bytes();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,6 +481,7 @@ impl<Config, Auth> OctocrabBuilder<NoSvc, Config, Auth, NotLayerReady> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Svc, Config, Auth, B> OctocrabBuilder<Svc, Config, Auth, LayerReady>
 where
     Svc: Service<Request<OctoBody>, Response = Response<B>> + Send + 'static,
@@ -503,12 +504,67 @@ where
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+impl<Svc, Config, Auth, B> OctocrabBuilder<Svc, Config, Auth, LayerReady>
+where
+    Svc: Service<Request<OctoBody>, Response = Response<B>> + Clone + 'static,
+    Svc::Future: 'static,
+    Svc::Error: Into<BoxError>,
+    B: http_body::Body<Data = bytes::Bytes> + 'static,
+    B::Error: Into<BoxError>,
+{
+    pub fn with_executor(
+        self,
+        executor: Executor,
+    ) -> OctocrabBuilder<Svc, Config, Auth, LayerReady> {
+        OctocrabBuilder {
+            service: self.service,
+            auth: self.auth,
+            config: self.config,
+            _layer_ready: PhantomData,
+            executor: Some(executor),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 impl<Svc, Config, Auth, B> OctocrabBuilder<Svc, Config, Auth, LayerReady>
 where
     Svc: Service<Request<OctoBody>, Response = Response<B>> + Send + 'static,
     Svc::Future: Send + 'static,
     Svc::Error: Into<BoxError>,
     B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    B::Error: Into<BoxError>,
+{
+    /// Add a [`Layer`] to the current [`Service`] stack.
+    pub fn with_layer<L: Layer<Svc>>(
+        self,
+        layer: &L,
+    ) -> OctocrabBuilder<L::Service, Config, Auth, LayerReady> {
+        let Self {
+            service: stack,
+            auth,
+            config,
+            executor,
+            ..
+        } = self;
+        OctocrabBuilder {
+            service: layer.layer(stack),
+            auth,
+            config,
+            executor,
+            _layer_ready: PhantomData,
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<Svc, Config, Auth, B> OctocrabBuilder<Svc, Config, Auth, LayerReady>
+where
+    Svc: Service<Request<OctoBody>, Response = Response<B>> + Clone + 'static,
+    Svc::Future: 'static,
+    Svc::Error: Into<BoxError>,
+    B: http_body::Body<Data = bytes::Bytes> + 'static,
     B::Error: Into<BoxError>,
 {
     /// Add a [`Layer`] to the current [`Service`] stack.
@@ -551,12 +607,39 @@ impl<Svc, Auth, LayerState> OctocrabBuilder<Svc, NoConfig, Auth, LayerState> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Svc, B, LayerState> OctocrabBuilder<Svc, NoConfig, AuthState, LayerState>
 where
     Svc: Service<Request<OctoBody>, Response = Response<B>> + Send + 'static,
     Svc::Future: Send + 'static,
     Svc::Error: Into<BoxError>,
     B: http_body::Body<Data = bytes::Bytes> + Send + Sync + 'static,
+    B::Error: Into<BoxError>,
+{
+    /// Build a [`Client`](OctocrabService) instance with the current [`Service`] stack.
+    pub fn build(self) -> Result<Octocrab, Infallible> {
+        // Transform response body to `BoxBody<Bytes, crate::Error>` and use type erased error to avoid type parameters.
+        let service = MapResponseBodyLayer::new(|b: B| {
+            b.map_err(|e| ServiceSnafu.into_error(e.into())).boxed()
+        })
+        .layer(self.service)
+        .map_err(|e| e.into());
+
+        if let Some(executor) = self.executor {
+            return Ok(Octocrab::new_with_executor(service, self.auth, executor));
+        }
+
+        Ok(Octocrab::new(service, self.auth))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<Svc, B, LayerState> OctocrabBuilder<Svc, NoConfig, AuthState, LayerState>
+where
+    Svc: Service<Request<OctoBody>, Response = Response<B>> + Clone + 'static,
+    Svc::Future: 'static,
+    Svc::Error: Into<BoxError>,
+    B: http_body::Body<Data = bytes::Bytes> + 'static,
     B::Error: Into<BoxError>,
 {
     /// Build a [`Client`](OctocrabService) instance with the current [`Service`] stack.
@@ -1050,9 +1133,17 @@ pub enum AuthState {
     },
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub type OctocrabService = Buffer<
     http::Request<OctoBody>,
     <BoxService<http::Request<OctoBody>, http::Response<BoxBody<Bytes, Error>>, BoxError> as tower::Service<http::Request<OctoBody>>>::Future
+>;
+
+#[cfg(target_arch = "wasm32")]
+pub type OctocrabService = tower::util::BoxCloneService<
+    http::Request<OctoBody>,
+    http::Response<BoxBody<Bytes, Error>>,
+    BoxError,
 >;
 
 /// The GitHub API client.
@@ -1091,6 +1182,7 @@ impl Octocrab {
     }
 
     /// Creates a new `Octocrab`.
+    #[cfg(not(target_arch = "wasm32"))]
     fn new<S>(service: S, auth_state: AuthState) -> Self
     where
         S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>>
@@ -1107,7 +1199,26 @@ impl Octocrab {
         }
     }
 
+    /// Creates a new `Octocrab`.
+    #[cfg(target_arch = "wasm32")]
+    fn new<S>(service: S, auth_state: AuthState) -> Self
+    where
+        S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>>
+            + Clone
+            + 'static,
+        S::Future: 'static,
+        S::Error: Into<BoxError>,
+    {
+        let service = tower::util::BoxCloneService::new(service.map_err(Into::into));
+
+        Self {
+            client: service,
+            auth_state,
+        }
+    }
+
     /// Creates a new `Octocrab` with a custom executor
+    #[cfg(not(target_arch = "wasm32"))]
     fn new_with_executor<S>(service: S, auth_state: AuthState, executor: Executor) -> Self
     where
         S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>>
@@ -1126,6 +1237,19 @@ impl Octocrab {
             client: service,
             auth_state,
         }
+    }
+
+    /// Creates a new `Octocrab` with a custom executor
+    #[cfg(target_arch = "wasm32")]
+    fn new_with_executor<S>(service: S, auth_state: AuthState, _executor: Executor) -> Self
+    where
+        S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>>
+            + Clone
+            + 'static,
+        S::Future: 'static,
+        S::Error: Into<BoxError>,
+    {
+        Self::new(service, auth_state)
     }
 
     /// Returns a new `Octocrab` based on the current builder but

--- a/src/page.rs
+++ b/src/page.rs
@@ -177,11 +177,10 @@ impl<'iter, T> IntoIterator for &'iter Page<T> {
     }
 }
 
-#[async_trait::async_trait]
-impl<T: serde::de::DeserializeOwned> crate::FromResponse for Page<T> {
-    async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
+impl<T: serde::de::DeserializeOwned> Page<T> {
+    async fn from_response_impl<B>(response: http::Response<B>) -> crate::Result<Self>
     where
-        B: Body<Data = Bytes, Error = crate::Error> + Send,
+        B: Body<Data = Bytes, Error = crate::Error>,
     {
         let HeaderLinks {
             first,
@@ -235,6 +234,26 @@ impl<T: serde::de::DeserializeOwned> crate::FromResponse for Page<T> {
                 last,
             })
         }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<T: serde::de::DeserializeOwned> crate::FromResponse for Page<T> {
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
+    where
+        B: Body<Data = Bytes, Error = crate::Error> + Send,
+    {
+        Self::from_response_impl(response).await
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    async fn from_response<B>(response: http::Response<B>) -> crate::Result<Self>
+    where
+        B: Body<Data = Bytes, Error = crate::Error>,
+    {
+        Self::from_response_impl(response).await
     }
 }
 


### PR DESCRIPTION
## Summary

- relax `FromResponse` and `Page` response parsing futures for `wasm32` with `async_trait(?Send)`
- keep the existing `Send` bounds for native targets
- use `BoxCloneService` for `wasm32` clients so building Octocrab for browser/Yew-style targets does not require `tower::Buffer`'s background worker and `Send` future bounds

Fixes #224

## Validation

- `cargo fmt --check`
- `git diff --check`

I attempted the target check locally with `cargo check --target wasm32-unknown-unknown --no-default-features`, but this Windows host is missing the MSVC/Windows SDK linker libraries needed to build proc-macro/build-script dependencies. The repo's existing CI has a wasm job (`cargo build --target=wasm32-unknown-unknown --no-default-features -F jwt-rust-crypto`), so this PR should get the authoritative wasm result there.