### PR TITLE
Add WebAssembly (WASM) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- WebAssembly (WASM) support via `wasm::wasm_builder()` ([#224](https://github.com/XAMPPRocky/octocrab/issues/224))
+  - New `wasm` module with `ReqwestTowerService` for WASM compatibility
+  - Support for using Octocrab in browser-based applications (Yew, Leptos, etc.)
+  - Example and documentation for WASM usage
+
 ## [0.54.1](https://github.com/XAMPPRocky/octocrab/compare/v0.54.0...v0.54.1) - 2026-07-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,11 @@ tower-http = { version = "0.6.1", features = ["map-response-body", "trace"] }
 tracing = { version = "0.1.37", features = ["log"], optional = true }
 url = { version = "2.2.2", features = ["serde"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = "0.4.54"
+reqwest = { version = "0.12.23", default-features = false, features = ["rustls-tls"] }
+thiserror = "2.0"
+
 [dev-dependencies]
 tokio = { version = "1.17.0", default-features = false, features = [
     "macros",

--- a/README.md
+++ b/README.md
@@ -202,6 +202,46 @@ octocrab::initialise(octocrab::Octocrab::builder());
 let octocrab = octocrab::instance();
 ```
 
+## WebAssembly (WASM) Support
+
+Octocrab now supports WebAssembly targets, allowing you to use it in browser-based applications
+with frameworks like Yew, Leptos, or Dioxus. Due to WASM's single-threaded nature, a special
+builder is provided for WASM targets.
+
+### Usage in WASM
+
+When using Octocrab in a WASM environment:
+
+1. Add octocrab to your `Cargo.toml` with default features disabled:
+```toml
+[dependencies]
+octocrab = { version = "0.49", default-features = false }
+```
+
+2. Use the `wasm::wasm_builder()` function to create your instance:
+```rust
+#[cfg(target_arch = "wasm32")]
+async fn github_api_example() -> octocrab::Result<()> {
+    let mut octocrab = octocrab::wasm::wasm_builder()
+        .build()?;
+
+    // Add authentication if needed
+    octocrab = octocrab.user_access_token("your_token".to_string())?;
+
+    // Use octocrab normally
+    let repo = octocrab.repos("XAMPPRocky", "octocrab").get().await?;
+    Ok(())
+}
+```
+
+The WASM builder automatically configures:
+- A reqwest-based Tower service compatible with WASM
+- The GitHub API base URL
+- The `wasm-bindgen-futures` executor
+- Proper handling of non-Send futures in WASM
+
+See the [`wasm_example.rs`](examples/wasm_example.rs) for a complete example.
+
 ## GitHub Webhook Support
 
 `octocrab` provides [deserializable datatypes](https://docs.rs/octocrab/latest/octocrab/models/webhook_events/index.html)

--- a/examples/wasm_example.rs
+++ b/examples/wasm_example.rs
@@ -1,0 +1,67 @@
+//! This example demonstrates how to use octocrab in a WASM environment.
+//!
+//! To compile this for WASM, run:
+//! ```sh
+//! rustup target add wasm32-unknown-unknown
+//! cargo build --target wasm32-unknown-unknown --example wasm_example
+//! ```
+//!
+//! Note: This example is designed to show the API usage. To actually run it,
+//! you would need to integrate it into a web application using a framework
+//! like Yew, Leptos, or similar.
+
+#[cfg(target_arch = "wasm32")]
+use octocrab::wasm::wasm_builder;
+
+#[cfg(target_arch = "wasm32")]
+pub async fn example_usage() -> octocrab::Result<()> {
+    // Create an octocrab instance for WASM
+    let mut octocrab = wasm_builder().build()?;
+
+    // Optionally add authentication
+    // If you have a GitHub token, you can authenticate like this:
+    // octocrab = octocrab.user_access_token("your_github_token".to_string())?;
+
+    // Now you can use octocrab as you normally would!
+
+    // Example: Get information about a repository
+    let repo = octocrab.repos("XAMPPRocky", "octocrab").get().await?;
+
+    println!("Repository: {}", repo.name);
+    println!("Stars: {}", repo.stargazers_count.unwrap_or(0));
+    println!("Description: {}", repo.description.unwrap_or_default());
+
+    // Example: List issues
+    let issues = octocrab
+        .issues("XAMPPRocky", "octocrab")
+        .list()
+        .per_page(10)
+        .send()
+        .await?;
+
+    println!("Found {} issues", issues.items.len());
+
+    Ok(())
+}
+
+#[cfg(target_arch = "wasm32")]
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    // In a real WASM application, you would spawn this using your framework's
+    // async runtime. For example, in Yew you might use:
+    // wasm_bindgen_futures::spawn_local(async {
+    //     example_usage().await.expect("Failed to run example");
+    // });
+
+    wasm_bindgen_futures::spawn_local(async {
+        if let Err(e) = example_usage().await {
+            eprintln!("Error: {}", e);
+        }
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
+    println!("This example is only meant to be compiled for WASM targets.");
+    println!("Run: cargo build --target wasm32-unknown-unknown --example wasm_example");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,10 @@ pub mod models;
 pub mod params;
 pub mod service;
 
+#[cfg(target_arch = "wasm32")]
+#[cfg_attr(docsrs, doc(cfg(target_arch = "wasm32")))]
+pub mod wasm;
+
 use api::repos::RepoRef;
 use api::users::UserRef;
 pub use body::OctoBody;

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -1,0 +1,36 @@
+//! WASM support for octocrab
+//!
+//! This module provides the necessary infrastructure to use octocrab in WebAssembly environments.
+//! The main issue with using octocrab in WASM is that reqwest's futures are not `Send` in WASM,
+//! which conflicts with octocrab's requirements. This module works around this by providing a
+//! custom Tower service implementation that properly handles WASM's single-threaded nature.
+//!
+//! # Usage
+//!
+//! To use octocrab in a WASM environment:
+//!
+//! 1. Add octocrab to your Cargo.toml with default features disabled:
+//!    ```toml
+//!    octocrab = { version = "0.49", default-features = false }
+//!    ```
+//!
+//! 2. Use the `wasm_builder()` function to create an octocrab instance:
+//!    ```no_run
+//!    # #[cfg(target_arch = "wasm32")]
+//!    # async fn example() -> octocrab::Result<()> {
+//!    let octocrab = octocrab::wasm::wasm_builder()
+//!        .build()?;
+//!    # Ok(())
+//!    # }
+//!    ```
+//!
+//! # Features
+//!
+//! This module is only available when compiling for the `wasm32` target architecture.
+//! It will not be included in non-WASM builds.
+
+mod reqwest_tower_service;
+mod wasm;
+
+pub use reqwest_tower_service::{ReqwestTowerError, ReqwestTowerService};
+pub use wasm::wasm_builder;

--- a/src/wasm/reqwest_tower_service.rs
+++ b/src/wasm/reqwest_tower_service.rs
@@ -1,0 +1,116 @@
+use bytes::Bytes;
+use http::uri::{Authority, Scheme};
+use http_body_util::combinators::BoxBody;
+use http_body_util::BodyExt;
+use std::task::Poll;
+
+/// A tower Service implementation that wraps reqwest for WASM compatibility.
+/// This service allows octocrab to work in WASM environments by properly handling
+/// the async futures that aren't Send in WASM.
+#[derive(Clone)]
+pub struct ReqwestTowerService {
+    pub base_url: Option<(Scheme, Authority)>,
+    pub client: reqwest::Client,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ReqwestTowerError<Body>
+where
+    Body: http_body::Body + 'static + Send,
+    Body::Error: Send,
+{
+    #[error("Reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("HTTP error: {0}")]
+    BodyError(Body::Error),
+    #[error("HTTP error: {0}")]
+    HttpError(#[from] http::Error),
+    #[error("Invalid URI parts: {0}")]
+    InvalidUriParts(#[from] http::uri::InvalidUriParts),
+    #[error("Channel canceled")]
+    ChannelCanceled(#[from] futures::channel::oneshot::Canceled),
+}
+
+impl<Body> tower::Service<http::Request<Body>> for ReqwestTowerService
+where
+    Body: http_body::Body + Send + 'static,
+    Body::Data: Send,
+    Body::Error: std::error::Error + Send + Sync + 'static,
+{
+    type Response = http::Response<BoxBody<Bytes, std::convert::Infallible>>;
+    type Error = ReqwestTowerError<Body>;
+    type Future = std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<Self::Response, Self::Error>>
+                + Send,
+        >,
+    >;
+
+    fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: http::Request<Body>) -> Self::Future {
+        let Self { base_url, client } = self.clone();
+        Box::pin(async move {
+            let (tx, rx) = futures::channel::oneshot::channel();
+            wasm_bindgen_futures::spawn_local(async move {
+                let result = call(client, base_url, req).await;
+                tx.send(result).ok();
+            });
+
+            let response = rx.await??;
+            Ok(response)
+        })
+    }
+}
+
+pub async fn call<Body>(
+    client: reqwest::Client,
+    base_url: Option<(Scheme, Authority)>,
+    request: http::Request<Body>,
+) -> Result<http::Response<BoxBody<Bytes, std::convert::Infallible>>, ReqwestTowerError<Body>>
+where
+    Body: http_body::Body + 'static + Send,
+    Body::Error: Send + 'static,
+{
+    let (parts, body) = request.into_parts();
+
+    let body = body
+        .collect()
+        .await
+        .map_err(ReqwestTowerError::BodyError)?
+        .to_bytes();
+
+    let uri = parts.uri;
+    let mut uri_parts = uri.into_parts();
+
+    if uri_parts.authority.is_none() {
+        if let Some((scheme, authority)) = base_url {
+            uri_parts.scheme = Some(scheme);
+            uri_parts.authority = Some(authority);
+        }
+    }
+
+    let request = client
+        .request(
+            parts.method,
+            http::uri::Uri::from_parts(uri_parts)?.to_string(),
+        )
+        .body(body)
+        .headers(parts.headers)
+        .build()?;
+
+    let reqwest_response = client.execute(request).await?;
+
+    let headers = reqwest_response.headers().clone();
+    let status = reqwest_response.status();
+    let bytes = reqwest_response.bytes().await?;
+
+    let mut response = http::Response::new(BoxBody::new(http_body_util::Full::new(bytes)));
+
+    *response.status_mut() = status;
+    *response.headers_mut() = headers;
+
+    Ok(response)
+}

--- a/src/wasm/wasm.rs
+++ b/src/wasm/wasm.rs
@@ -1,0 +1,41 @@
+use crate::wasm::reqwest_tower_service::ReqwestTowerService;
+use crate::{AuthState, LayerReady, NoConfig};
+
+/// Creates an OctocrabBuilder pre-configured for WASM environments.
+///
+/// This builder is automatically configured with:
+/// - A reqwest-based Tower service that works in WASM
+/// - The GitHub API base URL (https://api.github.com)
+/// - The wasm-bindgen-futures executor for spawning local tasks
+/// - No authentication by default (use `.with_auth()` to add)
+///
+/// # Example
+///
+/// ```no_run
+/// # #[cfg(target_arch = "wasm32")]
+/// # async fn example() -> octocrab::Result<()> {
+/// let mut octocrab = octocrab::wasm::wasm_builder()
+///     .build()?;
+///
+/// // Optionally add authentication
+/// octocrab = octocrab.user_access_token("your_token".to_string())?;
+///
+/// // Now use octocrab as normal
+/// let repos = octocrab.current().list_repos_for_authenticated_user().send().await?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn wasm_builder() -> crate::OctocrabBuilder<ReqwestTowerService, NoConfig, AuthState, LayerReady>
+{
+    let reqwest_client = ReqwestTowerService {
+        base_url: Some(("https".parse().unwrap(), "api.github.com".parse().unwrap())),
+        client: reqwest::Client::new(),
+    };
+
+    let builder = crate::OctocrabBuilder::new_empty()
+        .with_service(reqwest_client)
+        .with_executor(Box::new(wasm_bindgen_futures::spawn_local))
+        .with_auth(AuthState::None);
+
+    builder
+}


### PR DESCRIPTION
This adds comprehensive WASM support to octocrab, enabling its use in browser-based applications with frameworks like Yew, Leptos, and Dioxus.

Rebased and updated version of #847 by @sanks011.

**Changes:**
- New `wasm` module with `ReqwestTowerService` that wraps reqwest for WASM compatibility
- `wasm_builder()` function for easy WASM initialization
- Conditional WASM dependencies (wasm-bindgen-futures, reqwest, thiserror) only when targeting wasm32
- WASM example demonstrating usage
- Feature-gated behind `#[cfg(target_arch = "wasm32")]`

**Verification:**
- `cargo check` — passes (native)
- `cargo check --target wasm32-unknown-unknown --no-default-features -F jwt-rust-crypto` — passes (WASM)
- `cargo clippy --all-targets` — no new warnings

Fixes #224
Closes #847

Co-authored-by: sanks011 <sankalpasarkar68@gmail.com>