### PR TITLE
Document wasm feature for Yew builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
       - run: |
           rustup default stable
           rustup target add wasm32-unknown-unknown
-          cargo build --target=wasm32-unknown-unknown --no-default-features -F jwt-rust-crypto
+          cargo build --target=wasm32-unknown-unknown --no-default-features -F wasm
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ features = [
     "default-client",
     "follow-redirect",
     "jwt-rust-crypto",
+    "wasm",
     # "jwt-aws-lc-rs",  # Excluded: conflicts with jwt-rust-crypto
     "opentls",
     "retry",
@@ -126,6 +127,7 @@ rustls-ring = ["hyper-rustls/ring"]
 rustls-aws-lc-rs = ["hyper-rustls/aws-lc-rs"]
 jwt-aws-lc-rs = ["jsonwebtoken/aws_lc_rs"]
 jwt-rust-crypto = ["jsonwebtoken/rust_crypto"]
+wasm = ["jwt-rust-crypto"]
 rustls-webpki-tokio = ["hyper-rustls/webpki-tokio"]
 opentls = ["hyper-tls"]
 stream = ["futures-core", "futures-util"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ Run this command in your terminal to add the latest version of `Octocrab`.
 cargo add octocrab
 ```
 
+## Using Octocrab With WebAssembly
+
+Browser-based WebAssembly projects, including Yew apps, should disable the
+default client features and enable Octocrab's `wasm` feature:
+
+```toml
+octocrab = { version = "0.53", default-features = false, features = ["wasm"] }
+```
+
+The default features include native HTTP client support for server and desktop
+targets. Those native networking dependencies do not compile for
+`wasm32-unknown-unknown`, while the `wasm` feature keeps the shared models,
+builders, and response parsing available for browser projects.
+
 ## Semantic API
 The semantic API provides strong typing around GitHub's API, a set of
 [`models`] that maps to GitHub's types, and [`auth`] functions that are useful


### PR DESCRIPTION
## Summary

- Add a `wasm` feature alias for browser-based WebAssembly builds.
- Document the Cargo configuration Yew/browser users need:
  `default-features = false, features = ["wasm"]`.
- Update the existing CI WebAssembly build to use the new feature alias.

## Verification

- `cargo check --target wasm32-unknown-unknown --no-default-features --features wasm`
- `cargo check`

I also confirmed the current default feature set still fails on
`wasm32-unknown-unknown` because native networking dependencies are compiled,
so the README now makes the supported browser/WASM configuration explicit.

## Note

`cargo fmt --all -- --check` could not run on this machine because Windows
Application Control blocked `cargo-fmt` with `os error 4551`. This PR does not
change Rust source files.

Closes XAMPPRocky/octocrab#224.
