### PR TITLE
Use std::sync::LazyLock over once_cell::sync::Lazy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ http-serde = "2.1.1"
 hyper-timeout = { version = "0.5.1", optional = true }
 hyper-tls = { version = "0.6.0", optional = true }
 hyper-util = { version = "0.1.3", features = ["http1"] }
-once_cell = "1.7.2"
 percent-encoding = "2.2.0"
 pin-project = "1.0.12"
 secrecy = "0.10.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,6 @@ use web_time::Duration;
 use http::{header::HeaderName, StatusCode};
 use hyper::{Request, Response};
 
-use once_cell::sync::Lazy;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use snafu::*;
@@ -320,8 +319,8 @@ const GITHUB_BASE_UPLOAD_URI: &str = "https://uploads.github.com";
 include!(concat!(env!("OUT_DIR"), "/headers_metadata.rs"));
 
 #[cfg(feature = "default-client")]
-static STATIC_INSTANCE: Lazy<arc_swap::ArcSwap<Octocrab>> =
-    Lazy::new(|| arc_swap::ArcSwap::from_pointee(Octocrab::default()));
+static STATIC_INSTANCE: std::sync::LazyLock<arc_swap::ArcSwap<Octocrab>> =
+    std::sync::LazyLock::new(|| arc_swap::ArcSwap::from_pointee(Octocrab::default()));
 
 /// Formats a GitHub preview from it's name into the full value for the
 /// `Accept` header.


### PR DESCRIPTION
After MSRV 1.85 (commit 174950f0fbdbbbfb2e2a6c38f4f2003831163bca), the `std::` variant of the lazy lock can be used.