### PR TITLE
feat: Add WebAssembly (WASM) support for browser targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,10 @@ tower-http = { version = "0.6.1", features = ["map-response-body", "trace"] }
 tracing = { version = "0.1.37", features = ["log"], optional = true }
 url = { version = "2.2.2", features = ["serde"] }
 
-[dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+reqwest = { version = "0.12.0", default-features = false }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.17.0", default-features = false, features = [
     "macros",
     "rt-multi-thread",

--- a/README.md
+++ b/README.md
@@ -18,6 +18,37 @@ Run this command in your terminal to add the latest version of `Octocrab`.
 cargo add octocrab
 ```
 
+## WebAssembly
+For `wasm32-unknown-unknown` browser targets, disable the default client:
+
+```toml
+octocrab = { version = "0.53", default-features = false, features = [
+    "jwt-rust-crypto",
+] }
+```
+
+Then construct Octocrab with the browser-compatible service:
+
+```rust
+use std::sync::Arc;
+
+use http::{header::USER_AGENT, Uri};
+use octocrab::service::middleware::base_uri::BaseUriLayer;
+use octocrab::service::middleware::extra_headers::ExtraHeadersLayer;
+use octocrab::service::wasm::ReqwestService;
+use octocrab::{AuthState, OctocrabBuilder};
+
+let octocrab = OctocrabBuilder::new_empty()
+    .with_service(ReqwestService::new())
+    .with_layer(&BaseUriLayer::new(Uri::from_static("https://api.github.com")))
+    .with_layer(&ExtraHeadersLayer::new(Arc::new(vec![(
+        USER_AGENT,
+        "octocrab".parse().unwrap(),
+    )])))
+    .with_auth(AuthState::None)
+    .build()?;
+```
+
 ## Semantic API
 The semantic API provides strong typing around GitHub's API, a set of
 [`models`] that maps to GitHub's types, and [`auth`] functions that are useful

--- a/examples/wasm_client.rs
+++ b/examples/wasm_client.rs
@@ -1,0 +1,31 @@
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+        use std::sync::Arc;
+
+        use http::{header::USER_AGENT, Uri};
+        use octocrab::service::middleware::base_uri::BaseUriLayer;
+        use octocrab::service::middleware::extra_headers::ExtraHeadersLayer;
+        use octocrab::service::wasm::ReqwestService;
+        use octocrab::{AuthState, Octocrab, OctocrabBuilder};
+
+        fn build_octocrab() -> octocrab::Result<Octocrab, std::convert::Infallible> {
+            OctocrabBuilder::new_empty()
+                .with_service(ReqwestService::new())
+                .with_layer(&BaseUriLayer::new(Uri::from_static(
+                    "https://api.github.com",
+                )))
+                .with_layer(&ExtraHeadersLayer::new(Arc::new(vec![(
+                    USER_AGENT,
+                    "octocrab".parse().unwrap(),
+                )])))
+                .with_auth(AuthState::None)
+                .build()
+        }
+
+        fn main() {
+            let _octocrab = build_octocrab().expect("build wasm client");
+        }
+    } else {
+        fn main() {}
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,19 +226,32 @@ use api::repos::RepoRef;
 use api::users::UserRef;
 pub use body::OctoBody;
 use chrono::{DateTime, Utc};
-use http::{HeaderMap, HeaderValue, Method, Uri};
+#[cfg(all(feature = "default-client", feature = "tracing"))]
+use http::HeaderMap;
+use http::{HeaderValue, Method, Uri};
 use http_body_util::combinators::BoxBody;
 use http_body_util::BodyExt;
+#[cfg(feature = "default-client")]
 use service::middleware::auth_header::AuthHeaderLayer;
-use service::middleware::cache::{CacheStorage, HttpCacheLayer};
+use service::middleware::cache::CacheStorage;
+#[cfg(feature = "default-client")]
+use service::middleware::cache::HttpCacheLayer;
+#[cfg(target_arch = "wasm32")]
+use std::cell::RefCell;
 use std::convert::{Infallible, TryInto};
 use std::fmt;
 use std::future::Future;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::pin::Pin;
+#[cfg(target_arch = "wasm32")]
+use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
+#[cfg(any(
+    feature = "timeout",
+    all(feature = "default-client", feature = "tracing")
+))]
 use web_time::Duration;
 
 use http::{header::HeaderName, StatusCode};
@@ -247,9 +260,14 @@ use hyper::{Request, Response};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use snafu::*;
-use tower::{buffer::Buffer, util::BoxService, BoxError, Layer, Service, ServiceExt};
+#[cfg(target_arch = "wasm32")]
+use tower::util::UnsyncBoxService;
+#[cfg(not(target_arch = "wasm32"))]
+use tower::{buffer::Buffer, util::BoxService};
+use tower::{BoxError, Layer, Service, ServiceExt};
 
 use bytes::Bytes;
+#[cfg(feature = "default-client")]
 use http::header::USER_AGENT;
 use http::request::Builder;
 #[cfg(feature = "opentls")]
@@ -264,18 +282,24 @@ use tower::retry::{Retry, RetryLayer};
 #[cfg(feature = "timeout")]
 use hyper_timeout::TimeoutConnector;
 
-use tower_http::{classify::ServerErrorsFailureClass, map_response_body::MapResponseBodyLayer};
+#[cfg(all(feature = "default-client", feature = "tracing"))]
+use tower_http::classify::ServerErrorsFailureClass;
+use tower_http::map_response_body::MapResponseBodyLayer;
 
 #[cfg(feature = "tracing")]
 use {tower_http::trace::TraceLayer, tracing::Span};
 
 use crate::api::codes_of_conduct;
+#[cfg(feature = "default-client")]
+use crate::error::HyperSnafu;
 use crate::error::{
-    HttpSnafu, HyperSnafu, InvalidUtf8Snafu, SerdeSnafu, SerdeUrlEncodedSnafu, ServiceSnafu,
+    HttpSnafu, InvalidUtf8Snafu, SerdeSnafu, SerdeUrlEncodedSnafu, ServiceSnafu,
     UriParseError, UriParseSnafu, UriSnafu,
 };
 
+#[cfg(feature = "default-client")]
 use crate::service::middleware::base_uri::BaseUriLayer;
+#[cfg(feature = "default-client")]
 use crate::service::middleware::extra_headers::ExtraHeadersLayer;
 
 #[cfg(feature = "retry")]
@@ -306,7 +330,9 @@ compile_error!("at least one of the features \"jwt-rust-crypto\" and feature \"j
 /// A convenience type with a default error type of [`Error`].
 pub type Result<T, E = error::Error> = std::result::Result<T, E>;
 
+#[allow(dead_code)]
 const GITHUB_BASE_URI: &str = "https://api.github.com";
+#[allow(dead_code)]
 const GITHUB_BASE_UPLOAD_URI: &str = "https://uploads.github.com";
 
 // This `include!` gives us pub const _SET_HEADERS_MAP: [(&str, &str)]
@@ -480,6 +506,7 @@ impl<Config, Auth> OctocrabBuilder<NoSvc, Config, Auth, NotLayerReady> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Svc, Config, Auth, B> OctocrabBuilder<Svc, Config, Auth, LayerReady>
 where
     Svc: Service<Request<OctoBody>, Response = Response<B>> + Send + 'static,
@@ -502,10 +529,65 @@ where
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+impl<Svc, Config, Auth, B> OctocrabBuilder<Svc, Config, Auth, LayerReady>
+where
+    Svc: Service<Request<OctoBody>, Response = Response<B>> + 'static,
+    Svc::Future: 'static,
+    Svc::Error: Into<BoxError>,
+    B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    B::Error: Into<BoxError>,
+{
+    pub fn with_executor(
+        self,
+        executor: Executor,
+    ) -> OctocrabBuilder<Svc, Config, Auth, LayerReady> {
+        OctocrabBuilder {
+            service: self.service,
+            auth: self.auth,
+            config: self.config,
+            _layer_ready: PhantomData,
+            executor: Some(executor),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 impl<Svc, Config, Auth, B> OctocrabBuilder<Svc, Config, Auth, LayerReady>
 where
     Svc: Service<Request<OctoBody>, Response = Response<B>> + Send + 'static,
     Svc::Future: Send + 'static,
+    Svc::Error: Into<BoxError>,
+    B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    B::Error: Into<BoxError>,
+{
+    /// Add a [`Layer`] to the current [`Service`] stack.
+    pub fn with_layer<L: Layer<Svc>>(
+        self,
+        layer: &L,
+    ) -> OctocrabBuilder<L::Service, Config, Auth, LayerReady> {
+        let Self {
+            service: stack,
+            auth,
+            config,
+            executor,
+            ..
+        } = self;
+        OctocrabBuilder {
+            service: layer.layer(stack),
+            auth,
+            config,
+            executor,
+            _layer_ready: PhantomData,
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<Svc, Config, Auth, B> OctocrabBuilder<Svc, Config, Auth, LayerReady>
+where
+    Svc: Service<Request<OctoBody>, Response = Response<B>> + 'static,
+    Svc::Future: 'static,
     Svc::Error: Into<BoxError>,
     B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
     B::Error: Into<BoxError>,
@@ -550,10 +632,37 @@ impl<Svc, Auth, LayerState> OctocrabBuilder<Svc, NoConfig, Auth, LayerState> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Svc, B, LayerState> OctocrabBuilder<Svc, NoConfig, AuthState, LayerState>
 where
     Svc: Service<Request<OctoBody>, Response = Response<B>> + Send + 'static,
     Svc::Future: Send + 'static,
+    Svc::Error: Into<BoxError>,
+    B: http_body::Body<Data = bytes::Bytes> + Send + Sync + 'static,
+    B::Error: Into<BoxError>,
+{
+    /// Build a [`Client`](OctocrabService) instance with the current [`Service`] stack.
+    pub fn build(self) -> Result<Octocrab, Infallible> {
+        // Transform response body to `BoxBody<Bytes, crate::Error>` and use type erased error to avoid type parameters.
+        let service = MapResponseBodyLayer::new(|b: B| {
+            b.map_err(|e| ServiceSnafu.into_error(e.into())).boxed()
+        })
+        .layer(self.service)
+        .map_err(|e| e.into());
+
+        if let Some(executor) = self.executor {
+            return Ok(Octocrab::new_with_executor(service, self.auth, executor));
+        }
+
+        Ok(Octocrab::new(service, self.auth))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<Svc, B, LayerState> OctocrabBuilder<Svc, NoConfig, AuthState, LayerState>
+where
+    Svc: Service<Request<OctoBody>, Response = Response<B>> + 'static,
+    Svc::Future: 'static,
     Svc::Error: Into<BoxError>,
     B: http_body::Body<Data = bytes::Bytes> + Send + Sync + 'static,
     B::Error: Into<BoxError>,
@@ -1049,9 +1158,17 @@ pub enum AuthState {
     },
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub type OctocrabService = Buffer<
     http::Request<OctoBody>,
     <BoxService<http::Request<OctoBody>, http::Response<BoxBody<Bytes, Error>>, BoxError> as tower::Service<http::Request<OctoBody>>>::Future
+>;
+
+#[cfg(target_arch = "wasm32")]
+pub type OctocrabService = Rc<
+    RefCell<
+        UnsyncBoxService<http::Request<OctoBody>, http::Response<BoxBody<Bytes, Error>>, BoxError>,
+    >,
 >;
 
 /// The GitHub API client.
@@ -1090,6 +1207,7 @@ impl Octocrab {
     }
 
     /// Creates a new `Octocrab`.
+    #[cfg(not(target_arch = "wasm32"))]
     fn new<S>(service: S, auth_state: AuthState) -> Self
     where
         S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>>
@@ -1106,7 +1224,26 @@ impl Octocrab {
         }
     }
 
+    /// Creates a new `Octocrab`.
+    #[cfg(target_arch = "wasm32")]
+    fn new<S>(service: S, auth_state: AuthState) -> Self
+    where
+        S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>> + 'static,
+        S::Future: 'static,
+        S::Error: Into<BoxError>,
+    {
+        let service = Rc::new(RefCell::new(UnsyncBoxService::new(
+            service.map_err(Into::into),
+        )));
+
+        Self {
+            client: service,
+            auth_state,
+        }
+    }
+
     /// Creates a new `Octocrab` with a custom executor
+    #[cfg(not(target_arch = "wasm32"))]
     fn new_with_executor<S>(service: S, auth_state: AuthState, executor: Executor) -> Self
     where
         S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>>
@@ -1127,6 +1264,16 @@ impl Octocrab {
         }
     }
 
+    /// Creates a new `Octocrab` with a custom executor.
+    #[cfg(target_arch = "wasm32")]
+    fn new_with_executor<S>(service: S, auth_state: AuthState, _executor: Executor) -> Self
+    where
+        S: Service<Request<OctoBody>, Response = Response<BoxBody<Bytes, crate::Error>>> + 'static,
+        S::Future: 'static,
+        S::Error: Into<BoxError>,
+    {
+        Self::new(service, auth_state)
+    }
     /// Returns a new `Octocrab` based on the current builder but
     /// authorizing via a specific installation ID.
     /// Typically you will first construct an `Octocrab` using
@@ -1810,15 +1957,32 @@ impl Octocrab {
         &self,
         request: Request<OctoBody>,
     ) -> Result<http::Response<BoxBody<Bytes, crate::Error>>> {
-        let mut svc = self.client.clone();
-        let response: Response<BoxBody<Bytes, crate::Error>> = svc
-            .ready()
-            .await
-            .context(ServiceSnafu)?
-            .call(request)
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let mut svc = self.client.clone();
+            let response: Response<BoxBody<Bytes, crate::Error>> = svc
+                .ready()
+                .await
+                .context(ServiceSnafu)?
+                .call(request)
+                .await
+                .context(ServiceSnafu)?;
+            Ok(response)
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            futures::future::poll_fn(|cx| self.client.borrow_mut().poll_ready(cx))
+                .await
+                .context(ServiceSnafu)?;
+
+            let response: Response<BoxBody<Bytes, crate::Error>> = {
+                let mut svc = self.client.borrow_mut();
+                svc.call(request)
+            }
             .await
             .context(ServiceSnafu)?;
-        Ok(response)
+            Ok(response)
+        }
         //todo: attempt to downcast error to something more specific before returning. (Currently having trouble with this because I am not accustomed with snafu)
         // map_err(|err| {
         //     // Error decorating request

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,8 +293,8 @@ use crate::api::codes_of_conduct;
 #[cfg(feature = "default-client")]
 use crate::error::HyperSnafu;
 use crate::error::{
-    HttpSnafu, InvalidUtf8Snafu, SerdeSnafu, SerdeUrlEncodedSnafu, ServiceSnafu,
-    UriParseError, UriParseSnafu, UriSnafu,
+    HttpSnafu, InvalidUtf8Snafu, SerdeSnafu, SerdeUrlEncodedSnafu, ServiceSnafu, UriParseError,
+    UriParseSnafu, UriSnafu,
 };
 
 #[cfg(feature = "default-client")]

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -3,4 +3,3 @@ pub mod middleware;
 #[cfg(target_arch = "wasm32")]
 #[cfg_attr(docsrs, doc(cfg(target_arch = "wasm32")))]
 pub mod wasm;
-

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,1 +1,6 @@
 pub mod middleware;
+
+#[cfg(target_arch = "wasm32")]
+#[cfg_attr(docsrs, doc(cfg(target_arch = "wasm32")))]
+pub mod wasm;
+

--- a/src/service/wasm.rs
+++ b/src/service/wasm.rs
@@ -1,0 +1,67 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use http::{Request, Response};
+use http_body_util::{BodyExt, Full};
+use tower::{BoxError, Service};
+
+use crate::OctoBody;
+
+/// A browser-compatible HTTP service for Octocrab.
+///
+/// This service is intended for `wasm32-unknown-unknown` targets where the
+/// default hyper client is unavailable. It wraps `reqwest`'s browser client and
+/// returns collected response bodies that Octocrab can deserialize.
+#[derive(Clone, Debug, Default)]
+pub struct ReqwestService {
+    client: reqwest::Client,
+}
+
+impl ReqwestService {
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+        }
+    }
+
+    pub fn with_client(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+}
+
+impl Service<Request<OctoBody>> for ReqwestService {
+    type Response = Response<Full<Bytes>>;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: Request<OctoBody>) -> Self::Future {
+        let client = self.client.clone();
+
+        Box::pin(async move {
+            let (parts, body) = request.into_parts();
+            let body = body.collect().await?.to_bytes();
+
+            let response = client
+                .request(parts.method, parts.uri.to_string())
+                .headers(parts.headers)
+                .body(body)
+                .send()
+                .await?;
+
+            let status = response.status();
+            let headers = response.headers().clone();
+            let body = response.bytes().await?;
+
+            let mut builder = Response::builder().status(status);
+            *builder.headers_mut().expect("response builder is valid") = headers;
+
+            Ok(builder.body(Full::new(body))?)
+        })
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds comprehensive WebAssembly (WASM) support to `octocrab` by introducing a browser-compatible HTTP client and refactoring the underlying service structure on WASM targets to run cleanly in a single-threaded environment (like browser-based apps using Yew, Leptos, or Dioxus).

Fixes #224
/claim #224

### Changes
1. **Target-specific Dependency**: Added `reqwest` (with default-features disabled) under `wasm32` targets in `Cargo.toml`.
2. **Target-conditional Dev-dependencies**: Moved heavy native-only testing dependencies (e.g., `wiremock`, `tokio` multi-thread) to `not(target_arch = "wasm32")` in `Cargo.toml` to prevent build issues during WASM tests.
3. **Browser HTTP Service (`ReqwestService`)**: Introduced a new Tower `Service` in `src/service/wasm.rs` that leverages `reqwest`'s browser client (fetch API).
4. **Single-threaded Service Wrapper**: Replaced the multi-threaded `Buffer` and `BoxService` with `Rc<RefCell<UnsyncBoxService>>` as the underlying `OctocrabService` on `wasm32-unknown-unknown` target.
5. **Constructor Cleanups**: Added target-conditional compilation flags (`#[cfg]`) directly on constructor methods (`new`, `new_with_executor`) in `src/lib.rs` to allow compiling without `Send + Sync` constraints in single-threaded environments.
6. **Documentation & Example**: Added a runnable `examples/wasm_client.rs` and updated `README.md` to demonstrate how to initialize and run the browser-compatible client.

### Testing
1. Verify native compilation and tests:
   ```bash
   cargo check
   cargo test