### PR TITLE
Disabled semver_check because cargo-semver-checks enables all features

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,2 +1,5 @@
 [workspace]
 pr_labels = ["release"]
+# Disable semver_check because cargo-semver-checks enables all features by default,
+# which causes jwt-rust-crypto and jwt-aws-lc-rs (mutually exclusive) to conflict.
+semver_check = false


### PR DESCRIPTION
Disabled semver_check because cargo-semver-checks enables all features by default, which causes jwt-rust-crypto and jwt-aws-lc-rs (mutually exclusive) to conflict.
