### PR TITLE
Do not serialize input object if it is null (fixes #622)

### DIFF
--- a/src/models/workflows.rs
+++ b/src/models/workflows.rs
@@ -168,5 +168,6 @@ pub struct ArtifactWorkflowRun {
 #[non_exhaustive]
 pub struct WorkflowDispatch {
     pub r#ref: String,
+    #[serde(skip_serializing_if = "serde_json::Value::is_null")]
     pub inputs: serde_json::Value,
 }

--- a/tests/actions_workflows_dispatches_test.rs
+++ b/tests/actions_workflows_dispatches_test.rs
@@ -2,12 +2,14 @@ mod mock_error;
 
 use mock_error::setup_error_handler;
 use octocrab::Octocrab;
+use serde::Serialize;
+use serde_json::json;
 use wiremock::{
-    matchers::{method, path},
+    matchers::{body_json, method, path},
     Mock, MockServer, ResponseTemplate,
 };
 
-async fn setup_post_api(template: ResponseTemplate) -> MockServer {
+async fn setup_post_api(template: ResponseTemplate, request: impl Serialize) -> MockServer {
     let owner: &str = "org";
     let repo: &str = "some-repo";
     let workflow_id: &str = "workflow.yaml";
@@ -18,6 +20,7 @@ async fn setup_post_api(template: ResponseTemplate) -> MockServer {
         .and(path(format!(
             "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches"
         )))
+        .and(body_json(request))
         .respond_with(template.clone())
         .mount(&mock_server)
         .await;
@@ -42,7 +45,16 @@ const REF: &str = "ref";
 #[tokio::test]
 async fn should_be_ok_with_204() {
     let template = ResponseTemplate::new(204);
-    let mock_server = setup_post_api(template).await;
+    let mock_server = setup_post_api(
+        template,
+        json!({
+            "ref": REF,
+            "inputs": {
+                "foo": "bar"
+            }
+        }),
+    )
+    .await;
     let client = setup_octocrab(&mock_server.uri());
 
     let result = client
@@ -65,9 +77,42 @@ async fn should_be_ok_with_204() {
 }
 
 #[tokio::test]
+async fn should_omit_inputs_when_not_provided() {
+    let template = ResponseTemplate::new(204);
+    let mock_server = setup_post_api(template, json!({ "ref": REF })).await;
+    let client = setup_octocrab(&mock_server.uri());
+
+    let result = client
+        .actions()
+        .create_workflow_dispatch(
+            OWNER.to_owned(),
+            REPO.to_owned(),
+            WORKFLOW_ID.to_owned(),
+            REF.to_owned(),
+        )
+        .send()
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "expected successful result, got error: {:#?}",
+        result
+    );
+}
+
+#[tokio::test]
 async fn should_be_err_with_500() {
     let template = ResponseTemplate::new(500);
-    let mock_server = setup_post_api(template).await;
+    let mock_server = setup_post_api(
+        template,
+        json!({
+            "ref": REF,
+            "inputs": {
+                "foo": "bar"
+            }
+        }),
+    )
+    .await;
     let client = setup_octocrab(&mock_server.uri());
 
     let result = client


### PR DESCRIPTION
https://docs.rs/octocrab/latest/octocrab/actions/struct.ActionsHandler.html#method.create_workflow_dispatch
The call to inputs() is documented as optional:
```
octocrab.actions()
   .create_workflow_dispatch("org", "repo", "workflow.yaml", "ref")
   // optional
   .inputs(serde_json::json!({"my-key": "my-value"}))
   .send()
   .await?;
```
But skipping this call leads to a null-object being sent to Github which leads to a HTTP 422 Invalid Request  with the message "For 'properties/inputs', nil is not an object." This change skips the inputs field from serialization if its null, which is the default.

fixes #622